### PR TITLE
Fix Settings view on iPad

### DIFF
--- a/SwiftLeeds/Views/About/AboutView.swift
+++ b/SwiftLeeds/Views/About/AboutView.swift
@@ -144,7 +144,7 @@ struct AboutView: View {
                 .ignoresSafeArea(edges: .bottom)
         }
         .sheet(isPresented: $isFullAboutShown) {
-            NavigationView {
+            NavigationStack {
                 ScrollView {
                     VStack(alignment: .leading, spacing: Padding.cellGap) {
                         Text(aboutSwiftLeeds)

--- a/SwiftLeeds/Views/My Conference/MyConferenceView.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceView.swift
@@ -8,7 +8,7 @@ struct MyConferenceView: View {
     @Namespace private var namespace
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 0) {
                 Divider()
 
@@ -52,7 +52,6 @@ struct MyConferenceView: View {
                 }
             }
         }
-        .navigationViewStyle(.stack)
         .accentColor(.white)
         .task {
             try? await viewModel.loadSchedule()

--- a/SwiftLeeds/Views/Tab/SidebarMainView.swift
+++ b/SwiftLeeds/Views/Tab/SidebarMainView.swift
@@ -21,6 +21,5 @@ struct SidebarMainView: View {
                 SettingsView()
             }
         }
-
     }
 }

--- a/SwiftLeeds/Views/Tab/SidebarView.swift
+++ b/SwiftLeeds/Views/Tab/SidebarView.swift
@@ -1,3 +1,4 @@
+import Settings
 import SwiftUI
 
 struct SidebarView: View {
@@ -24,6 +25,12 @@ struct SidebarView: View {
                 appState.selectedTab = .sponsors
             }) {
                 Label("Sponsors", systemImage: "sparkles")
+            }
+
+            NavigationLink(destination: SettingsView().onAppear {
+                appState.selectedTab = .settings
+            }) {
+                Label("Settings", systemImage: "gearshape.fill")
             }
         }
         .listStyle(.sidebar)

--- a/SwiftLeeds/Views/Tab/Tabs.swift
+++ b/SwiftLeeds/Views/Tab/Tabs.swift
@@ -1,3 +1,4 @@
+import ColorTheme
 import SwiftUI
 
 struct Tabs: View {
@@ -14,8 +15,8 @@ struct Tabs: View {
     }
 }
 
-struct Tabs_Previews: PreviewProvider {
-    static var previews: some View {
-        Tabs()
-    }
+#Preview {
+    Tabs()
+        .environmentObject(AppState())
+        .environmentObject(ThemeManager.shared)
 }

--- a/SwiftLeedsPackage/Sources/Settings/SettingsView.swift
+++ b/SwiftLeedsPackage/Sources/Settings/SettingsView.swift
@@ -8,7 +8,7 @@ public struct SettingsView: View {
     public init() {}
 
     public var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 Section("App Icon") {
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: 16) {
@@ -24,7 +24,7 @@ public struct SettingsView: View {
                     }
                     .padding(.vertical, 8)
                 }
-                
+
                 Section("Appearance") {
                     Picker("Theme", selection: $themeManager.currentTheme) {
                         ForEach(ThemeOption.allCases, id: \.self) { theme in
@@ -35,7 +35,7 @@ public struct SettingsView: View {
                         themeManager.setTheme(newTheme)
                     }
                 }
-                
+
                 Section("About") {
                     HStack {
                         Text("Version")
@@ -43,11 +43,11 @@ public struct SettingsView: View {
                         Text(viewModel.appVersion)
                             .foregroundColor(.secondary)
                     }
-                    
+
                     Button("Contact Us") {
                         viewModel.openContactUs()
                     }
-                    
+
                     Button("Code of Conduct") {
                         viewModel.openCodeOfConduct()
                     }


### PR DESCRIPTION
Fix bug where the `Settings` view on iPad was appearing in sidebar not detail view in split view.

@adamrushy This was the iPad navigation bug raised earlier in Slack.

This PR also removes any use of the deprecated `NavigationView` in the app, replacing it with `NavigationStack`.

# Screenshots

<details>
  <summary>Screenshot of bug before fix</summary>
<img width="2360" height="1640" alt="image" src="https://github.com/user-attachments/assets/bf56124c-b947-4924-811f-c8fcef79e6f6" />

</details>

<details>
  <summary>Screenshot after fix</summary>
<img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-12-15 at 19 57 10" src="https://github.com/user-attachments/assets/e8e2f08a-1170-438e-8c50-32080241579e" />

</details>