### PR TITLE
Update FancyHeaderView, fixes #41

### DIFF
--- a/SwiftLeeds/Views/Components/FancyHeaderView.swift
+++ b/SwiftLeeds/Views/Components/FancyHeaderView.swift
@@ -36,7 +36,7 @@ struct FancyHeaderView: View {
                 .accessibilityHidden(true)
             )
             .overlay(foregroundGroup,alignment: .center)
-            .padding(.bottom,foregroundGroupViewHeight/4)
+            .padding(.bottom,foregroundGroupViewHeight/2)
     }
     
     private var foregroundGroup: some View {


### PR DESCRIPTION
Update FancyHeaderView, this fixes #41.

I have changed the value of https://github.com/SwiftLeeds/swiftleeds-ios/blob/main/SwiftLeeds/Views/Components/FancyHeaderView.swift#L39 to `/2`

<table>
<tr>
<th><code>foregroundGroupViewHeight/2</code></th>
<th><code>foregroundGroupViewHeight/3</code></th>
</tr>
<tr>
<td>
<img src='https://github.com/0xWDG/swiftleeds-ios/assets/1290461/106ecf4d-59ff-421f-acb8-8204e07255d6' width=350px>
</td>
<td>
<img src='https://github.com/0xWDG/swiftleeds-ios/assets/1290461/644dfda9-5c43-4611-b0c8-7bb8636b41e6' width=350px>
</td>
</tr>
</table>