### PR TITLE
Add sponsor grid

### DIFF
--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		AED26F7A28676AA300E06064 /* LocalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED26F7928676AA300E06064 /* LocalView.swift */; };
 		AEDC0DAE286759630078A153 /* Tabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDC0DAD286759630078A153 /* Tabs.swift */; };
 		FA29253C286F7A4F00B1ABE7 /* ContentTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA29253B286F7A4F00B1ABE7 /* ContentTileView.swift */; };
+		FA6F17DE286F81150088CDB7 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6F17DD286F81150088CDB7 /* Sponsor.swift */; };
+		FA6F17E0286F81CD0088CDB7 /* SponsorGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6F17DF286F81CD0088CDB7 /* SponsorGridView.swift */; };
+		FA6F17E3286F89AF0088CDB7 /* SwiftLeedsContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6F17E2286F89AF0088CDB7 /* SwiftLeedsContainer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +66,9 @@
 		AED26F7928676AA300E06064 /* LocalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalView.swift; sourceTree = "<group>"; };
 		AEDC0DAD286759630078A153 /* Tabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tabs.swift; sourceTree = "<group>"; };
 		FA29253B286F7A4F00B1ABE7 /* ContentTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTileView.swift; sourceTree = "<group>"; };
+		FA6F17DD286F81150088CDB7 /* Sponsor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sponsor.swift; sourceTree = "<group>"; };
+		FA6F17DF286F81CD0088CDB7 /* SponsorGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsorGridView.swift; sourceTree = "<group>"; };
+		FA6F17E2286F89AF0088CDB7 /* SwiftLeedsContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLeedsContainer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +119,7 @@
 		AECB295527417F9D00CDC983 /* SwiftLeeds */ = {
 			isa = PBXGroup;
 			children = (
+				FA6F17DA286F81000088CDB7 /* Data */,
 				AECB29862741AC5800CDC983 /* App */,
 				AECB298027418D9800CDC983 /* Extension */,
 				AECB295C27417F9E00CDC983 /* Preview Content */,
@@ -167,6 +174,7 @@
 		AECB29852741AC4B00CDC983 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				FA6F17E1286F89A60088CDB7 /* Common */,
 				AED26F7628676A9200E06064 /* About */,
 				AED26F7528676A8E00E06064 /* Local */,
 				AEDC0DAF28675D060078A153 /* My Conference */,
@@ -198,6 +206,7 @@
 			children = (
 				AED26F7728676A9900E06064 /* AboutView.swift */,
 				FA29253B286F7A4F00B1ABE7 /* ContentTileView.swift */,
+				FA6F17DF286F81CD0088CDB7 /* SponsorGridView.swift */,
 			);
 			path = About;
 			sourceTree = "<group>";
@@ -218,6 +227,30 @@
 				AED26F73286764F000E06064 /* TalkCell.swift */,
 			);
 			path = "My Conference";
+			sourceTree = "<group>";
+		};
+		FA6F17DA286F81000088CDB7 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				FA6F17DC286F810F0088CDB7 /* Model */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		FA6F17DC286F810F0088CDB7 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				FA6F17DD286F81150088CDB7 /* Sponsor.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		FA6F17E1286F89A60088CDB7 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				FA6F17E2286F89AF0088CDB7 /* SwiftLeedsContainer.swift */,
+			);
+			path = Common;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -354,11 +387,14 @@
 				AED26F7828676A9900E06064 /* AboutView.swift in Sources */,
 				AED26F7A28676AA300E06064 /* LocalView.swift in Sources */,
 				AED26F74286764F000E06064 /* TalkCell.swift in Sources */,
+				FA6F17DE286F81150088CDB7 /* Sponsor.swift in Sources */,
+				FA6F17E3286F89AF0088CDB7 /* SwiftLeedsContainer.swift in Sources */,
 				AECB295927417F9D00CDC983 /* MyConferenceView.swift in Sources */,
 				AECB298227418DA200CDC983 /* Color+Extension.swift in Sources */,
 				AED26F7028675DA000E06064 /* AnnouncementCell.swift in Sources */,
 				FA29253C286F7A4F00B1ABE7 /* ContentTileView.swift in Sources */,
 				AECB295727417F9D00CDC983 /* SwiftLeedsApp.swift in Sources */,
