### PR TITLE
Add a network stack 

### DIFF
--- a/Packages/NetworkKit/.gitignore
+++ b/Packages/NetworkKit/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Packages/NetworkKit/Package.swift
+++ b/Packages/NetworkKit/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "NetworkKit",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "NetworkKit",
+            targets: ["NetworkKit"]
+        ),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "NetworkKit",
+            dependencies: []),
+        .testTarget(
+            name: "NetworkKitTests",
+            dependencies: ["NetworkKit"]),
+    ]
+)

--- a/Packages/NetworkKit/README.md
+++ b/Packages/NetworkKit/README.md
@@ -1,0 +1,3 @@
+# NetworkKit
+
+A description of this package.

--- a/Packages/NetworkKit/Sources/NetworkKit/DateFormatters.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/DateFormatters.swift
@@ -1,0 +1,21 @@
+//
+//  DateFormatters.swift
+//
+
+import Foundation
+
+struct DateFormatters {
+    // 2022-06-22
+    static var shortDateFormatter: DateFormatter {
+        let dateformatter = DateFormatter()
+        dateformatter.dateFormat = "yyyy-mm-dd"
+        return dateformatter
+    }
+    
+    // Sunday, Feb 6, 2022
+    static var writtenDateFormatter: DateFormatter {
+        let dateformatter = DateFormatter()
+        dateformatter.dateFormat = "EEEE, MMM d, yyyy"
+        return dateformatter
+    }
+}

--- a/Packages/NetworkKit/Sources/NetworkKit/Endpoint.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/Endpoint.swift
@@ -1,0 +1,51 @@
+//
+//  Endpoint.swift
+//
+
+import Foundation
+
+public enum HTTPMethod {
+    case GET, POST, PUT, PATCH, DELETE
+}
+
+public protocol Endpoint {
+    associatedtype DataType: Decodable
+
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var queryParameters: [URLQueryItem] { get }
+    var pathParameters: [String] { get }
+
+    func makeRequest(for environment: NetworkEnvironmentProviding) -> URLRequest?
+}
+
+public extension Endpoint {
+    /// Default parameters so routes do not need to declare these
+    var queryParameters: [URLQueryItem] {
+        return []
+    }
+    var pathParameters: [String] {
+        return []
+    }
+
+    /// The basic implementation of `Endpoint` `toRequest` builds the path. This should be usable with most instances of Endpoint.
+    func makeRequest(for environment: NetworkEnvironmentProviding) -> URLRequest? {
+        // Add all the parameters
+        guard var urlComponents = URLComponents(string: environment.apiUrl) else {
+            return nil
+        }
+        urlComponents.queryItems = self.queryParameters
+        
+        guard var url = urlComponents.url?.appendingPathComponent(self.path) else {
+            return nil
+        }
+
+        pathParameters.forEach {
+            url.appendPathComponent($0)
+        }
+
+        var request = URLRequest(url: url)
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        return request
+    }
+}

