### PR TITLE
bugfix(URLSession): Enable `URLCache`

### DIFF
--- a/SwiftLeeds/Network/URLSession.swift
+++ b/SwiftLeeds/Network/URLSession.swift
@@ -13,7 +13,7 @@ public extension URLSession {
         configuration.waitsForConnectivity = true
         configuration.timeoutIntervalForRequest = 30
         configuration.timeoutIntervalForResource = 30
-        configuration.requestCachePolicy = .returnCacheDataElseLoad
+        configuration.requestCachePolicy = .useProtocolCachePolicy
         return URLSession(configuration: configuration)
     }()
 

--- a/SwiftLeeds/Network/URLSession.swift
+++ b/SwiftLeeds/Network/URLSession.swift
@@ -53,6 +53,9 @@ public extension URLSession {
                 case 304: throw NetworkError.notModified
                 default: throw NetworkError.unexpectedStatusCode(response.statusCode)
                 }
+                
+                let cachedResponse = CachedURLResponse(response: response, data: data)
+                URLCache.shared.storeCachedResponse(cachedResponse, for: request.urlRequest)
 
                 try data.write(to: path, options: .atomicWrite)
 

--- a/SwiftLeeds/Network/URLSession.swift
+++ b/SwiftLeeds/Network/URLSession.swift
@@ -10,29 +10,6 @@ public extension URLSession {
         return URLSession(configuration: configuration)
     }()
 
-    func cached<Response: Decodable>(
-        _ request: Request<Response>,
-        using decoder: JSONDecoder = .init(),
-        dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .deferredToDate,
-        fileManager: FileManager = .default,
-        filename: String? = nil
-    ) async throws -> Response {
-        let filename = filename ?? request.url.lastPathComponent
-        let path = fileManager.temporaryDirectory.appendingPathComponent(filename)
-
-        guard let data = fileManager.contents(atPath: path.path.appending(".json")) else {
-            throw NetworkError.cacheNotFound
-        }
-
-        let decoded = Task.detached(priority: .userInitiated) {
-            try Task.checkCancellation()
-            decoder.dateDecodingStrategy = dateDecodingStrategy
-            return try decoder.decode(Response.self, from: data)
-        }
-
-        return try await decoded.value
-    }
-
     func decode<Response: Decodable>(
         _ request: Request<Response>,
         using decoder: JSONDecoder = .init(),

--- a/SwiftLeeds/Network/URLSession.swift
+++ b/SwiftLeeds/Network/URLSession.swift
@@ -13,8 +13,7 @@ public extension URLSession {
         configuration.waitsForConnectivity = true
         configuration.timeoutIntervalForRequest = 30
         configuration.timeoutIntervalForResource = 30
-        configuration.urlCache = nil
-        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.requestCachePolicy = .returnCacheDataElseLoad
         return URLSession(configuration: configuration)
     }()
 

--- a/SwiftLeeds/Network/URLSession.swift
+++ b/SwiftLeeds/Network/URLSession.swift
@@ -17,9 +17,6 @@ public extension URLSession {
         fileManager: FileManager = .default,
         filename: String? = nil
     ) async throws -> Response {
-        let filename = filename ?? request.url.lastPathComponent
-        let path = fileManager.temporaryDirectory.appendingPathComponent("\(filename).json")
-
         let decoded = Task.detached(priority: .userInitiated) {
             do {
                 let (data, response) = try await self.data(for: request.urlRequest)
@@ -43,11 +40,6 @@ public extension URLSession {
                 URLCache.shared.storeCachedResponse(
                     cachedResponse,
                     for: request.urlRequest
-                )
-
-                try data.write(
-                    to: path,
-                    options: .atomicWrite
                 )
 
                 if let eTagKey = request.eTagKey, let eTagValue = response.value(forHTTPHeaderField: "Etag") {

--- a/SwiftLeeds/Views/Local/LocalViewModel.swift
+++ b/SwiftLeeds/Views/Local/LocalViewModel.swift
@@ -29,11 +29,7 @@ class LocalViewModel: ObservableObject {
             let localResults = try await URLSession.awaitConnectivity.decode(Requests.local, dateDecodingStrategy: Requests.defaultDateDecodingStratergy)
             await updateLocal(localResults)
         } catch {
-            if let cachedResponse = try? await URLSession.shared.cached(Requests.local, dateDecodingStrategy: Requests.defaultDateDecodingStratergy) {
-                await updateLocal(cachedResponse)
-            } else {
-                self.error = error
-            }
+            self.error = error
         }
     }
 

--- a/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
@@ -19,7 +19,10 @@ class MyConferenceViewModel: ObservableObject {
 
     func loadSchedule() async throws {
         do {
-            let schedule = try await URLSession.awaitConnectivity.decode(Requests.schedule, dateDecodingStrategy: Requests.defaultDateDecodingStratergy)
+            let schedule = try await URLSession.awaitConnectivity.decode(
+                Requests.schedule,
+                dateDecodingStrategy: Requests.defaultDateDecodingStratergy
+            )
             await updateSchedule(schedule)
 
             do {
@@ -29,11 +32,7 @@ class MyConferenceViewModel: ObservableObject {
                 throw(error)
             }
         } catch {
-            if let cachedResponse = try? await URLSession.shared.cached(Requests.schedule, dateDecodingStrategy: Requests.defaultDateDecodingStratergy) {
-                await updateSchedule(cachedResponse)
-            } else {
-                throw(error)
-            }
+            throw error
         }
     }
 

--- a/SwiftLeeds/Views/Sponsors/SponsorsViewModel.swift
+++ b/SwiftLeeds/Views/Sponsors/SponsorsViewModel.swift
@@ -23,11 +23,7 @@ final class SponsorsViewModel: ObservableObject {
             let sponsors = try await URLSession.awaitConnectivity.decode(Requests.sponsors, dateDecodingStrategy: Requests.defaultDateDecodingStratergy)
             await updateSponsors(sponsors)
         } catch {
-            if let cachedResponse = try? await URLSession.shared.cached(Requests.sponsors, dateDecodingStrategy: Requests.defaultDateDecodingStratergy) {
-                await updateSponsors(cachedResponse)
-            } else {
-                throw(error)
-            }
+            throw error
         }
     }
 


### PR DESCRIPTION
**Issue**
Network caching was relying on a manual file manager-based implementation

**Solution**
Enable `URLCache` in `URLSession.shared` global singleton to automatically handle network-related caching

**Additional notes**
* Works for main app
* Works for app clip
* Allows further work to simplify `URLSession` implementation, including removing `cached()` function

**Screenshots**
<details>
  <summary>Screenshot: existing issue where loading shows on no internet connection</summary>
  
<img width="603" height="1311" alt="url-cache-loading" src="https://github.com/user-attachments/assets/e5be0fd4-45f4-47d2-9dd6-aa2ebb00f69a" />

</details>

<details>
  <summary>Screenshot: loaded data from network</summary>
  
<img width="603" height="1311" alt="url-cache-loaded-from-network" src="https://github.com/user-attachments/assets/b17ecb70-e12a-41a0-b0da-bae02bcb2886" />

</details>

<details>
  <summary>Screenshot: loaded data from `URLCache`</summary>
  
<img width="603" height="1311" alt="url-cache-loaded-from-cache" src="https://github.com/user-attachments/assets/9ff69416-c033-4134-9ff3-19abcc654bfa" />

</details>