### PR TITLE
Fix `MyConferenceView` on iPads, closes #53

### DIFF
--- a/SwiftLeeds/Views/My Conference/MyConferenceView.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceView.swift
@@ -58,6 +58,7 @@ struct MyConferenceView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .accentColor(.white)
         .task {
             try? await viewModel.loadSchedule()


### PR DESCRIPTION
Fix `MyConferenceView` on iPads, closes #53

<img width="854" alt="E4B296E5-D013-464E-B280-85B6B60565C1" src="https://github.com/user-attachments/assets/1bbafa94-040a-4e90-b914-41b65c3a7660">

<img width="649" alt="Screenshot 2024-10-08 at 00 03 14" src="https://github.com/user-attachments/assets/1a1dde74-ea21-434e-9249-44390b6acbe1">

----

iPhone screenshot to show that it still works on the iPhone.

<img width="481" alt="632A707C-2D98-4D55-A23C-60EB47F902CE" src="https://github.com/user-attachments/assets/803a50c7-0d4f-42e7-be27-4341416bcc60">

-----


cc: @pdamonkey 