+				FA6F17E0286F81CD0088CDB7 /* SponsorGridView.swift in Sources */,
 				AEDC0DAE286759630078A153 /* Tabs.swift in Sources */,
 				AE32CDF0286CCF9D00DF0AFF /* Constants.swift in Sources */,
 			);

--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		FA6F17DE286F81150088CDB7 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6F17DD286F81150088CDB7 /* Sponsor.swift */; };
 		FA6F17E0286F81CD0088CDB7 /* SponsorGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6F17DF286F81CD0088CDB7 /* SponsorGridView.swift */; };
 		FA6F17E3286F89AF0088CDB7 /* SwiftLeedsContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6F17E2286F89AF0088CDB7 /* SwiftLeedsContainer.swift */; };
+		FA6F17E5286F8D9A0088CDB7 /* SquishyButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6F17E4286F8D9A0088CDB7 /* SquishyButtonStyle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		FA6F17DD286F81150088CDB7 /* Sponsor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sponsor.swift; sourceTree = "<group>"; };
 		FA6F17DF286F81CD0088CDB7 /* SponsorGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsorGridView.swift; sourceTree = "<group>"; };
 		FA6F17E2286F89AF0088CDB7 /* SwiftLeedsContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLeedsContainer.swift; sourceTree = "<group>"; };
+		FA6F17E4286F8D9A0088CDB7 /* SquishyButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquishyButtonStyle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -158,6 +160,7 @@
 			isa = PBXGroup;
 			children = (
 				AECB298127418DA200CDC983 /* Color+Extension.swift */,
+				FA6F17E4286F8D9A0088CDB7 /* SquishyButtonStyle.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -386,6 +389,7 @@
 			files = (
 				AED26F7828676A9900E06064 /* AboutView.swift in Sources */,
 				AED26F7A28676AA300E06064 /* LocalView.swift in Sources */,
+				FA6F17E5286F8D9A0088CDB7 /* SquishyButtonStyle.swift in Sources */,
 				AED26F74286764F000E06064 /* TalkCell.swift in Sources */,
 				FA6F17DE286F81150088CDB7 /* Sponsor.swift in Sources */,
 				FA6F17E3286F89AF0088CDB7 /* SwiftLeedsContainer.swift in Sources */,

--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		AED26F7828676A9900E06064 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED26F7728676A9900E06064 /* AboutView.swift */; };
 		AED26F7A28676AA300E06064 /* LocalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED26F7928676AA300E06064 /* LocalView.swift */; };
 		AEDC0DAE286759630078A153 /* Tabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDC0DAD286759630078A153 /* Tabs.swift */; };
+		FA29253C286F7A4F00B1ABE7 /* ContentTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA29253B286F7A4F00B1ABE7 /* ContentTileView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,7 @@
 		AED26F7728676A9900E06064 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		AED26F7928676AA300E06064 /* LocalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalView.swift; sourceTree = "<group>"; };
 		AEDC0DAD286759630078A153 /* Tabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tabs.swift; sourceTree = "<group>"; };
+		FA29253B286F7A4F00B1ABE7 /* ContentTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTileView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				AED26F7728676A9900E06064 /* AboutView.swift */,
+				FA29253B286F7A4F00B1ABE7 /* ContentTileView.swift */,
 			);
 			path = About;
 			sourceTree = "<group>";
@@ -354,6 +357,7 @@
 				AECB295927417F9D00CDC983 /* MyConferenceView.swift in Sources */,
 				AECB298227418DA200CDC983 /* Color+Extension.swift in Sources */,
 				AED26F7028675DA000E06064 /* AnnouncementCell.swift in Sources */,
