### PR TITLE
Fix schedule display in distant timezones.

### DIFF
--- a/SwiftLeeds/Extension/Calendar.swift
+++ b/SwiftLeeds/Extension/Calendar.swift
@@ -15,4 +15,10 @@ extension Calendar {
 
         return numberOfDays.day ?? 0
     }
+    
+    static var atConferenceVenue: Calendar {
+        var calendar = Calendar.current
+        calendar.timeZone = .init(abbreviation: "BST")!
+        return calendar
+    }
 }

--- a/SwiftLeeds/Extension/Date.swift
+++ b/SwiftLeeds/Extension/Date.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 extension Date {
-    var withoutTime: Date {
-        guard let date = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month, .day], from: self)) else {
+    var withoutTimeAtConferenceVenue: Date {
+        guard let date = Calendar.atConferenceVenue.date(from: Calendar.atConferenceVenue.dateComponents([.year, .month, .day], from: self)) else {
             fatalError("Failed to strip time from Date")
         }
 

--- a/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
@@ -24,12 +24,12 @@ class MyConferenceViewModel: ObservableObject {
             await MainActor.run {
                 event = schedule.data.event
 
-                let individualDates = Set(schedule.data.slots.compactMap { $0.date?.withoutTime }).sorted(by: (<))
+                let individualDates = Set(schedule.data.slots.compactMap { $0.date?.withoutTimeAtConferenceVenue }).sorted(by: (<))
                 days = individualDates.map { Helper.shortDateFormatter.string(from: $0) }
 
                 for date in individualDates {
                     let key = Helper.shortDateFormatter.string(from: date)
-                    slots[key] = schedule.data.slots.filter { Calendar.current.compare(date, to: $0.date ?? Date(), toGranularity: .day) == .orderedSame }
+                    slots[key] = schedule.data.slots.filter { Calendar.atConferenceVenue.compare(date, to: $0.date ?? Date(), toGranularity: .day) == .orderedSame }
                 }
             }
 


### PR DESCRIPTION
The display of the schedule was being split into days based on when each talk was being given in the user's current timezone. This lead to, for example, a 3-day conference schedule when viewed from Japan.

![IMG_95083DE51197-2](https://github.com/SwiftLeeds/swiftleeds-ios/assets/227043/6499ed9a-7860-41e9-8f78-c9dc9d4e6d6e)