--- a/Packages/NetworkKit/Sources/NetworkKit/MockNetwork.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/MockNetwork.swift
@@ -1,0 +1,46 @@
+//
+//  MockNetwork.swift
+//
+
+import Foundation
+import Combine
+
+/// A fully featured mock for `Networking` that allows injection of any error or data, from any endpoint.
+/// The endpoint itself is ignored, and the provided data or error is emitted instead.
+public class MockNetwork: Networking {
+
+    private let environment: NetworkEnvironmentProviding
+    private let urlSession: URLSession
+    private var mockData: Decodable?
+    private var mockError: NetworkError?
+
+    required public init(environment: NetworkEnvironmentProviding, urlSession: URLSession) {
+        self.environment = environment
+        self.urlSession = urlSession
+    }
+
+    public func performRequest<E>(endpoint: E) -> AnyPublisher<E.DataType, NetworkError> where E: Endpoint {
+        Deferred {
+            Future { handler in
+                if let mockData = self.mockData as? E.DataType {
+                    handler(.success(mockData))
+                } else if let mockError = self.mockError {
+                    handler(.failure(mockError))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+
+    /// Sets up the network handlers to return success with the provided `Decodable` provided that it matches the `Endpoint` data type.
+    /// Takes precedence over `injectMockError`, in cases where both are provided the success will be returned.
+    func injectMockData(data: Decodable) {
+        self.mockData = data
+    }
+
+    /// Sets up the network handlers to return failure with the provided `NetworkError`
+    func injectMockError(error: NetworkError) {
+        self.mockError = error
+    }
+
+}

--- a/Packages/NetworkKit/Sources/NetworkKit/Network.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/Network.swift
@@ -1,0 +1,72 @@
+//
+//  Network.swift
+//
+
+import Foundation
+import Combine
+
+/// A simple implementation of `Networking` that should handle most use cases.
+final public class Network: Networking {
+    let environment: NetworkEnvironmentProviding
+    let urlSession: URLSession
+
+    required public init(environment: NetworkEnvironmentProviding, urlSession: URLSession = .shared) {
+        self.environment = environment
+        self.urlSession = urlSession
+    }
+
+    public func performRequest<E: Endpoint>(endpoint: E) async throws -> E.DataType {
+        guard let request = endpoint.makeRequest(for: environment) else {
+            throw NetworkError.other
+        }
+
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+            try validateResponseCode(response: response)
+            // Try to decode
+            do {
+                return try decoder.decode(E.DataType.self, from: data)
+            } catch {
+                throw NetworkError.failedToDecode
+            }
+        } catch {
+            throw NetworkError.init(from: (error as NSError).code)
+        }
+    }
+
+    private func validateResponseCode(response: URLResponse) throws {
+        guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+            throw NetworkError.badResponse
+        }
+        guard 200..<399  ~= statusCode else {
+            throw NetworkError(from: statusCode)
+        }
+    }
+
+    public func performRequest<E: Endpoint>(endpoint: E) -> AnyPublisher<E.DataType, NetworkError> {
+        // If we can't make a request, fail early, and just emit a lazy failure.
+        guard let request = endpoint.makeRequest(for: environment) else {
+            return Deferred {
+                Future { continuation in
+                    continuation(.failure(.other))
+                }
+            }
+            .eraseToAnyPublisher()
+        }
+
+        return urlSession.dataTaskPublisher(for: request)
+            .mapError { NetworkError(from: $0) }
+            .map(\.data)
+            .decode(type: E.DataType.self, decoder: decoder)
+            .mapError { err in
+                return NetworkError(from: (err as NSError).code)
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    lazy var decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        return decoder
+    }()
+}

--- a/Packages/NetworkKit/Sources/NetworkKit/NetworkEnvironmentProviding.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/NetworkEnvironmentProviding.swift
@@ -1,0 +1,9 @@
+//
+//  NetworkEnvironmentProviding.swift
+//
+
+import Foundation
+
+public protocol NetworkEnvironmentProviding {
+    var apiUrl: String { get }
+}

--- a/Packages/NetworkKit/Sources/NetworkKit/NetworkError.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/NetworkError.swift
@@ -1,0 +1,23 @@
+//
+//  NetworkError.swift
+//
+
+import Foundation
+
+public enum NetworkError: Int, Error {
+    case badResponse = 0
+    case badRequest = 400
+    case notFound = 404
+    case conflict = 409
+    case offline = -1009
+    case other
+    case failedToDecode = 4864
+    
+    public init(from error: URLError) {
+        self = NetworkError(rawValue: error.errorCode) ?? .other
+    }
+
+    public init(from errorCode: Int) {
+        self = NetworkError(rawValue: errorCode) ?? .other
+    }
+}

--- a/Packages/NetworkKit/Sources/NetworkKit/Networking.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/Networking.swift
@@ -1,0 +1,11 @@
+//
+//  Networking.swift
+//
+
+import Foundation
+import Combine
+
+public protocol Networking {
+    func performRequest<E: Endpoint>(endpoint: E) -> AnyPublisher<E.DataType, NetworkError>
+    init(environment: NetworkEnvironmentProviding, urlSession: URLSession)
+}

--- a/Packages/NetworkKit/Tests/NetworkKitTests/NetworkKitTests.swift
+++ b/Packages/NetworkKit/Tests/NetworkKitTests/NetworkKitTests.swift
@@ -1,0 +1,4 @@
+import XCTest
+@testable import NetworkKit
+
+final class NetworkKitTests: XCTestCase { }

--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		FA57DE552875B0C100911F03 /* SquishyButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA57DE542875B0C100911F03 /* SquishyButtonStyle.swift */; };
 		FA57DE592875B0EF00911F03 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA57DE582875B0EF00911F03 /* Sponsor.swift */; };
 		FAAB819128844EBC001159BB /* View+MeasureSize+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAB819028844EBC001159BB /* View+MeasureSize+Extension.swift */; };
+		FAF74EDC288B44BE00A0926C /* NetworkKit in Frameworks */ = {isa = PBXBuildFile; productRef = FAF74EDB288B44BE00A0926C /* NetworkKit */; };
+		FAF74EDF288B451E00A0926C /* SwiftLeedsEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF74EDE288B451E00A0926C /* SwiftLeedsEnvironment.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +89,8 @@
 		FA57DE542875B0C100911F03 /* SquishyButtonStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SquishyButtonStyle.swift; sourceTree = "<group>"; };
 		FA57DE582875B0EF00911F03 /* Sponsor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sponsor.swift; sourceTree = "<group>"; };
 		FAAB819028844EBC001159BB /* View+MeasureSize+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+MeasureSize+Extension.swift"; sourceTree = "<group>"; };
+		FAF74ED9288B415900A0926C /* NetworkKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = NetworkKit; sourceTree = "<group>"; };
+		FAF74EDE288B451E00A0926C /* SwiftLeedsEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLeedsEnvironment.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +98,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FAF74EDC288B44BE00A0926C /* NetworkKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,11 +122,13 @@
 		AECB294A27417F9D00CDC983 = {
 			isa = PBXGroup;
 			children = (
+				FAF74ED8288B413100A0926C /* Packages */,
 				AECB295527417F9D00CDC983 /* SwiftLeeds */,
 				AECB296627417F9E00CDC983 /* SwiftLeedsTests */,
 				AECB297027417F9E00CDC983 /* SwiftLeedsUITests */,
 				AECB295427417F9D00CDC983 /* Products */,
 				FA57DE402875B01900911F03 /* Recovered References */,