+				FA29253C286F7A4F00B1ABE7 /* ContentTileView.swift in Sources */,
 				AECB295727417F9D00CDC983 /* SwiftLeedsApp.swift in Sources */,
 				AEDC0DAE286759630078A153 /* Tabs.swift in Sources */,
 				AE32CDF0286CCF9D00DF0AFF /* Constants.swift in Sources */,

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -9,10 +9,6 @@ import SwiftUI
 
 @main
 struct SwiftLeedsApp: App {
-    init() {
-        UITabBar.appearance().backgroundColor = UIColor(named: "TabBarBackground")
-    }
-
     var body: some Scene {
         WindowGroup {
             Tabs()

--- a/SwiftLeeds/Data/Model/Sponsor.swift
+++ b/SwiftLeeds/Data/Model/Sponsor.swift
@@ -1,0 +1,61 @@
+//
+//  Sponsor.swift
+//  SwiftLeeds
+//
+//  Created by Alex Logan on 01/07/2022.
+//
+
+import Foundation
+
+// These should come from an API eventually
+struct Sponsor: Hashable {
+    let name: String
+    let oneLiner: String
+    let imageURL: URL?
+}
+
+// MARK: - Static data
+extension Sponsor {
+    static let platinum = [codemagic, stream]
+    static let gold = [mkodo, and, xdesign, bitrise]
+
+    // All of these images are temporary until this is API based
+    
+    // Platinum
+    static let codemagic = Sponsor(
+        name: "codemagic",
+        oneLiner: "CI/CD for mobile that matches your needs",
+        imageURL: URL(string: "https://miro.medium.com/max/3150/1*8FOeoWB-4SAzwTXFBWUTeg.jpeg")
+    )
+
+    static let stream = Sponsor(
+        name: "Stream",
+        oneLiner: "Build In-App Chat + Feeds, Faster",
+        imageURL: URL(string: "https://pbs.twimg.com/media/E20a5PKWUAELWeX.png")
+    )
+
+    // Gold
+    static let mkodo = Sponsor(
+        name: "mkodo",
+        oneLiner: "Let's innovate lottery and gaming",
+        imageURL: URL(string: "https://lafleurs.com/wp-content/uploads/2019/06/Mkodo_slate.png")
+    )
+
+    static let and = Sponsor(
+        name: "AND Digital",
+        oneLiner: "Build better digital products AND stronger teams",
+        imageURL: URL(string: "https://launchpadreading.org.uk/wp-content/uploads/2020/06/AND-logo.png")
+    )
+
+    static let xdesign = Sponsor(
+        name: "xdesign",
+        oneLiner: "Web and mobile product development",
+        imageURL: URL(string: "https://thewealthmosaic.s3.amazonaws.com/media/Logo_xDesign.png")
+    )
+
+    static let bitrise = Sponsor(
+        name: "Bitrise",
+        oneLiner: "Build better mobile applications, faster",
+        imageURL: URL(string: "https://assets-global.website-files.com/5db35de024bb983af1b4e151/5e6f9ccda4e7ff12841abe18_Bitrise%20Logo%20-%20White%20Bg.png")
+    )
+}

--- a/SwiftLeeds/Data/Model/Sponsor.swift
+++ b/SwiftLeeds/Data/Model/Sponsor.swift
@@ -12,6 +12,7 @@ struct Sponsor: Hashable {
     let name: String
     let oneLiner: String
     let imageURL: URL?
+    let link: URL?
 }
 
 // MARK: - Static data
@@ -20,42 +21,48 @@ extension Sponsor {
     static let gold = [mkodo, and, xdesign, bitrise]
 
     // All of these images are temporary until this is API based
-    
+
     // Platinum
     static let codemagic = Sponsor(
         name: "codemagic",
         oneLiner: "CI/CD for mobile that matches your needs",
-        imageURL: URL(string: "https://miro.medium.com/max/3150/1*8FOeoWB-4SAzwTXFBWUTeg.jpeg")
+        imageURL: URL(string: "https://miro.medium.com/max/3150/1*8FOeoWB-4SAzwTXFBWUTeg.jpeg"),
+        link: URL(string: "https://codemagic.io/")
     )
 
     static let stream = Sponsor(
         name: "Stream",
         oneLiner: "Build In-App Chat + Feeds, Faster",
-        imageURL: URL(string: "https://pbs.twimg.com/media/E20a5PKWUAELWeX.png")
+        imageURL: URL(string: "https://pbs.twimg.com/media/E20a5PKWUAELWeX.png"),
+        link: URL(string: "https://getstream.io/chat/sdk/swiftui/?utm_source=SwiftLeeds&utm_medium=Whole_Event_L&utm_content=Developer&utm_campaign=SwiftLeeds_Oct2022")
     )
 
     // Gold
     static let mkodo = Sponsor(
         name: "mkodo",
         oneLiner: "Let's innovate lottery and gaming",
-        imageURL: URL(string: "https://lafleurs.com/wp-content/uploads/2019/06/Mkodo_slate.png")
+        imageURL: URL(string: "https://lafleurs.com/wp-content/uploads/2019/06/Mkodo_slate.png"),
+        link: URL(string: "https://www.mkodo.com/s/careers")
     )
 
     static let and = Sponsor(
         name: "AND Digital",
         oneLiner: "Build better digital products AND stronger teams",
-        imageURL: URL(string: "https://launchpadreading.org.uk/wp-content/uploads/2020/06/AND-logo.png")
+        imageURL: URL(string: "https://launchpadreading.org.uk/wp-content/uploads/2020/06/AND-logo.png"),
+        link: URL(string: "https://www.and.digital/join/open-roles")
     )
 
     static let xdesign = Sponsor(
         name: "xdesign",
         oneLiner: "Web and mobile product development",
-        imageURL: URL(string: "https://thewealthmosaic.s3.amazonaws.com/media/Logo_xDesign.png")
+        imageURL: URL(string: "https://thewealthmosaic.s3.amazonaws.com/media/Logo_xDesign.png"),
+        link: URL(string: "https://www.xdesign.com/")
     )
 
     static let bitrise = Sponsor(
         name: "Bitrise",
         oneLiner: "Build better mobile applications, faster",
-        imageURL: URL(string: "https://assets-global.website-files.com/5db35de024bb983af1b4e151/5e6f9ccda4e7ff12841abe18_Bitrise%20Logo%20-%20White%20Bg.png")
+        imageURL: URL(string: "https://assets-global.website-files.com/5db35de024bb983af1b4e151/5e6f9ccda4e7ff12841abe18_Bitrise%20Logo%20-%20White%20Bg.png"),
+        link: URL(string: "https://www.bitrise.io/")
     )
 }

--- a/SwiftLeeds/Extension/Color+Extension.swift
+++ b/SwiftLeeds/Extension/Color+Extension.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 extension Color {
-    static let tabBarBackgrond = Color("TabBarBackground")
-    static let backgrond = Color("Background")
+    static let tabBarBackground = Color("TabBarBackground")
+    static let background = Color("Background")
     static let cellBackground = Color("CellBackground")
     static let cellForeground = Color("CellForeground")
 

--- a/SwiftLeeds/Extension/SquishyButtonStyle.swift
+++ b/SwiftLeeds/Extension/SquishyButtonStyle.swift
@@ -1,0 +1,16 @@
+//
+//  SquishyButtonStyle.swift
+//  SwiftLeeds
+//
+//  Created by Alex Logan on 01/07/2022.
+//
+
+import Foundation
+import SwiftUI
+
+struct SquishyButtonStyle: ButtonStyle {
+    func makeBody(configuration: Self.Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+    }
+}

--- a/SwiftLeeds/Views/About/AboutView.swift
+++ b/SwiftLeeds/Views/About/AboutView.swift
@@ -16,7 +16,7 @@ struct AboutView: View {
         }
     }
 
-    var content: some View {
+    private var content: some View {
         SponsorGridView()
     }
 }

--- a/SwiftLeeds/Views/About/AboutView.swift
+++ b/SwiftLeeds/Views/About/AboutView.swift
@@ -9,7 +9,15 @@ import SwiftUI
 
 struct AboutView: View {
     var body: some View {
-        Text("About")
+        SwiftLeedsContainer {
+            ScrollView {
+                content
+            }
+        }
+    }
+
+    var content: some View {
+        SponsorGridView()
     }
 }
 

--- a/SwiftLeeds/Views/About/ContentTileView.swift
+++ b/SwiftLeeds/Views/About/ContentTileView.swift
@@ -9,25 +9,39 @@ import SwiftUI
 
 struct ContentTileView: View {
     let title: String
-    let subTitle: String?
+    var subTitle: String?
     let imageURL: URL?
 
     private let cornerRadius: CGFloat = 12
-
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             image
             text
         }
-        .background(Color.white, in: contentShape)
+        .background(Color.cellBackground, in: contentShape)
         .clipShape(contentShape)
     }
 
     private var image: some View {
-        Rectangle()
-            .aspectRatio(1.66, contentMode: .fit)
-            .foregroundColor(.accentColor)
+        AsyncImage(
+            url: imageURL,
+            content: { image in
+                Rectangle()
+                    .foregroundColor(.clear)
+                    .background(
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    )
+                    .clipped()
+            },
+            placeholder: {
+                Rectangle()
+                    .foregroundColor(Color("AccentColor"))
+            }
+        )
+        .aspectRatio(1.66, contentMode: .fit)
     }
 
     private var text: some View {
@@ -53,12 +67,19 @@ struct ContentTileView: View {
 struct ContentTileView_Previews: PreviewProvider {
     static var previews: some View {
         ZStack {
-            Color.backgrond.edgesIgnoringSafeArea(.all)
-            ContentTileView(
-                title: "Alex Logan",
-                subTitle: "subtitle",
-                imageURL: URL(string: "https://pbs.twimg.com/profile_images/1475087054652559361/lgTnY96Q_400x400.jpg")
-            )
+            Color.background.edgesIgnoringSafeArea(.all)
+            VStack {
+                ContentTileView(
+                    title: "Alex Logan",
+                    subTitle: "subtitle",
+                    imageURL: URL(string: "https://pbs.twimg.com/profile_images/1475087054652559361/lgTnY96Q_400x400.jpg")
+                )
+                ContentTileView(
+                    title: "Alex Logan",
+                    subTitle: nil,
+                    imageURL: nil
+                )
+            }
             .padding()
         }
     }

--- a/SwiftLeeds/Views/About/ContentTileView.swift
+++ b/SwiftLeeds/Views/About/ContentTileView.swift
@@ -11,19 +11,25 @@ struct ContentTileView: View {
     let title: String
     let subTitle: String?
     let imageURL: URL?
+
     var placeholderColor: Color = .accentColor
     var imageBackgroundColor: Color = .accentColor
     var imageContentMode: ContentMode = .fill
 
+    let onTap: () -> ()
+
     private let cornerRadius: CGFloat = 12
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            image
-            text
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 0) {
+                image
+                text
+            }
         }
         .background(Color.cellBackground, in: contentShape)
         .clipShape(contentShape)
+        .buttonStyle(SquishyButtonStyle())
     }
 
     private var image: some View {
@@ -94,12 +100,14 @@ struct ContentTileView_Previews: PreviewProvider {
                 ContentTileView(
                     title: "Alex Logan",
                     subTitle: "subtitle",
-                    imageURL: URL(string: "https://pbs.twimg.com/profile_images/1475087054652559361/lgTnY96Q_400x400.jpg")
+                    imageURL: URL(string: "https://pbs.twimg.com/profile_images/1475087054652559361/lgTnY96Q_400x400.jpg"),
+                    onTap: {}
                 )
                 ContentTileView(
                     title: "Alex Logan",
                     subTitle: nil,
-                    imageURL: nil
+                    imageURL: nil,
+                    onTap: {}
                 )
             }
             .padding()

--- a/SwiftLeeds/Views/About/ContentTileView.swift
+++ b/SwiftLeeds/Views/About/ContentTileView.swift
@@ -1,0 +1,65 @@
+//
+//  ContentTileView.swift
+//  SwiftLeeds
+//
+//  Created by Alex Logan on 01/07/2022.
+//
+
+import SwiftUI
+
+struct ContentTileView: View {
+    let title: String
+    let subTitle: String?
+    let imageURL: URL?
+
+    private let cornerRadius: CGFloat = 12
+
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            image
+            text
+        }
+        .background(Color.white, in: contentShape)
+        .clipShape(contentShape)
+    }
+
+    private var image: some View {
+        Rectangle()
+            .aspectRatio(1.66, contentMode: .fit)
+            .foregroundColor(.accentColor)
+    }
+
+    private var text: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .foregroundColor(.primary)
+                .font(.subheadline.weight(.medium))
+            if let subTitle = subTitle {
+                Text(subTitle)
+                    .foregroundColor(.secondary)
+                    .font(.subheadline.weight(.regular))
+            }
+        }
+        .padding()
+        .frame(minHeight: 55)
+    }
+
+    private var contentShape: some Shape {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+    }
+}
+
+struct ContentTileView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            Color.backgrond.edgesIgnoringSafeArea(.all)
+            ContentTileView(
+                title: "Alex Logan",
+                subTitle: "subtitle",
+                imageURL: URL(string: "https://pbs.twimg.com/profile_images/1475087054652559361/lgTnY96Q_400x400.jpg")
+            )
+            .padding()
+        }
+    }
+}

