### PR TITLE
feature(Schedule V2): App & Widget v2 Handling

### DIFF
--- a/SwiftLeeds/Data/Model/Schedule.swift
+++ b/SwiftLeeds/Data/Model/Schedule.swift
@@ -7,16 +7,27 @@
 
 import Foundation
 
-struct Schedule: Decodable {
+struct Schedule: Codable {
     let data: Data
 
-    struct Data: Decodable {
+
+    struct Data: Codable {
         let event: Event
         let events: [Event]
-        let slots: [Slot]
+        let days: [Day]
     }
 
-    struct Event: Decodable, Identifiable {
+    struct Day: Codable, Identifiable {
+        let date: Date
+        let name: String
+        let slots: [Slot]
+
+        var id: String {
+            "\(name)-\(date.timeIntervalSince1970.description)"
+        }
+    }
+
+    struct Event: Codable, Identifiable {
         let id: UUID
         let name: String
         let location: String

--- a/SwiftLeeds/Network/Requests.swift
+++ b/SwiftLeeds/Network/Requests.swift
@@ -9,19 +9,68 @@ import Foundation
 
 enum Requests {
     private static let host = "swiftleeds.co.uk"
-    private static let apiPath = "/api/v1"
+    private static let apiVersion1 = "/api/v1"
+    private static let apiVersion2 = "/api/v2"
 
-    static let schedule = Request<Schedule>(host: host, path: "\(apiPath)/schedule", eTagKey: "etag-schedule")
-    static let local = Request<Local>(host: host, path: "\(apiPath)/local", eTagKey: "etag-local")
-    static let sponsors = Request<Sponsors>(host: host, path: "\(apiPath)/sponsors", eTagKey: "etag-sponsors")
+    static let schedule = Request<Schedule>(
+        host: host,
+        path: "\(apiVersion2)/schedule",
+        eTagKey: "etag-schedule"
+    )
+
+    static let local = Request<Local>(
+        host: host,
+        path: "\(apiVersion1)/local",
+        eTagKey: "etag-local"
+    )
+
+    static let sponsors = Request<Sponsors>(
+        host: host,
+        path: "\(apiVersion1)/sponsors",
+        eTagKey: "etag-sponsors"
+    )
 
     static func schedule(for eventID: UUID) -> Request<Schedule> {
-        Request<Schedule>(host: host, path: "\(apiPath)/schedule", method: .get([.init(name: "event", value: eventID.uuidString)]), eTagKey: "etag-schedule-\(eventID.uuidString)")
+        Request<Schedule>(
+            host: host,
+            path: "\(apiVersion2)/schedule",
+            method: .get([.init(
+                name: "event",
+                value: eventID.uuidString)
+            ]),
+            eTagKey: "etag-schedule-\(eventID.uuidString)"
+        )
     }
 
     static var defaultDateDecodingStratergy: JSONDecoder.DateDecodingStrategy = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "dd-MM-yyyy"
         return .formatted(dateFormatter)
+    }()
+
+    // Custom strategy for v2 schedule endpoint (handles both ISO8601 and dd-MM-yyyy)
+    static var scheduleDateDecodingStrategy: JSONDecoder.DateDecodingStrategy = {
+        return .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+
+            // Try ISO8601 first (for slot dates)
+            if let date = ISO8601DateFormatter().date(from: dateString) {
+                return date
+            }
+
+            // Fallback to dd-MM-yyyy format (for event dates)
+            let formatter = DateFormatter()
+            formatter.dateFormat = "dd-MM-yyyy"
+            if let date = formatter.date(from: dateString) {
+                return date
+            }
+
+            // If neither works, throw an error
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Date string does not match expected format. Expected ISO8601 or dd-MM-yyyy, got: \(dateString)"
+            )
+        }
     }()
 }

--- a/SwiftLeeds/Views/My Conference/MyConferenceView.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceView.swift
@@ -26,7 +26,7 @@ struct MyConferenceView: View {
                             .progressViewStyle(.circular)
                             .scaleEffect(2)
                     }
-                } else if viewModel.slots.isEmpty {
+                } else if viewModel.days.isEmpty {
                     empty
                 } else {
                     schedule
@@ -69,7 +69,6 @@ struct MyConferenceView: View {
         VStack(spacing: 0) {
             ViewThatFits {
                 scheduleHeaders
-
                 ScrollView(.horizontal) {
                     scheduleHeaders
                 }
@@ -77,8 +76,8 @@ struct MyConferenceView: View {
 
             TabView(selection: $currentIndex) {
                 ForEach(Array(zip(viewModel.days.indices, viewModel.days)),
-                        id: \.0) { index, key in
-                    ScheduleView(slots: viewModel.slots[key] ?? [], showSlido: viewModel.showSlido)
+                        id: \.0) { index, day in
+                    ScheduleView(slots: day.slots, showSlido: viewModel.showSlido)
                         .tag(index)
                 }
             }
@@ -89,19 +88,11 @@ struct MyConferenceView: View {
 
     @ViewBuilder
     private var scheduleHeaders: some View {
-        if viewModel.days.count == 3 {
-            // Temporary solution until new API is ready to support days correctly
+        if viewModel.days.count > 1 {
             HStack(spacing: 20) {
-                tabBarHeader(title: "Talkshow", index: 0)
-                tabBarHeader(title: "Day 1", index: 1)
-                tabBarHeader(title: "Day 2", index: 2)
-            }
-            .padding(.horizontal)
-            .padding(.top)
-        } else if viewModel.days.count > 1 {
-            HStack(spacing: 20) {
-                ForEach(Array(zip(viewModel.days.indices, viewModel.days)), id: \.0) { index, key in
-                    tabBarHeader(title: "Day \(index + 1)", index: index)
+                ForEach(Array(zip(viewModel.days.indices, viewModel.days)), id: \.0) { index, day in
+                    // Use the actual day names from the API
+                    tabBarHeader(title: day.name, index: index)
                 }
             }
             .padding(.horizontal)

--- a/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
@@ -13,23 +13,28 @@ class MyConferenceViewModel: ObservableObject {
     @Published private(set) var hasLoaded = false
     @Published private(set) var event: Schedule.Event?
     @Published private(set) var events: [Schedule.Event] = []
-    @Published private(set) var days: [String] = []
-    @Published private(set) var slots: [String: [Schedule.Slot]] = [:]
+    @Published private(set) var days: [Schedule.Day] = []
     @Published private(set) var currentEvent: Schedule.Event?
 
     func loadSchedule() async throws {
         do {
-            let schedule = try await URLSession.awaitConnectivity.decode(Requests.schedule, dateDecodingStrategy: Requests.defaultDateDecodingStratergy)
+            let schedule = try await URLSession.awaitConnectivity.decode(
+                Requests.schedule,
+                dateDecodingStrategy: Requests.scheduleDateDecodingStrategy
+            )
             await updateSchedule(schedule)
 
             do {
-                let data = try PropertyListEncoder().encode(slots)
-                UserDefaults(suiteName: "group.uk.co.swiftleeds")?.setValue(data, forKey: "Slots")
+                let data = try PropertyListEncoder().encode(schedule)
+                UserDefaults(suiteName: "group.uk.co.swiftleeds")?.setValue(data, forKey: "Schedule")
             } catch {
                 throw(error)
             }
         } catch {
-            if let cachedResponse = try? await URLSession.shared.cached(Requests.schedule, dateDecodingStrategy: Requests.defaultDateDecodingStratergy) {
+            if let cachedResponse = try? await URLSession.shared.cached(
+                Requests.schedule,
+                dateDecodingStrategy: Requests.scheduleDateDecodingStrategy
+            ) {
                 await updateSchedule(cachedResponse)
             } else {
                 throw(error)
@@ -47,15 +52,15 @@ class MyConferenceViewModel: ObservableObject {
             currentEvent = event
         }
 
-        let individualDates = Set(schedule.data.slots.compactMap { $0.date?.withoutTimeAtConferenceVenue }).sorted(by: (<))
-        days = individualDates.map { Helper.shortDateFormatter.string(from: $0) }
-
-        for date in individualDates {
-            let key = Helper.shortDateFormatter.string(from: date)
-            slots[key] = schedule.data.slots
-                .filter { Calendar.current.compare(date, to: $0.date ?? Date(), toGranularity: .day) == .orderedSame }
-                .sorted { $0.startTime < $1.startTime }
-        }
+        days = schedule.data.days
+            .sorted(by: { $0.date < $1.date })
+            .map { day in
+                Schedule.Day(
+                    date: day.date,
+                    name: day.name,
+                    slots: day.slots.sorted { $0.startTime < $1.startTime }
+                )
+            }
 
         hasLoaded = true
     }
@@ -63,7 +68,11 @@ class MyConferenceViewModel: ObservableObject {
     private func reloadSchedule() async throws {
         guard let currentEvent else { return }
 
-        let schedule = try await URLSession.awaitConnectivity.decode(Requests.schedule(for: currentEvent.id), dateDecodingStrategy: Requests.defaultDateDecodingStratergy, filename: "schedule-\(currentEvent.id.uuidString)")
+        let schedule = try await URLSession.awaitConnectivity.decode(
+            Requests.schedule(for: currentEvent.id),
+            dateDecodingStrategy: Requests.scheduleDateDecodingStrategy,
+            filename: "schedule-\(currentEvent.id.uuidString)"
+        )
         await updateSchedule(schedule)
     }
 


### PR DESCRIPTION
I've added handling for the v2 schedule from the API, this should now match the web where we can grab the day names from the API instead of the names being hardcoded on the front-end. It should also mean we have the flexibility to have as many days (though the UI wouldn't fit more than 4 😉) as we want now.

I've verified that this functionality works on old schedules which had the singular day, and this years schedule.

Also put an update in for the widget which was hardcoded to 2022 but can't run on a device due to AppStoreConnect permission limitations and the simulator wasn't playing ball for the widget to show correctly so pretty much put it in blindly if someone can check that 😆 

**Changes**

- Implemented a new `scheduleDateDecodingStrategy` because the v2 API sends down date formats in different formats (that was a fun one) for Day/Slots & Event so applying a singular .iso8601 formatter to the whole decode didn't work as expected
    - Day dates: "2025-10-06T00:00:00Z"
    - Slot dates: "2025-10-06T00:00Z"
    - Event dates: "07-10-2025" (still dd-MM-yyyy)

**Screenshots**

**2021 (Singular day)**|**2023 (Two day)**|**2025 (Talkshow + two day)**
------- | ------- | -------
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-26 at 22 27 06" src="https://github.com/user-attachments/assets/ae1a08aa-e196-4aaf-a0fc-d5167d29419d" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-26 at 22 27 41" src="https://github.com/user-attachments/assets/314eb86b-c14d-4166-9585-89c12aa0ebf5" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-26 at 22 28 01" src="https://github.com/user-attachments/assets/6a017949-b6fe-408d-a734-7df15251440b" />
