### PR TITLE
Add multi-day schedule

### DIFF
--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -94,6 +94,13 @@
 		AE8C1B2628BFCFE700AF7318 /* Speaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8C1B2528BFCFE700AF7318 /* Speaker.swift */; };
 		AE8C1B2828C4B36B00AF7318 /* AppDelegate+Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8C1B2728C4B36B00AF7318 /* AppDelegate+Push.swift */; };
 		AE8C1B2B28C4B39A00AF7318 /* TokenDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8C1B2A28C4B39A00AF7318 /* TokenDetails.swift */; };
+		AE93678F2A93455400F2DB3F /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE93678E2A93455400F2DB3F /* ScheduleView.swift */; };
+		AE9367902A93467500F2DB3F /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE93678E2A93455400F2DB3F /* ScheduleView.swift */; };
+		AE9367922A93481800F2DB3F /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9367912A93481800F2DB3F /* Date.swift */; };
+		AE9367932A93481800F2DB3F /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9367912A93481800F2DB3F /* Date.swift */; };
+		AE9367962A9354CC00F2DB3F /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9367952A9354CC00F2DB3F /* Helper.swift */; };
+		AE9367972A9354CC00F2DB3F /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9367952A9354CC00F2DB3F /* Helper.swift */; };
+		AE9367982A9357D000F2DB3F /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9367952A9354CC00F2DB3F /* Helper.swift */; };
 		AEB06BD128CF8D2100E51967 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB06BD028CF8D2100E51967 /* WebView.swift */; };
 		AECB295727417F9D00CDC983 /* SwiftLeedsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB295627417F9D00CDC983 /* SwiftLeedsApp.swift */; };
 		AECB295927417F9D00CDC983 /* MyConferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB295827417F9D00CDC983 /* MyConferenceView.swift */; };
@@ -230,6 +237,9 @@
 		AE8C1B2728C4B36B00AF7318 /* AppDelegate+Push.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Push.swift"; sourceTree = "<group>"; };
 		AE8C1B2A28C4B39A00AF7318 /* TokenDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDetails.swift; sourceTree = "<group>"; };
 		AE8C1B2C28C4B8D800AF7318 /* SwiftLeeds.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftLeeds.entitlements; sourceTree = "<group>"; };
+		AE93678E2A93455400F2DB3F /* ScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
+		AE9367912A93481800F2DB3F /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		AE9367952A9354CC00F2DB3F /* Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helper.swift; sourceTree = "<group>"; };
 		AEB06BD028CF8D2100E51967 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		AECB295327417F9D00CDC983 /* SwiftLeeds.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftLeeds.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AECB295627417F9D00CDC983 /* SwiftLeedsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLeedsApp.swift; sourceTree = "<group>"; };
@@ -454,6 +464,7 @@
 			children = (
 				AEDC2256289C65D500746247 /* Calendar.swift */,
 				AECB298127418DA200CDC983 /* Color.swift */,
+				AE9367912A93481800F2DB3F /* Date.swift */,
 				FA57DE4C2875B08600911F03 /* LinearGradient.swift */,
 				AE1C800F289E9F3800996659 /* String.swift */,
 				FAAB819028844EBC001159BB /* View+MeasureSize.swift */,
@@ -534,6 +545,7 @@
 				AED26F6F28675DA000E06064 /* AnnouncementCell.swift */,
 				AECB295827417F9D00CDC983 /* MyConferenceView.swift */,
 				AEDC22522898281300746247 /* MyConferenceViewModel.swift */,
+				AE93678E2A93455400F2DB3F /* ScheduleView.swift */,
 				394653AA288BB7C800212E1C /* SpeakerView.swift */,
 				AED26F73286764F000E06064 /* TalkCell.swift */,
 			);