--- a/SwiftLeeds/Views/About/ContentTileView.swift
+++ b/SwiftLeeds/Views/About/ContentTileView.swift
@@ -9,8 +9,11 @@ import SwiftUI
 
 struct ContentTileView: View {
     let title: String
-    var subTitle: String?
+    let subTitle: String?
     let imageURL: URL?
+    var placeholderColor: Color = .accentColor
+    var imageBackgroundColor: Color = .accentColor
+    var imageContentMode: ContentMode = .fill
 
     private let cornerRadius: CGFloat = 12
 
@@ -28,17 +31,27 @@ struct ContentTileView: View {
             url: imageURL,
             content: { image in
                 Rectangle()
+                    .aspectRatio(1.66, contentMode: .fill)
                     .foregroundColor(.clear)
                     .background(
                         image
                             .resizable()
-                            .aspectRatio(contentMode: .fill)
+                            .aspectRatio(contentMode: imageContentMode)
+                            .transition(.opacity)
                     )
+                    .background(imageBackgroundColor)
                     .clipped()
+                    .transition(contentTransition)
             },
             placeholder: {
                 Rectangle()
-                    .foregroundColor(Color("AccentColor"))
+                    .foregroundColor(placeholderColor)
+                    .transition(contentTransition)
+                    .overlay(content: {
+                        ProgressView()
+                            .tint(.white)
+                            .opacity(0.5)
+                    })
             }
         )
         .aspectRatio(1.66, contentMode: .fit)
@@ -61,6 +74,10 @@ struct ContentTileView: View {
 
     private var contentShape: some Shape {
         RoundedRectangle(cornerRadius: 12, style: .continuous)
+    }
+
+    private var contentTransition: AnyTransition {
+        .opacity.animation(.spring())
     }
 }
 

--- a/SwiftLeeds/Views/About/ContentTileView.swift
+++ b/SwiftLeeds/Views/About/ContentTileView.swift
@@ -18,7 +18,6 @@ struct ContentTileView: View {
 
     let onTap: () -> ()
 
-    private let cornerRadius: CGFloat = 12
 
     var body: some View {
         Button(action: onTap) {
@@ -84,7 +83,7 @@ struct ContentTileView: View {
     }
 
     private var contentShape: some Shape {
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
+        RoundedRectangle(cornerRadius: Constants.cellRadius, style: .continuous)
     }
 
     private var contentTransition: AnyTransition {

--- a/SwiftLeeds/Views/About/ContentTileView.swift
+++ b/SwiftLeeds/Views/About/ContentTileView.swift
@@ -55,6 +55,7 @@ struct ContentTileView: View {
             }
         )
         .aspectRatio(1.66, contentMode: .fit)
+        .accessibilityHidden(true)
     }
 
     private var text: some View {
@@ -68,6 +69,10 @@ struct ContentTileView: View {
                     .font(.subheadline.weight(.regular))
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "Sponsor, \(title) \(subTitle ?? "")"
+        )
         .padding()
         .frame(minHeight: 55)
     }

--- a/SwiftLeeds/Views/About/SponsorGridView.swift
+++ b/SwiftLeeds/Views/About/SponsorGridView.swift
@@ -1,0 +1,61 @@
+//
+//  SponsorGridView.swift
+//  SwiftLeeds
+//
+//  Created by Alex Logan on 01/07/2022.
+//
+
+import SwiftUI
+
+struct SponsorGridView: View {
+    let goldSponsors = Sponsor.platinum
+
+    var body: some View {
+        VStack(spacing: Padding.cellGap) {
+            sectionHeader(text: "Platinum Sponsors")
+            contentTile(for: Sponsor.codemagic)
+            contentTile(for: Sponsor.stream)
+            sectionHeader(text: "Gold Sponsors")
+            grid(for: Sponsor.gold)
+        }
+        .padding()
+    }
+
+    private func sectionHeader(text: String) -> some View {
+        Text(text)
+            .font(.callout.weight(.semibold))
+            .foregroundColor(.secondary)
+            .frame(maxWidth:.infinity, alignment: .leading)
+    }
+
+    private func contentTile(for sponsor: Sponsor, oneLinerEnabled: Bool = true) -> some View {
+        ContentTileView(
+            title: sponsor.name,
+            subTitle: oneLinerEnabled ? sponsor.oneLiner : nil,
+            imageURL: sponsor.imageURL,
+            imageBackgroundColor: .white,
+            imageContentMode: .fit
+        )
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private func grid(for sponsors: [Sponsor]) -> some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: Padding.cellGap), count: 2),
+            alignment: .center, spacing: Padding.cellGap, pinnedViews: []) {
+                ForEach(sponsors, id: \.self) { sponsor in
+                    contentTile(for: sponsor, oneLinerEnabled: false)
+                }
+        }
+    }
+}
+
+struct SponsorGridView_Previews: PreviewProvider {
+    static var previews: some View {
+        SwiftLeedsContainer {
+            ScrollView {
+                SponsorGridView()
+            }
+        }
+    }
+}

