### PR TITLE
Add RevenueCat as Gold sponsor

### DIFF
--- a/SwiftLeeds/Data/Model/Sponsor.swift
+++ b/SwiftLeeds/Data/Model/Sponsor.swift
@@ -18,7 +18,7 @@ struct Sponsor: Hashable {
 // MARK: - Static data
 extension Sponsor {
     static let platinum = [codemagic, stream]
-    static let gold = [mkodo, and, xdesign, bitrise]
+    static let gold = [mkodo, and, xdesign, bitrise, revenueCat]
 
     // All of these images are temporary until this is API based
 
@@ -64,5 +64,12 @@ extension Sponsor {
         oneLiner: "Build better mobile applications, faster",
         imageURL: URL(string: "https://assets-global.website-files.com/5db35de024bb983af1b4e151/5e6f9ccda4e7ff12841abe18_Bitrise%20Logo%20-%20White%20Bg.png"),
         link: URL(string: "https://www.bitrise.io/")
+    )
+
+    static let revenueCat = Sponsor(
+        name: "RevenueCat",
+        oneLiner: "In-App Subscriptions Made Easy",
+        imageURL: URL(string: "https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/1B6DDD64-3DCE-46BD-9EFB-75444654ADBE-revenuecat-logo-red.png"),
+        link: URL(string: "https://www.revenuecat.com")
     )
 }

--- a/SwiftLeeds/Views/About/ContributorsView.swift
+++ b/SwiftLeeds/Views/About/ContributorsView.swift
@@ -38,6 +38,7 @@ struct ContributorsView: View {
             title: contributer.name,
             subTitle: oneLinerEnabled ? contributer.oneLiner : nil,
             imageURL: contributer.imageURL,
+            isImagePadded: false,
             imageBackgroundColor: .white,
             imageContentMode: .fill,
             onTap: { }

--- a/SwiftLeeds/Views/About/SponsorGridView.swift
+++ b/SwiftLeeds/Views/About/SponsorGridView.swift
@@ -29,12 +29,13 @@ struct SponsorGridView: View {
             .accessibilityAddTraits(.isHeader)
     }
 
-    private func contentTile(for sponsor: Sponsor, oneLinerEnabled: Bool = true) -> some View {
+    private func contentTile(for sponsor: Sponsor, oneLinerEnabled: Bool = true, isImagePadded: Bool = false) -> some View {
         ContentTileView(
             accessibilityLabel: "Sponsor",
             title: sponsor.name,
             subTitle: oneLinerEnabled ? sponsor.oneLiner : nil,
             imageURL: sponsor.imageURL,
+            isImagePadded: isImagePadded,
             imageBackgroundColor: .white,
             imageContentMode: .fit,
             onTap: { openSponsor(sponsor: sponsor) }
@@ -47,7 +48,7 @@ struct SponsorGridView: View {
             columns: Array(repeating: GridItem(.flexible(), spacing: Padding.cellGap), count: 2),
             alignment: .center, spacing: Padding.cellGap, pinnedViews: []) {
                 ForEach(sponsors, id: \.self) { sponsor in
-                    contentTile(for: sponsor, oneLinerEnabled: false)
+                    contentTile(for: sponsor, oneLinerEnabled: false, isImagePadded: true)
                 }
         }
     }
@@ -63,6 +64,7 @@ struct SponsorGridView_Previews: PreviewProvider {
         SwiftLeedsContainer {
             ScrollView {
                 SponsorGridView()
+                    .padding()
             }
         }
     }

--- a/SwiftLeeds/Views/Components/ContentTileView.swift
+++ b/SwiftLeeds/Views/Components/ContentTileView.swift
@@ -14,6 +14,7 @@ struct ContentTileView: View {
     let title: String
     let subTitle: String?
     let imageURL: URL?
+    let isImagePadded: Bool
 
     var placeholderColor: Color = .accentColor
     var imageBackgroundColor: Color = .accentColor
@@ -25,6 +26,8 @@ struct ContentTileView: View {
         Button(action: onTap) {
             VStack(alignment: .leading, spacing: 0) {
                 image
+                    .padding(isImagePadded ? 8 : 0)
+
                 text
             }
         }
@@ -103,6 +106,7 @@ struct ContentTileView_Previews: PreviewProvider {
                     title: "Alex Logan",
                     subTitle: "subtitle",
                     imageURL: URL(string: "https://pbs.twimg.com/profile_images/1475087054652559361/lgTnY96Q_400x400.jpg"),
+                    isImagePadded: false,
                     onTap: {}
                 )
                 ContentTileView(
@@ -110,6 +114,7 @@ struct ContentTileView_Previews: PreviewProvider {
                     title: "Alex Logan",
                     subTitle: nil,
                     imageURL: nil,
+                    isImagePadded: false,
                     onTap: {}
                 )
             }


### PR DESCRIPTION
Added RevenueCat to Gold sponsors.  
Also added some padding to make the gold sponsor logos look better.  

![swift-leeds-revenuecat](https://user-images.githubusercontent.com/20776253/192147994-16dec90a-9a89-45f1-adbf-7cd349c5a1f8.png)