@@ -545,6 +557,7 @@
 			children = (
 				394653A8288BB47A00212E1C /* SectionHeader.swift */,
 				FA57DE4A2875B06B00911F03 /* SwiftLeedsContainer.swift */,
+				AE9367952A9354CC00F2DB3F /* Helper.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -839,6 +852,7 @@
 				0B4CB3DF28EAF58400246E62 /* Constants.swift in Sources */,
 				0B4CB3F128EAF61000246E62 /* StackedTileView.swift in Sources */,
 				0B4CB3DE28EAF57E00246E62 /* MyConferenceViewModel.swift in Sources */,
+				AE9367902A93467500F2DB3F /* ScheduleView.swift in Sources */,
 				0B4CB3ED28EAF5F200246E62 /* SwiftLeedsContainer.swift in Sources */,
 				0B4CB3EC28EAF5E900246E62 /* ActivityView.swift in Sources */,
 				0B4CB3F228EAF61600246E62 /* WebView.swift in Sources */,
@@ -847,12 +861,14 @@
 				0B4CB3EF28EAF60200246E62 /* FancyHeaderView.swift in Sources */,
 				0B4CB3F628EAF63100246E62 /* LinearGradient.swift in Sources */,
 				0B4CB3F028EAF60800246E62 /* SpeakerView.swift in Sources */,
+				AE9367932A93481800F2DB3F /* Date.swift in Sources */,
 				0B4CB3E428EAF5AF00246E62 /* Presentation.swift in Sources */,
 				741ED8FC2A7582A600494B25 /* SponsorsView.swift in Sources */,
 				0B4CB3F528EAF62A00246E62 /* SquishyButtonStyle.swift in Sources */,
 				0B4CB3E928EAF5D200246E62 /* Local.swift in Sources */,
 				0B4CB3E228EAF59900246E62 /* Calendar.swift in Sources */,
 				0B910A352A48FEC100648B32 /* ContentTileView.swift in Sources */,
+				AE9367972A9354CC00F2DB3F /* Helper.swift in Sources */,
 				0B4CB3E528EAF5B700246E62 /* Speaker.swift in Sources */,
 				0B4CB3E828EAF5CD00246E62 /* AnnouncementCell.swift in Sources */,
 				0B4CB3DD28EAF57900246E62 /* MyConferenceView.swift in Sources */,
@@ -879,6 +895,7 @@
 				74E62F7228CA98EA004422F9 /* SwiftLeedsSmallWidgetView.swift in Sources */,
 				7406572928E240720087F44F /* WidgetConstants.swift in Sources */,
 				74A09FF228C689AB00E03F39 /* Color.swift in Sources */,
+				AE9367982A9357D000F2DB3F /* Helper.swift in Sources */,
 				74B14FB028CE21D7004C0A40 /* TimeineProvider.swift in Sources */,
 				74E62F7828CADBE0004422F9 /* Activity.swift in Sources */,
 				74E62F7A28CAE4DF004422F9 /* Speaker.swift in Sources */,
@@ -902,6 +919,7 @@
 				394653A9288BB47A00212E1C /* SectionHeader.swift in Sources */,
 				FA57DE552875B0C100911F03 /* SquishyButtonStyle.swift in Sources */,
 				FA534D7F28A1905000A3BFBB /* Environment.swift in Sources */,
+				AE9367962A9354CC00F2DB3F /* Helper.swift in Sources */,
 				AED26F7A28676AA300E06064 /* LocalView.swift in Sources */,
 				39ED0034288F113500AB337A /* LocalCell.swift in Sources */,
 				AEDC22552898288F00746247 /* Schedule.swift in Sources */,
@@ -925,6 +943,7 @@
 				0B4B1A4B2A4858F600ED7EA9 /* SponsorsView.swift in Sources */,
 				AE8C1B2B28C4B39A00AF7318 /* TokenDetails.swift in Sources */,
 				0B910A372A49D07700648B32 /* Sponsor.swift in Sources */,
+				AE9367922A93481800F2DB3F /* Date.swift in Sources */,
 				AEDC0DAE286759630078A153 /* Tabs.swift in Sources */,
 				AE8C1B2628BFCFE700AF7318 /* Speaker.swift in Sources */,
 				39029E0228883851006BC6EE /* ContributorsView.swift in Sources */,
@@ -932,6 +951,7 @@
 				AE8C1B2228BFCF4700AF7318 /* Activity.swift in Sources */,
 				FA57DE482875B06500911F03 /* StackedTileView.swift in Sources */,
 				FA534D8228A1909300A3BFBB /* Local.swift in Sources */,
+				AE93678F2A93455400F2DB3F /* ScheduleView.swift in Sources */,
 				AE32CDF0286CCF9D00DF0AFF /* Constants.swift in Sources */,
 				FA57DE472875B06500911F03 /* CommonTileView.swift in Sources */,
 				FA57DE462875B06500911F03 /* CommonTileButton.swift in Sources */,

--- a/SwiftLeeds/Data/Model/Schedule.swift
+++ b/SwiftLeeds/Data/Model/Schedule.swift
@@ -28,13 +28,14 @@ struct Schedule: Decodable {
 
     struct Slot: Identifiable {
         let id: UUID
+        let date: Date?
         let startTime: String
         let duration: Int
         let activity: Activity?
         let presentation: Presentation?
 
         private enum CodingKeys: CodingKey {
-            case id, activity, presentation, startTime, duration
+            case id, activity, presentation, date, startTime, duration
         }
 
         static var timeFormat: DateFormatter = {
@@ -51,8 +52,11 @@ extension Schedule.Slot: Codable {
         let values = try decoder.container(keyedBy: CodingKeys.self)
 
         id = try values.decode(UUID.self, forKey: .id)
-        duration = try values.decode(Int.self, forKey: .duration)
         startTime = try values.decode(String.self, forKey: .startTime)
+        duration = try values.decode(Int.self, forKey: .duration)
+
+        let date = try values.decodeIfPresent(String.self, forKey: .date) ?? ""
+        self.date = ISO8601DateFormatter().date(from: date)
 
         if let activity = try values.decodeIfPresent(Activity.self, forKey: .activity) {
             self.activity = activity

--- a/SwiftLeeds/Extension/Date.swift
+++ b/SwiftLeeds/Extension/Date.swift
@@ -1,0 +1,18 @@
+//
+//  Date.swift
+//  SwiftLeeds
+//
+//  Created by Matthew Gallagher on 21/08/2023.
+//
+
+import Foundation
+
+extension Date {
+    var withoutTime: Date {
+        guard let date = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month, .day], from: self)) else {
+            fatalError("Failed to strip time from Date")
+        }
+
+        return date
+    }
+}

--- a/SwiftLeeds/Views/Common/Helper.swift
+++ b/SwiftLeeds/Views/Common/Helper.swift
@@ -1,0 +1,16 @@
+//
+//  Helper.swift
+//  SwiftLeeds
+//
+//  Created by Matthew Gallagher on 21/08/2023.
+//
+
+import Foundation
+
+enum Helper {
+    static var shortDateFormatter: DateFormatter = {
+        let dateformatter = DateFormatter()
+        dateformatter.dateFormat = "dd-MM-yyyy"
+        return dateformatter
+    }()
+}

--- a/SwiftLeeds/Views/My Conference/MyConferenceView.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceView.swift
@@ -8,58 +8,96 @@
 import SwiftUI
 
 struct MyConferenceView: View {
-    
     @StateObject private var viewModel = MyConferenceViewModel()
+
+    @State private var currentIndex: Int = 0
+    @Namespace private var namespace
     
     var body: some View {
-        VStack(spacing: 0) {
-            Divider()
-            
-            if viewModel.slots.isEmpty {
-                empty
-            } else {
-                schedule
+        NavigationView {
+            VStack(spacing: 0) {
+                Divider()
+
+                if viewModel.slots.isEmpty {
+                    empty
+                } else {
+                    schedule
+                }
+
+                Divider()
             }
-            
-            Divider()
+            .background(Color.listBackground)
+            .navigationTitle("Schedule")
+            .accentColor(.white)
         }
-        .background(Color.listBackground)
-        .navigationTitle("Schedule")
-        .accentColor(.white)
         .task {
             try? await viewModel.loadSchedule()
         }
     }
-    
+
     private var schedule: some View {
-        ScrollView {
-            VStack(spacing: Padding.cellGap) {
-                ForEach(viewModel.slots) { slot in
-                    if let activity = slot.activity {
-                        NavigationLink {
-                            ActivityView(activity: activity)
-                        } label: {
-                            TalkCell(time: slot.startTime, details: activity.title)
-                                .transition(.opacity)
-                        }
-                    }
-                    
-                    if let presentation = slot.presentation {
-                        NavigationLink {
-                            SpeakerView(presentation: presentation,
-                                        showSlido: viewModel.showSlido)
-                        } label: {
-                            TalkCell(time: slot.startTime,
-                                     details: presentation.title,
-                                     speakers: presentation.speakers)
-                            .transition(.opacity)
-                        }
-                    }
+        VStack(spacing: 0) {
+            ViewThatFits {
+                scheduleHeaders
+
+                ScrollView(.horizontal) {
+                    scheduleHeaders
                 }
             }
-            .animation(.easeInOut, value: viewModel.slots)
-            .padding(Padding.screen)
+
+            TabView(selection: $currentIndex) {
+                ForEach(Array(zip(viewModel.days.indices, viewModel.days)), id: \.0) { index, key in
+                    ScheduleView(slots: viewModel.slots[key] ?? [], showSlido: viewModel.showSlido)
+                        .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .edgesIgnoringSafeArea(.all)
         }
+    }
+
+    @ViewBuilder
+    private var scheduleHeaders: some View {
+        if viewModel.days.count == 1 {
+            tabBarHeader(title: viewModel.days.first!, index: 0)
+                .disabled(true)
+                .padding()
+        } else {
+            HStack(spacing: 20) {
+                ForEach(Array(zip(viewModel.days.indices, viewModel.days)), id: \.0) { index, key in
+                    tabBarHeader(title: "Day \(index + 1)", index: index)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.top)
+        }
+    }
+
+    private func tabBarHeader(title: String, index: Int) -> some View {
+        Button {
+            currentIndex = index
+        } label: {
+            VStack(spacing: 4) {
+                Text(title)
+                    .font(.system(size: 13, weight: .light, design: .default))
+
+                Text("")
+                    .frame(height: 2)
+            }
+            .foregroundColor(.cellForeground)
+            .overlay(alignment: .bottom) {
+                if currentIndex == index {
+                    Color.cellForeground
+                        .frame(height: 2)
+                        .matchedGeometryEffect(id: "tabSelectionLine", in: namespace, properties: .frame)
+                } else {
+                    Color.clear.frame(height: 2)
+                }
+
+            }
+            .animation(.spring(), value: currentIndex)
+        }
+        .buttonStyle(.plain)
     }
     
     @ViewBuilder

--- a/SwiftLeeds/Views/My Conference/ScheduleView.swift
+++ b/SwiftLeeds/Views/My Conference/ScheduleView.swift
@@ -1,0 +1,50 @@
+//
+//  ScheduleView.swift
+//  SwiftLeeds
+//
+//  Created by Matthew Gallagher on 21/08/2023.
+//
+
+import SwiftUI
+
+struct ScheduleView: View {
+    let slots: [Schedule.Slot]
+    let showSlido: Bool
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: Padding.cellGap) {
+                ForEach(slots) { slot in
+                    if let activity = slot.activity {
+                        NavigationLink {
+                            ActivityView(activity: activity)
+                        } label: {
+                            TalkCell(time: slot.startTime, details: activity.title)
+                                .transition(.opacity)
+                        }
+                    }
+
+                    if let presentation = slot.presentation {
+                        NavigationLink {
+                            SpeakerView(presentation: presentation,
+                                        showSlido: showSlido)
+                        } label: {
+                            TalkCell(time: slot.startTime,
+                                     details: presentation.title,
+                                     speakers: presentation.speakers)
+                            .transition(.opacity)
+                        }
+                    }
+                }
+            }
+            .animation(.easeInOut, value: slots)
+            .padding(Padding.screen)
+        }
+    }
+}
+
+struct ScheduleView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScheduleView(slots: [], showSlido: true)
+    }
+}

--- a/SwiftLeedsWidget/SwiftLeedsMediumWidgetView.swift
+++ b/SwiftLeedsWidget/SwiftLeedsMediumWidgetView.swift
@@ -94,10 +94,10 @@ extension SwiftLeedsMediumWidgetView {
 
 struct SwiftLeedsMediumWidgetView_Previews: PreviewProvider {
     static var previews: some View {
-        SwiftLeedsMediumWidgetView(slot: Schedule.Slot(id: UUID(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.donnyWalls))
+        SwiftLeedsMediumWidgetView(slot: Schedule.Slot(id: UUID(), date: Date(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.donnyWalls))
             .previewContext(WidgetPreviewContext(family: .systemMedium))
         
-        SwiftLeedsMediumWidgetView(slot: Schedule.Slot(id: UUID(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.donnyWalls))
+        SwiftLeedsMediumWidgetView(slot: Schedule.Slot(id: UUID(), date: Date(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.donnyWalls))
             .environment(\.colorScheme, .dark)
             .previewContext(WidgetPreviewContext(family: .systemMedium))
     }

--- a/SwiftLeedsWidget/SwiftLeedsSmallWidgetView.swift
+++ b/SwiftLeedsWidget/SwiftLeedsSmallWidgetView.swift
@@ -82,10 +82,10 @@ extension SwiftLeedsSmallWidgetView {
 
 struct SwiftLeedsSmallWidgetView_Previews: PreviewProvider {
     static var previews: some View {
-        SwiftLeedsSmallWidgetView(slot: Schedule.Slot(id: UUID(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.skyBet))
+        SwiftLeedsSmallWidgetView(slot: Schedule.Slot(id: UUID(), date: Date(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.skyBet))
             .previewContext(WidgetPreviewContext(family: .systemSmall))
         
-        SwiftLeedsSmallWidgetView(slot: Schedule.Slot(id: UUID(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.skyBet))
+        SwiftLeedsSmallWidgetView(slot: Schedule.Slot(id: UUID(), date: Date(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.skyBet))
             .environment(\.colorScheme, .dark)
             .previewContext(WidgetPreviewContext(family: .systemSmall))
     }

--- a/SwiftLeedsWidget/SwiftLeedsWidgetEntryView.swift
+++ b/SwiftLeedsWidget/SwiftLeedsWidgetEntryView.swift
@@ -23,10 +23,10 @@ struct SwiftLeedsWidgetEntryView : View {
 
 struct SwiftLeedsWidget_Previews: PreviewProvider {
     static var previews: some View {
-        SwiftLeedsWidgetEntryView(entry: SwiftLeedsWidgetEntry(date: Date(), slot: Schedule.Slot(id: UUID(), startTime: "11:00 AM", duration: 1, activity: Activity.lunch, presentation: Presentation.donnyWalls)))
+        SwiftLeedsWidgetEntryView(entry: SwiftLeedsWidgetEntry(date: Date(), slot: Schedule.Slot(id: UUID(), date: Date(), startTime: "11:00 AM", duration: 1, activity: Activity.lunch, presentation: Presentation.donnyWalls)))
             .previewContext(WidgetPreviewContext(family: .systemSmall))
         
-        SwiftLeedsWidgetEntryView(entry: SwiftLeedsWidgetEntry(date: Date(), slot: Schedule.Slot(id: UUID(), startTime: "11:00 AM", duration: 1, activity: Activity.lunch, presentation: Presentation.donnyWalls)))
+        SwiftLeedsWidgetEntryView(entry: SwiftLeedsWidgetEntry(date: Date(), slot: Schedule.Slot(id: UUID(), date: Date(), startTime: "11:00 AM", duration: 1, activity: Activity.lunch, presentation: Presentation.donnyWalls)))
             .previewContext(WidgetPreviewContext(family: .systemMedium))
     }
 }

--- a/SwiftLeedsWidget/WidgetSetup/TimeineProvider.swift
+++ b/SwiftLeedsWidget/WidgetSetup/TimeineProvider.swift
@@ -10,11 +10,11 @@ import SwiftUI
 
 struct Provider: TimelineProvider {
     func placeholder(in context: Context) -> SwiftLeedsWidgetEntry {
-        SwiftLeedsWidgetEntry(date: Date(), slot: Schedule.Slot(id: UUID(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.donnyWalls))
+        SwiftLeedsWidgetEntry(date: Date(), slot: Schedule.Slot(id: UUID(), date: Date(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.donnyWalls))
     }
 
     func getSnapshot(in context: Context, completion: @escaping (SwiftLeedsWidgetEntry) -> ()) {
-        let entry = SwiftLeedsWidgetEntry(date: Date(), slot: Schedule.Slot(id: UUID(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.donnyWalls))
+        let entry = SwiftLeedsWidgetEntry(date: Date(), slot: Schedule.Slot(id: UUID(), date: Date(), startTime: "11:00 AM", duration: 1, activity: nil, presentation: Presentation.donnyWalls))
         completion(entry)
     }
 


### PR DESCRIPTION
Added a single view for single day schedules (design potentially to change)
Added multi day view with swipe-able schedules (swipe between days) or tap the day at the top

https://github.com/SwiftLeeds/swiftleeds-ios/assets/20776253/672418cf-0929-4758-aac9-4cc53d18a59b

![Simulator Screenshot - iPhone 14 Pro - 2023-08-21 at 10 56 55](https://github.com/SwiftLeeds/swiftleeds-ios/assets/20776253/07f4f717-ec9d-467a-a6d9-30645f39f980)