--- a/SwiftLeeds/Views/About/SponsorGridView.swift
+++ b/SwiftLeeds/Views/About/SponsorGridView.swift
@@ -14,8 +14,7 @@ struct SponsorGridView: View {
         VStack(spacing: Padding.cellGap) {
             sectionHeader(text: "Platinum Sponsors")
             ForEach(Sponsor.platinum, id: \.self) { sponsor in
-                contentTile(for: Sponsor.codemagic)
-                contentTile(for: Sponsor.stream)
+                contentTile(for: sponsor)
             }
             sectionHeader(text: "Gold Sponsors")
             grid(for: Sponsor.gold)

--- a/SwiftLeeds/Views/About/SponsorGridView.swift
+++ b/SwiftLeeds/Views/About/SponsorGridView.swift
@@ -9,13 +9,14 @@ import SwiftUI
 
 struct SponsorGridView: View {
     @Environment(\.openURL) var openURL
-    let goldSponsors = Sponsor.platinum
 
     var body: some View {
         VStack(spacing: Padding.cellGap) {
             sectionHeader(text: "Platinum Sponsors")
-            contentTile(for: Sponsor.codemagic)
-            contentTile(for: Sponsor.stream)
+            ForEach(Sponsor.platinum, id: \.self) { sponsor in
+                contentTile(for: Sponsor.codemagic)
+                contentTile(for: Sponsor.stream)
+            }
             sectionHeader(text: "Gold Sponsors")
             grid(for: Sponsor.gold)
         }

--- a/SwiftLeeds/Views/About/SponsorGridView.swift
+++ b/SwiftLeeds/Views/About/SponsorGridView.swift
@@ -26,6 +26,7 @@ struct SponsorGridView: View {
             .font(.callout.weight(.semibold))
             .foregroundColor(.secondary)
             .frame(maxWidth:.infinity, alignment: .leading)
+            .accessibilityAddTraits(.isHeader)
     }
 
     private func contentTile(for sponsor: Sponsor, oneLinerEnabled: Bool = true) -> some View {

--- a/SwiftLeeds/Views/About/SponsorGridView.swift
+++ b/SwiftLeeds/Views/About/SponsorGridView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SponsorGridView: View {
+    @Environment(\.openURL) var openURL
     let goldSponsors = Sponsor.platinum
 
     var body: some View {
@@ -35,7 +36,8 @@ struct SponsorGridView: View {
             subTitle: oneLinerEnabled ? sponsor.oneLiner : nil,
             imageURL: sponsor.imageURL,
             imageBackgroundColor: .white,
-            imageContentMode: .fit
+            imageContentMode: .fit,
+            onTap: { openSponsor(sponsor: sponsor) }
         )
         .frame(maxWidth: .infinity, alignment: .center)
     }
@@ -48,6 +50,11 @@ struct SponsorGridView: View {
                     contentTile(for: sponsor, oneLinerEnabled: false)
                 }
         }
+    }
+
+    private func openSponsor(sponsor: Sponsor) {
+        guard let link = sponsor.link else { return }
+        openURL(link)
     }
 }
 

--- a/SwiftLeeds/Views/Common/SwiftLeedsContainer.swift
+++ b/SwiftLeeds/Views/Common/SwiftLeedsContainer.swift
@@ -1,0 +1,31 @@
+//
+//  SwiftLeedsContainer.swift
+//  SwiftLeeds
+//
+//  Created by Alex Logan on 01/07/2022.
+//
+
+import SwiftUI
+
+struct SwiftLeedsContainer<Content: View>: View {
+    private var content: () -> (Content)
+
+    init(@ViewBuilder content: @escaping () -> (Content)) {
+        self.content = content
+    }
+
+    var body: some View {
+        ZStack {
+            Color.background.edgesIgnoringSafeArea(.all)
+            content()
+        }
+    }
+}
+
+struct SwiftLeedsContainer_Previews: PreviewProvider {
+    static var previews: some View {
+        SwiftLeedsContainer {
+            Text("SwiftLeeds 22")
+        }
+    }
+}

--- a/SwiftLeeds/Views/My Conference/MyConferenceView.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceView.swift
@@ -35,7 +35,7 @@ struct MyConferenceView: View {
 
                 Divider()
             }
-            .background(Color.backgrond)
+            .background(Color.background)
             .navigationTitle("Swift Leeds")
         }
     }


### PR DESCRIPTION
Adds the sponsor grid, including a re-usable `ContentTile`. Voiceover should be a pretty solid experience that simply iterates over each section header then the sponsors underneath, and I've tested they can open the URLs nicely.

I've added it to the `AboutView` for now but we might want this to end up being a child view, lets see how it goes!

Whilst in here I fixed a couple typos etc along the way 😄 

| 🌝 | 🌚 |
| - | - | 
|![Simulator Screen Shot - iPhone 13 - 2022-07-01 at 21 05 13](https://user-images.githubusercontent.com/13989549/176961805-d8dd6d6d-9bc5-4a55-8677-a7a8732fcdbe.png) ![Simulator Screen Shot - iPhone 13 - 2022-07-01 at 21 05 42](https://user-images.githubusercontent.com/13989549/176961857-23e67ec5-000e-4986-99c9-1bb17957c4ff.png)|![Simulator Screen Shot - iPhone 13 - 2022-07-01 at 21 05 33](https://user-images.githubusercontent.com/13989549/176961842-90a4e4d4-37b6-4522-a6c7-cf01de8fa933.png)![Simulator Screen Shot - iPhone 13 - 2022-07-01 at 21 05 36](https://user-images.githubusercontent.com/13989549/176961847-846475dc-76f9-4bae-a77d-9e9276552286.png)| 


| 🌝 big ol text | 🌚 big ol text |
| - | - | 
|![Simulator Screen Shot - iPhone 13 - 2022-07-01 at 21 08 03](https://user-images.githubusercontent.com/13989549/176962056-1ca6c2f8-506b-4883-af2b-867d3343da57.png)|![Simulator Screen Shot - iPhone 13 - 2022-07-01 at 21 08 44](https://user-images.githubusercontent.com/13989549/176962111-23c93214-9810-4cc6-a161-637786a2a302.png)|