+				FAF74EDA288B44BE00A0926C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -138,12 +145,13 @@
 		AECB295527417F9D00CDC983 /* SwiftLeeds */ = {
 			isa = PBXGroup;
 			children = (
-				AECB29862741AC5800CDC983 /* App */,
 				FA57DE562875B0DC00911F03 /* Data */,
 				AECB298027418D9800CDC983 /* Extension */,
 				AECB295C27417F9E00CDC983 /* Preview Content */,
 				AECB29842741AC2500CDC983 /* Resources */,
 				FA57DE532875B0B500911F03 /* Style */,
+				AECB29862741AC5800CDC983 /* App */,
+				FAF74EDD288B44E200A0926C /* Network */,
 				AECB29852741AC4B00CDC983 /* Views */,
 			);
 			path = SwiftLeeds;
@@ -210,8 +218,8 @@
 			isa = PBXGroup;
 			children = (
 				AECB29832741ABFD00CDC983 /* Info.plist */,
-				AECB295627417F9D00CDC983 /* SwiftLeedsApp.swift */,
 				AE32CDEF286CCF9D00DF0AFF /* Constants.swift */,
+				AECB295627417F9D00CDC983 /* SwiftLeedsApp.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -304,6 +312,29 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		FAF74ED8288B413100A0926C /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				FAF74ED9288B415900A0926C /* NetworkKit */,
+			);
+			path = Packages;
+			sourceTree = "<group>";
+		};
+		FAF74EDA288B44BE00A0926C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FAF74EDD288B44E200A0926C /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				FAF74EDE288B451E00A0926C /* SwiftLeedsEnvironment.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -320,6 +351,9 @@
 			dependencies = (
 			);
 			name = SwiftLeeds;
+			packageProductDependencies = (
+				FAF74EDB288B44BE00A0926C /* NetworkKit */,
+			);
 			productName = SwiftLeeds;
 			productReference = AECB295327417F9D00CDC983 /* SwiftLeeds.app */;
 			productType = "com.apple.product-type.application";
@@ -437,6 +471,7 @@
 			files = (
 				AED26F7828676A9900E06064 /* AboutView.swift in Sources */,
 				FA57DE502875B09900911F03 /* ContentTileView.swift in Sources */,
+				FAF74EDF288B451E00A0926C /* SwiftLeedsEnvironment.swift in Sources */,
 				FA57DE4D2875B08600911F03 /* Gradient+Extension.swift in Sources */,
 				FA57DE552875B0C100911F03 /* SquishyButtonStyle.swift in Sources */,
 				AED26F7A28676AA300E06064 /* LocalView.swift in Sources */,
@@ -799,6 +834,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		FAF74EDB288B44BE00A0926C /* NetworkKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = NetworkKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AECB294B27417F9D00CDC983 /* Project object */;
 }

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import NetworkKit
 
 @main
 struct SwiftLeedsApp: App {

--- a/SwiftLeeds/Network/SwiftLeedsEnvironment.swift
+++ b/SwiftLeeds/Network/SwiftLeedsEnvironment.swift
@@ -1,0 +1,13 @@
+//
+//  SwiftLeedsEnvironment.swift
+//  SwiftLeeds
+//
+//  Created by Alex Logan on 22/07/2022.
+//
+
+import Foundation
+import NetworkKit
+
+struct SwiftLeedsEnvironment: NetworkEnvironmentProviding {
+    let apiUrl: String = "https://rickandmortyapi.com/api"
+}


### PR DESCRIPTION
This is my personal networking stack that I wrote for a coding test a while ago, but adapted for Swift concurrency. 
As it was written for a coding test it has a bunch of comments, which should hopefully help someone use this. 
The goal is that it should be trivial to add endpoints, and there should be type safety throughout.

I've added the basics and the SwiftLeeds environment - as soon as endpoints are ready I'll throw them in.

I'm sure there's improvements, but its battle tested, and it should help us speed along. Its also in a package because its nice to do 🕺🏻 

### How it works

Making the network stack is simply `Network(environment: SchwiftyEnvironment())`. This could be a static instance, in some object, or however you please.

The environment is just an object, designed simply so you could extend if you want, or ideally switch based on environments. I havent set up said scheme based switching or anything, but it certianly could be in here!

```swift
struct SchwiftyEnvironment: NetworkEnvironmentProviding {
    let apiUrl: String = "https://rickandmortyapi.com/api"
}
```

Creating an endpoint is lovely and typed, like so:

```swift
struct CharacterEndpoint: Endpoint {
    typealias DataType = GenericResponse<[Character]>
    let path: String = "character"
    let method: HTTPMethod = .GET
}
```

Actually using one is equally lovely = no strings!

```swift
Task {
    do {
        let network = Network(environment: SchwiftyEnvironment())
        let characters = try await network.performRequest(endpoint: CharacterEndpoint())
        print(characters)
    } catch {
        print(error)
    }
}
```