### PR TITLE
Fix image URLS & Fade cells

### DIFF
--- a/SwiftLeeds/App/Constants.swift
+++ b/SwiftLeeds/App/Constants.swift
@@ -20,10 +20,6 @@ enum Padding {
     static let stackGap: CGFloat = 4
 }
 
-enum BaseURL {
-    static let image = "https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/"
-}
-
 enum Strings {
     static let aboutSwiftLeeds = """
     Adam Rush founded SwiftLeeds in 2019, born from over ten years of experience attending conferences. The inspiration was bringing a modern, inclusive conference in the North of the UK to be more accessible for all.

--- a/SwiftLeeds/Views/My Conference/ActivityView.swift
+++ b/SwiftLeeds/Views/My Conference/ActivityView.swift
@@ -25,7 +25,7 @@ struct ActivityView: View {
         VStack(spacing: Padding.stackGap) {
             HeaderView(
                 title: activity.title,
-                imageURL: URL(string: "\(BaseURL.image)\(activity.image ?? "")"),
+                imageURL: URL(string: activity.image ?? ""),
                 backgroundImageAssetName: Assets.Image.playhouseImage
             )
 

--- a/SwiftLeeds/Views/My Conference/MyConferenceView.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceView.swift
@@ -34,6 +34,7 @@ struct MyConferenceView: View {
                                     .onTapGesture {
                                         selectedActivity = activity
                                     }
+                                    .transition(.opacity)
                             }
 
                             if let presentation = slot.presentation {
@@ -41,9 +42,11 @@ struct MyConferenceView: View {
                                     .onTapGesture {
                                         selectedPresentation = presentation
                                     }
+                                    .transition(.opacity)
                             }
                         }
                     }
+                    .animation(.easeInOut, value: viewModel.slots)
                     .padding(Padding.screen)
                 }
 

--- a/SwiftLeeds/Views/My Conference/SpeakerView.swift
+++ b/SwiftLeeds/Views/My Conference/SpeakerView.swift
@@ -26,7 +26,7 @@ struct SpeakerView: View {
             if let speaker = presentation.speaker {
                 HeaderView(
                     title: speaker.name,
-                    imageURL: URL(string: "\(BaseURL.image)\(speaker.profileImage)"),
+                    imageURL: URL(string: speaker.profileImage),
                     backgroundImageAssetName: Assets.Image.playhouseImage
                 )
             }

--- a/SwiftLeeds/Views/My Conference/TalkCell.swift
+++ b/SwiftLeeds/Views/My Conference/TalkCell.swift
@@ -51,7 +51,7 @@ struct TalkCell: View {
 
                         if let imageURL = imageURL {
                             CachedAsyncImage(
-                                url: URL(string: "\(BaseURL.image)\(imageURL)"),
+                                url: URL(string: imageURL),
                                 content: { image in
                                     image
                                         .resizable()


### PR DESCRIPTION
After the discussion around the app having to know the image URLS, we've adjusted the API in [this pr](https://github.com/SwiftLeeds/swiftleeds-web/pull/58) to map them to the full URLS.

This goes through and removes references to amazon via removing the base url, so that it only depends on the API for them.

I left the sponsor images and the previews alone as it doesn't feel like there's any harm in those having a reference given they're just previews 🙏🏻 

Whilst here I added the animation to the homepage loading, feel free to drop the commit if not wanted, it just adds a really nice fade. Its super subtle but this helps to illustrate:

| Before | After |
| - | - | 
|![before_demo](https://user-images.githubusercontent.com/13989549/183297867-3a45cc94-802e-4a69-addb-ca003d82a7ba.mp4)|![after_demo](https://user-images.githubusercontent.com/13989549/183297814-82742a43-15f1-4778-9407-3e5433da55f2.mp4)| 

