### PR TITLE
feat(SecureStorageKit): add Keychain-backed secure storage package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ playground.xcworkspace
 # hence it is not needed unless you have added a package configuration file to your project
 # .swiftpm
 
+# Local library packages resolve against the app's workspace Package.resolved,
+# so their own resolved files are redundant and cause churn.
+Packages/*/Package.resolved
+
 .build/
 *.DS_Store
 

--- a/Packages/SecureStorageKit/Package.swift
+++ b/Packages/SecureStorageKit/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "SecureStorageKit",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v13),
+    ],
+    products: [
+        .library(name: "SecureStorageKit", targets: ["SecureStorageKit"]),
+        .library(name: "SecureStorageKitKeychain", targets: ["SecureStorageKitKeychain"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "SecureStorageKit",
+            dependencies: [
+                .product(name: "Dependencies", package: "swift-dependencies"),
+            ]
+        ),
+        .target(
+            name: "SecureStorageKitKeychain",
+            dependencies: [
+                "SecureStorageKit",
+            ]
+        ),
+        .testTarget(
+            name: "SecureStorageKitKeychainTests",
+            dependencies: [
+                "SecureStorageKit",
+                "SecureStorageKitKeychain",
+            ]
+        ),
+    ]
+)

--- a/Packages/SecureStorageKit/Sources/SecureStorageKit/SecureStorage.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKit/SecureStorage.swift
@@ -1,0 +1,50 @@
+import Dependencies
+import Foundation
+
+/// A generic secure key-value store for small, sensitive `Data` payloads.
+///
+/// The store is agnostic of what it holds — callers own the meaning of each
+/// `SecureStorageKey`. A concrete implementation (e.g. Keychain) is supplied by
+/// the composition root; consumers depend only on this interface.
+public struct SecureStorage: Sendable {
+    /// Returns the stored value for `key`, or `nil` when nothing is stored.
+    public var data: @Sendable (SecureStorageKey) async throws -> Data?
+    /// Stores `data` for `key`, replacing any existing value.
+    public var set: @Sendable (Data, SecureStorageKey) async throws -> Void
+    /// Removes any value stored for `key`. Removing a missing key is not an error.
+    public var remove: @Sendable (SecureStorageKey) async throws -> Void
+
+    public init(
+        data: @escaping @Sendable (SecureStorageKey) async throws -> Data?,
+        set: @escaping @Sendable (Data, SecureStorageKey) async throws -> Void,
+        remove: @escaping @Sendable (SecureStorageKey) async throws -> Void
+    ) {
+        self.data = data
+        self.set = set
+        self.remove = remove
+    }
+}
+
+extension SecureStorage: TestDependencyKey {
+    public static var testValue: SecureStorage {
+        SecureStorage(
+            data: { _ in
+                reportIssue("SecureStorage.data is unimplemented")
+                return nil
+            },
+            set: { _, _ in
+                reportIssue("SecureStorage.set is unimplemented")
+            },
+            remove: { _ in
+                reportIssue("SecureStorage.remove is unimplemented")
+            }
+        )
+    }
+}
+
+extension DependencyValues {
+    public var secureStorage: SecureStorage {
+        get { self[SecureStorage.self] }
+        set { self[SecureStorage.self] = newValue }
+    }
+}

--- a/Packages/SecureStorageKit/Sources/SecureStorageKit/SecureStorageKey.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKit/SecureStorageKey.swift
@@ -1,0 +1,16 @@
+/// A namespaced key identifying a single secured value.
+public struct SecureStorageKey: Hashable, Sendable {
+    private let storage: String
+
+    public init(_ value: String) {
+        self.storage = value
+    }
+
+    fileprivate var stringValue: String { storage }
+}
+
+extension String {
+    public init(_ key: SecureStorageKey) {
+        self = key.stringValue
+    }
+}

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainError.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainError.swift
@@ -5,22 +5,20 @@ import Foundation
 /// The named cases are the ones a caller can act on. Everything else keeps its
 /// `OSStatus` so a failure is still diagnosable.
 public enum KeychainError: Error, Equatable {
-    /// The device is locked, or the item's protection class does not permit
-    /// access right now. Transient: the same call can succeed later, so this is
-    /// not a reason to discard the stored value.
+    /// The item is not accessible in the device's current lock state.
+    /// Transient: the same call can succeed later.
     case deviceLocked
 
     /// The user could not be authenticated for an item that required it.
     case authenticationFailed
 
-    /// The process is not entitled to reach this item. Usually a missing
-    /// keychain access group, or an unsigned test process.
+    /// The process is not entitled to reach this item.
     case missingEntitlement
 
-    /// An item exists but its value is not readable as `Data`.
+    /// An item exists but its value is not `Data`.
     case unreadableValue
 
-    /// Anything else, kept verbatim rather than flattened away.
+    /// Any other status, kept for diagnosis.
     case unexpected(OSStatus)
 
     package init(status: OSStatus) {

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainError.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainError.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// An error wrapping a non-success Keychain `OSStatus`.
+public struct KeychainError: Error, Equatable {
+    public let status: OSStatus
+
+    public init(status: OSStatus) {
+        self.status = status
+    }
+}

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainError.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainError.swift
@@ -1,10 +1,38 @@
 import Foundation
 
-/// An error wrapping a non-success Keychain `OSStatus`.
-public struct KeychainError: Error, Equatable {
-    public let status: OSStatus
+/// A Keychain operation that did not succeed.
+///
+/// The named cases are the ones a caller can act on. Everything else keeps its
+/// `OSStatus` so a failure is still diagnosable.
+public enum KeychainError: Error, Equatable {
+    /// The device is locked, or the item's protection class does not permit
+    /// access right now. Transient: the same call can succeed later, so this is
+    /// not a reason to discard the stored value.
+    case deviceLocked
 
-    public init(status: OSStatus) {
-        self.status = status
+    /// The user could not be authenticated for an item that required it.
+    case authenticationFailed
+
+    /// The process is not entitled to reach this item. Usually a missing
+    /// keychain access group, or an unsigned test process.
+    case missingEntitlement
+
+    /// An item exists but its value is not readable as `Data`.
+    case unreadableValue
+
+    /// Anything else, kept verbatim rather than flattened away.
+    case unexpected(OSStatus)
+
+    package init(status: OSStatus) {
+        switch status {
+        case errSecInteractionNotAllowed:
+            self = .deviceLocked
+        case errSecAuthFailed:
+            self = .authenticationFailed
+        case errSecMissingEntitlement:
+            self = .missingEntitlement
+        default:
+            self = .unexpected(status)
+        }
     }
 }

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainQuery.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainQuery.swift
@@ -1,0 +1,53 @@
+import Foundation
+import SecureStorageKit
+import Security
+
+/// Builds the dictionaries handed to the Keychain.
+///
+/// Separated from the calls themselves so the attributes can be asserted
+/// directly. The protection class in particular cannot be checked by storing
+/// and reading back: the legacy macOS keychain, which is what unit tests run
+/// against, discards `kSecAttrAccessible` entirely.
+package enum KeychainQuery {
+    /// Identifies one item. Used to search, update and delete.
+    ///
+    /// Deliberately carries no value and no attributes, because `SecItemUpdate`
+    /// requires a search query without `kSecValueData`.
+    static func identity(service: KeychainService, key: SecureStorageKey) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: String(service),
+            kSecAttrAccount as String: String(key),
+        ]
+    }
+
+    /// Creates an item, bound to this device and readable only while unlocked.
+    ///
+    /// `ThisDeviceOnly` keeps the session token out of encrypted backups, so it
+    /// cannot ride a restore onto another device. Re-authenticating costs an
+    /// email address and a ticket reference, so there is nothing to gain by
+    /// letting a bearer credential migrate.
+    package static func add(
+        service: KeychainService,
+        key: SecureStorageKey,
+        data: Data
+    ) -> [String: Any] {
+        var query = identity(service: service, key: key)
+        query[kSecValueData as String] = data
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        return query
+    }
+
+    /// Reads one item's value.
+    static func read(service: KeychainService, key: SecureStorageKey) -> [String: Any] {
+        var query = identity(service: service, key: key)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        return query
+    }
+
+    /// The attributes passed alongside a search query to change a value.
+    static func update(data: Data) -> [String: Any] {
+        [kSecValueData as String: data]
+    }
+}

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainQuery.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainQuery.swift
@@ -4,15 +4,12 @@ import Security
 
 /// Builds the dictionaries handed to the Keychain.
 ///
-/// Separated from the calls themselves so the attributes can be asserted
-/// directly. The protection class in particular cannot be checked by storing
-/// and reading back: the legacy macOS keychain, which is what unit tests run
-/// against, discards `kSecAttrAccessible` entirely.
+/// Separate from the calls so the attributes can be asserted directly.
 package enum KeychainQuery {
-    /// Identifies one item. Used to search, update and delete.
+    /// Identifies one item, for searching, updating and deleting.
     ///
-    /// Deliberately carries no value and no attributes, because `SecItemUpdate`
-    /// requires a search query without `kSecValueData`.
+    /// Carries no value: `SecItemUpdate` rejects a search query containing
+    /// `kSecValueData`.
     static func identity(service: KeychainService, key: SecureStorageKey) -> [String: Any] {
         [
             kSecClass as String: kSecClassGenericPassword,
@@ -21,12 +18,8 @@ package enum KeychainQuery {
         ]
     }
 
-    /// Creates an item, bound to this device and readable only while unlocked.
-    ///
-    /// `ThisDeviceOnly` keeps the session token out of encrypted backups, so it
-    /// cannot ride a restore onto another device. Re-authenticating costs an
-    /// email address and a ticket reference, so there is nothing to gain by
-    /// letting a bearer credential migrate.
+    /// Creates an item readable only while the device is unlocked, and bound to
+    /// this device so it is excluded from backups and device transfer.
     package static func add(
         service: KeychainService,
         key: SecureStorageKey,

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainService.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainService.swift
@@ -1,0 +1,16 @@
+/// The Keychain service namespace under which values are stored.
+public struct KeychainService: Hashable, Sendable {
+    private let storage: String
+
+    public init(_ value: String) {
+        self.storage = value
+    }
+
+    fileprivate var stringValue: String { storage }
+}
+
+extension String {
+    public init(_ service: KeychainService) {
+        self = service.stringValue
+    }
+}

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainStore.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/KeychainStore.swift
@@ -1,0 +1,87 @@
+import Foundation
+import SecureStorageKit
+import Security
+
+/// Owns the Keychain calls for one service.
+///
+/// An actor because `SecItem` calls are synchronous and blocking, and because
+/// writing is a read-modify-write across two calls.
+actor KeychainStore {
+    private let service: KeychainService
+
+    init(service: KeychainService) {
+        self.service = service
+    }
+
+    func data(for key: SecureStorageKey) throws -> Data? {
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(
+            KeychainQuery.read(service: service, key: key) as CFDictionary,
+            &result
+        )
+
+        switch status {
+        case errSecSuccess:
+            // An item that exists but is unreadable is a fault, not an absence.
+            guard let data = result as? Data else {
+                throw KeychainError.unreadableValue
+            }
+            return data
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError(status: status)
+        }
+    }
+
+    func set(_ data: Data, for key: SecureStorageKey) throws {
+        switch update(data, for: key) {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            try add(data, for: key)
+        case let status:
+            throw KeychainError(status: status)
+        }
+    }
+
+    func remove(_ key: SecureStorageKey) throws {
+        let status = SecItemDelete(
+            KeychainQuery.identity(service: service, key: key) as CFDictionary
+        )
+
+        switch status {
+        case errSecSuccess, errSecItemNotFound:
+            return
+        default:
+            throw KeychainError(status: status)
+        }
+    }
+
+    private func add(_ data: Data, for key: SecureStorageKey) throws {
+        let status = SecItemAdd(
+            KeychainQuery.add(service: service, key: key, data: data) as CFDictionary,
+            nil
+        )
+
+        switch status {
+        case errSecSuccess:
+            return
+        case errSecDuplicateItem:
+            // Something wrote between the update and the add. The actor rules
+            // that out within this process, leaving other processes.
+            guard update(data, for: key) == errSecSuccess else {
+                throw KeychainError(status: status)
+            }
+        default:
+            throw KeychainError(status: status)
+        }
+    }
+
+    private func update(_ data: Data, for key: SecureStorageKey) -> OSStatus {
+        SecItemUpdate(
+            KeychainQuery.identity(service: service, key: key) as CFDictionary,
+            KeychainQuery.update(data: data) as CFDictionary
+        )
+    }
+}

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
@@ -5,15 +5,17 @@ import Security
 extension SecureStorage {
     /// A `SecureStorage` backed by the Keychain (generic-password items),
     /// scoped to `service`. The Keychain encrypts values at rest.
+    ///
+    /// Items are stored `WhenUnlockedThisDeviceOnly`, so they are readable only
+    /// while the device is unlocked and never travel in a backup.
     public static func keychain(service: KeychainService) -> SecureStorage {
         SecureStorage(
             data: { key in
-                var query = baseQuery(service: service, key: key)
-                query[kSecReturnData as String] = true
-                query[kSecMatchLimit as String] = kSecMatchLimitOne
-
                 var result: CFTypeRef?
-                let status = SecItemCopyMatching(query as CFDictionary, &result)
+                let status = SecItemCopyMatching(
+                    KeychainQuery.read(service: service, key: key) as CFDictionary,
+                    &result
+                )
                 switch status {
                 case errSecSuccess:
                     return result as? Data
@@ -24,18 +26,19 @@ extension SecureStorage {
                 }
             },
             set: { data, key in
-                let query = baseQuery(service: service, key: key)
+                let identity = KeychainQuery.identity(service: service, key: key)
                 let updateStatus = SecItemUpdate(
-                    query as CFDictionary,
-                    [kSecValueData as String: data] as CFDictionary
+                    identity as CFDictionary,
+                    KeychainQuery.update(data: data) as CFDictionary
                 )
                 switch updateStatus {
                 case errSecSuccess:
                     return
                 case errSecItemNotFound:
-                    var addQuery = query
-                    addQuery[kSecValueData as String] = data
-                    let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+                    let addStatus = SecItemAdd(
+                        KeychainQuery.add(service: service, key: key, data: data) as CFDictionary,
+                        nil
+                    )
                     guard addStatus == errSecSuccess else {
                         throw KeychainError(status: addStatus)
                     }
@@ -44,7 +47,9 @@ extension SecureStorage {
                 }
             },
             remove: { key in
-                let status = SecItemDelete(baseQuery(service: service, key: key) as CFDictionary)
+                let status = SecItemDelete(
+                    KeychainQuery.identity(service: service, key: key) as CFDictionary
+                )
                 switch status {
                 case errSecSuccess, errSecItemNotFound:
                     return
@@ -54,12 +59,4 @@ extension SecureStorage {
             }
         )
     }
-}
-
-private func baseQuery(service: KeychainService, key: SecureStorageKey) -> [String: Any] {
-    [
-        kSecClass as String: kSecClassGenericPassword,
-        kSecAttrService as String: String(service),
-        kSecAttrAccount as String: String(key),
-    ]
 }

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Security
 import SecureStorageKit
+import Security
 
 extension SecureStorage {
     /// A `SecureStorage` backed by the Keychain (generic-password items),

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Security
+import SecureStorageKit
+
+extension SecureStorage {
+    /// A `SecureStorage` backed by the Keychain (generic-password items),
+    /// scoped to `service`. The Keychain encrypts values at rest.
+    public static func keychain(service: KeychainService) -> SecureStorage {
+        SecureStorage(
+            data: { key in
+                var query = baseQuery(service: service, key: key)
+                query[kSecReturnData as String] = true
+                query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+                var result: CFTypeRef?
+                let status = SecItemCopyMatching(query as CFDictionary, &result)
+                switch status {
+                case errSecSuccess:
+                    return result as? Data
+                case errSecItemNotFound:
+                    return nil
+                default:
+                    throw KeychainError(status: status)
+                }
+            },
+            set: { data, key in
+                let query = baseQuery(service: service, key: key)
+                let updateStatus = SecItemUpdate(
+                    query as CFDictionary,
+                    [kSecValueData as String: data] as CFDictionary
+                )
+                switch updateStatus {
+                case errSecSuccess:
+                    return
+                case errSecItemNotFound:
+                    var addQuery = query
+                    addQuery[kSecValueData as String] = data
+                    let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+                    guard addStatus == errSecSuccess else {
+                        throw KeychainError(status: addStatus)
+                    }
+                default:
+                    throw KeychainError(status: updateStatus)
+                }
+            },
+            remove: { key in
+                let status = SecItemDelete(baseQuery(service: service, key: key) as CFDictionary)
+                switch status {
+                case errSecSuccess, errSecItemNotFound:
+                    return
+                default:
+                    throw KeychainError(status: status)
+                }
+            }
+        )
+    }
+}
+
+private func baseQuery(service: KeychainService, key: SecureStorageKey) -> [String: Any] {
+    [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: String(service),
+        kSecAttrAccount as String: String(key),
+    ]
+}

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SecureStorageKit
-import Security
 
 extension SecureStorage {
     /// A `SecureStorage` backed by the Keychain (generic-password items),
@@ -9,60 +8,12 @@ extension SecureStorage {
     /// Items are stored `WhenUnlockedThisDeviceOnly`, so they are readable only
     /// while the device is unlocked and never travel in a backup.
     public static func keychain(service: KeychainService) -> SecureStorage {
-        SecureStorage(
-            data: { key in
-                var result: CFTypeRef?
-                let status = SecItemCopyMatching(
-                    KeychainQuery.read(service: service, key: key) as CFDictionary,
-                    &result
-                )
-                switch status {
-                case errSecSuccess:
-                    // An item that exists but is not readable is a fault, not an
-                    // absence: reporting nil would look like "never signed in"
-                    // and silently sign the user out.
-                    guard let data = result as? Data else {
-                        throw KeychainError.unreadableValue
-                    }
-                    return data
-                case errSecItemNotFound:
-                    return nil
-                default:
-                    throw KeychainError(status: status)
-                }
-            },
-            set: { data, key in
-                let identity = KeychainQuery.identity(service: service, key: key)
-                let updateStatus = SecItemUpdate(
-                    identity as CFDictionary,
-                    KeychainQuery.update(data: data) as CFDictionary
-                )
-                switch updateStatus {
-                case errSecSuccess:
-                    return
-                case errSecItemNotFound:
-                    let addStatus = SecItemAdd(
-                        KeychainQuery.add(service: service, key: key, data: data) as CFDictionary,
-                        nil
-                    )
-                    guard addStatus == errSecSuccess else {
-                        throw KeychainError(status: addStatus)
-                    }
-                default:
-                    throw KeychainError(status: updateStatus)
-                }
-            },
-            remove: { key in
-                let status = SecItemDelete(
-                    KeychainQuery.identity(service: service, key: key) as CFDictionary
-                )
-                switch status {
-                case errSecSuccess, errSecItemNotFound:
-                    return
-                default:
-                    throw KeychainError(status: status)
-                }
-            }
+        let store = KeychainStore(service: service)
+
+        return SecureStorage(
+            data: { key in try await store.data(for: key) },
+            set: { data, key in try await store.set(data, for: key) },
+            remove: { key in try await store.remove(key) }
         )
     }
 }

--- a/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
+++ b/Packages/SecureStorageKit/Sources/SecureStorageKitKeychain/SecureStorage+Keychain.swift
@@ -18,7 +18,13 @@ extension SecureStorage {
                 )
                 switch status {
                 case errSecSuccess:
-                    return result as? Data
+                    // An item that exists but is not readable is a fault, not an
+                    // absence: reporting nil would look like "never signed in"
+                    // and silently sign the user out.
+                    guard let data = result as? Data else {
+                        throw KeychainError.unreadableValue
+                    }
+                    return data
                 case errSecItemNotFound:
                     return nil
                 default:

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainConcurrencyTests.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainConcurrencyTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import SecureStorageKit
+import SecureStorageKitKeychain
+import Testing
+
+/// Covers the write path under concurrent callers, which the actor and the
+/// duplicate retry protect together. Removing both makes these fail; removing
+/// either alone does not.
+///
+/// They cannot use `storing(_:at:during:)`, because the collision only happens
+/// when no item exists yet.
+@Suite struct KeychainConcurrencyTests {
+    private let key = SecureStorageKey("auth.token")
+
+    @Test func whenWritingConcurrently_shouldStoreOneOfTheWrittenValues() async throws {
+        let storage = SecureStorage.uniqueKeychain
+        let values = (0..<20).map { Data("value-\($0)".utf8) }
+
+        let stored = try await storage.removingAfterwards(key) {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for value in values {
+                    group.addTask { try await storage.set(value, self.key) }
+                }
+                try await group.waitForAll()
+            }
+            return try await storage.data(self.key)
+        }
+
+        #expect(stored.map(values.contains) == true)
+    }
+
+    /// Guards that a read returns a whole value rather than a mixture of two.
+    ///
+    /// This passes with or without serialisation, because a single
+    /// `SecItemCopyMatching` is atomic in the system. It is here to catch a
+    /// future read that grows into several calls, not as evidence the actor
+    /// works: `whenWritingConcurrently` is what proves that.
+    @Test func whenReadingDuringWrites_shouldReturnOneOfTheWrittenValues() async throws {
+        let storage = SecureStorage.uniqueKeychain
+        let first = Data("first".utf8)
+        let second = Data("second".utf8)
+
+        let reads = try await storage.removingAfterwards(key) {
+            try await storage.set(first, self.key)
+
+            return try await withThrowingTaskGroup(of: Data?.self, returning: [Data?].self) { group in
+                for _ in 0..<20 {
+                    group.addTask { try await storage.data(self.key) }
+                    group.addTask { try await storage.set(second, self.key); return nil }
+                }
+                return try await group.reduce(into: []) { $0.append($1) }
+            }
+        }
+
+        let values = reads.compactMap { $0 }
+        #expect(values.allSatisfy { $0 == first || $0 == second })
+        #expect(!values.isEmpty)
+    }
+}

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainErrorTests.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainErrorTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import SecureStorageKitKeychain
+import Security
+import Testing
+
+/// Maps the statuses a caller can act on. `deviceLocked` matters most: it is
+/// transient, so treating it as a storage failure would sign a user out for
+/// having a locked phone.
+@Suite struct KeychainErrorTests {
+    @Test func whenInteractionIsNotAllowed_shouldReportDeviceLocked() {
+        #expect(KeychainError(status: errSecInteractionNotAllowed) == .deviceLocked)
+    }
+
+    @Test func whenAuthenticationFails_shouldReportAuthenticationFailed() {
+        #expect(KeychainError(status: errSecAuthFailed) == .authenticationFailed)
+    }
+
+    @Test func whenEntitlementIsMissing_shouldReportMissingEntitlement() {
+        #expect(KeychainError(status: errSecMissingEntitlement) == .missingEntitlement)
+    }
+
+    @Test func whenStatusIsUnrecognised_shouldKeepItForDiagnosis() {
+        #expect(KeychainError(status: errSecDecode) == .unexpected(errSecDecode))
+    }
+
+    @Test func whenStatusesDiffer_shouldNotBeEqual() {
+        #expect(KeychainError(status: errSecDecode) != KeychainError(status: errSecIO))
+    }
+}

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainQueryTests.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainQueryTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SecureStorageKit
+import SecureStorageKitKeychain
+import Security
+import Testing
+
+/// Pins the two attributes that protect the stored value.
+///
+/// These are asserted against the query rather than a stored item because they
+/// cannot be observed through behaviour: the legacy macOS keychain these tests
+/// run against discards `kSecAttrAccessible` entirely, returning it as absent.
+/// Changing either one silently weakens security and nothing else would catch
+/// it, which is the same reason the storage key is pinned elsewhere.
+///
+/// Everything else about the queries is covered by `KeychainSecureStorageTests`
+/// through the public API.
+@Suite struct KeychainQueryTests {
+    private let service = KeychainService("uk.co.swiftleeds.tests")
+    private let key = SecureStorageKey("auth.session")
+
+    @Test func whenAddingItem_shouldRestrictToThisDeviceWhileUnlocked() {
+        let sut = KeychainQuery.add(service: service, key: key, data: Data("jwt".utf8))
+
+        #expect(
+            sut[kSecAttrAccessible as String] as? String
+                == kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String
+        )
+    }
+
+    @Test func whenAddingItem_shouldNotMarkItSynchronizable() {
+        let sut = KeychainQuery.add(service: service, key: key, data: Data("jwt".utf8))
+
+        #expect(sut[kSecAttrSynchronizable as String] == nil)
+    }
+}

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainSecureStorageTests.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainSecureStorageTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 /// Exercises the real Keychain adapter through its public API. Each test uses a
 /// unique service (`SecureStorage.uniqueKeychain`) so runs don't collide, and
-/// cleans up after itself.
+/// removes what it stored before finishing.
 @Suite struct KeychainSecureStorageTests {
     @Test func whenSettingThenReading_shouldReturnTheStoredValue() async throws {
         let storage = SecureStorage.uniqueKeychain
@@ -13,20 +13,22 @@ import Testing
         let token = Data("jwt-abc-123".utf8)
 
         try await storage.set(token, key)
-        defer { Task { try? await storage.remove(key) } }
+        let stored = try await storage.data(key)
+        try await storage.remove(key)
 
-        #expect(try await storage.data(key) == token)
+        #expect(stored == token)
     }
 
     @Test func whenSettingAnExistingKey_shouldOverwriteTheValue() async throws {
         let storage = SecureStorage.uniqueKeychain
         let key = SecureStorageKey("auth.token")
-        defer { Task { try? await storage.remove(key) } }
 
         try await storage.set(Data("first".utf8), key)
         try await storage.set(Data("second".utf8), key)
+        let stored = try await storage.data(key)
+        try await storage.remove(key)
 
-        #expect(try await storage.data(key) == Data("second".utf8))
+        #expect(stored == Data("second".utf8))
     }
 
     @Test func whenReadingAMissingKey_shouldReturnNil() async throws {

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainSecureStorageTests.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainSecureStorageTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+import SecureStorageKit
+import SecureStorageKitKeychain
+
+/// Exercises the real Keychain adapter through its public API. Each test uses a
+/// unique service (`SecureStorage.uniqueKeychain`) so runs don't collide, and
+/// cleans up after itself.
+@Suite struct KeychainSecureStorageTests {
+    @Test func whenSettingThenReading_shouldReturnTheStoredValue() async throws {
+        let storage = SecureStorage.uniqueKeychain
+        let key = SecureStorageKey("auth.token")
+        let token = Data("jwt-abc-123".utf8)
+
+        try await storage.set(token, key)
+        defer { Task { try? await storage.remove(key) } }
+
+        #expect(try await storage.data(key) == token)
+    }
+
+    @Test func whenSettingAnExistingKey_shouldOverwriteTheValue() async throws {
+        let storage = SecureStorage.uniqueKeychain
+        let key = SecureStorageKey("auth.token")
+        defer { Task { try? await storage.remove(key) } }
+
+        try await storage.set(Data("first".utf8), key)
+        try await storage.set(Data("second".utf8), key)
+
+        #expect(try await storage.data(key) == Data("second".utf8))
+    }
+
+    @Test func whenReadingAMissingKey_shouldReturnNil() async throws {
+        let storage = SecureStorage.uniqueKeychain
+
+        #expect(try await storage.data(SecureStorageKey("does.not.exist")) == nil)
+    }
+
+    @Test func whenRemoving_shouldDeleteTheValue() async throws {
+        let storage = SecureStorage.uniqueKeychain
+        let key = SecureStorageKey("auth.token")
+        try await storage.set(Data("to-delete".utf8), key)
+
+        try await storage.remove(key)
+
+        #expect(try await storage.data(key) == nil)
+    }
+
+    @Test func whenRemovingAMissingKey_shouldNotThrow() async throws {
+        let storage = SecureStorage.uniqueKeychain
+
+        try await storage.remove(SecureStorageKey("never.stored"))
+    }
+}

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainSecureStorageTests.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainSecureStorageTests.swift
@@ -1,8 +1,7 @@
 import Foundation
-import Testing
-
 import SecureStorageKit
 import SecureStorageKitKeychain
+import Testing
 
 /// Exercises the real Keychain adapter through its public API. Each test uses a
 /// unique service (`SecureStorage.uniqueKeychain`) so runs don't collide, and

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainSecureStorageTests.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/KeychainSecureStorageTests.swift
@@ -4,29 +4,29 @@ import SecureStorageKitKeychain
 import Testing
 
 /// Exercises the real Keychain adapter through its public API. Each test uses a
-/// unique service (`SecureStorage.uniqueKeychain`) so runs don't collide, and
-/// removes what it stored before finishing.
+/// unique service (`SecureStorage.uniqueKeychain`) so runs cannot collide, and
+/// `storing(_:at:during:)` removes what it stored.
 @Suite struct KeychainSecureStorageTests {
+    private let key = SecureStorageKey("auth.token")
+
     @Test func whenSettingThenReading_shouldReturnTheStoredValue() async throws {
         let storage = SecureStorage.uniqueKeychain
-        let key = SecureStorageKey("auth.token")
         let token = Data("jwt-abc-123".utf8)
 
-        try await storage.set(token, key)
-        let stored = try await storage.data(key)
-        try await storage.remove(key)
+        let stored = try await storage.storing(token, at: key) {
+            try await storage.data(key)
+        }
 
         #expect(stored == token)
     }
 
     @Test func whenSettingAnExistingKey_shouldOverwriteTheValue() async throws {
         let storage = SecureStorage.uniqueKeychain
-        let key = SecureStorageKey("auth.token")
 
-        try await storage.set(Data("first".utf8), key)
-        try await storage.set(Data("second".utf8), key)
-        let stored = try await storage.data(key)
-        try await storage.remove(key)
+        let stored = try await storage.storing(Data("first".utf8), at: key) {
+            try await storage.set(Data("second".utf8), key)
+            return try await storage.data(key)
+        }
 
         #expect(stored == Data("second".utf8))
     }
@@ -39,7 +39,6 @@ import Testing
 
     @Test func whenRemoving_shouldDeleteTheValue() async throws {
         let storage = SecureStorage.uniqueKeychain
-        let key = SecureStorageKey("auth.token")
         try await storage.set(Data("to-delete".utf8), key)
 
         try await storage.remove(key)
@@ -51,5 +50,29 @@ import Testing
         let storage = SecureStorage.uniqueKeychain
 
         try await storage.remove(SecureStorageKey("never.stored"))
+    }
+
+    @Test func whenAnotherServiceStoredTheKey_shouldNotReturnItsValue() async throws {
+        let mine = SecureStorage.uniqueKeychain
+        let theirs = SecureStorage.uniqueKeychain
+
+        let stored = try await theirs.storing(Data("not-yours".utf8), at: key) {
+            try await mine.data(key)
+        }
+
+        #expect(stored == nil)
+    }
+
+    @Test func whenReadingWithAnotherInstanceOfTheSameService_shouldReturnTheStoredValue() async throws {
+        let service = KeychainService.unique
+        let token = Data("jwt-abc-123".utf8)
+        let writer = SecureStorage.keychain(service: service)
+        let reader = SecureStorage.keychain(service: service)
+
+        let stored = try await writer.storing(token, at: key) {
+            try await reader.data(key)
+        }
+
+        #expect(stored == token)
     }
 }

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/SecureStorage+Storing.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/SecureStorage+Storing.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SecureStorageKit
+
+extension SecureStorage {
+    /// Stores `data` at `key` for the duration of `body`, then removes it.
+    ///
+    /// Keeps cleanup out of the test body, so what a test reads as its steps is
+    /// only the behaviour under test. Removal still happens when `body` throws,
+    /// because a failing test is exactly when a leaked keychain item is least
+    /// welcome.
+    func storing<T>(
+        _ data: Data,
+        at key: SecureStorageKey,
+        during body: () async throws -> T
+    ) async throws -> T {
+        try await set(data, key)
+
+        do {
+            let result = try await body()
+            try await remove(key)
+            return result
+        } catch {
+            try? await remove(key)
+            throw error
+        }
+    }
+}

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/SecureStorage+Storing.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/SecureStorage+Storing.swift
@@ -14,7 +14,17 @@ extension SecureStorage {
         during body: () async throws -> T
     ) async throws -> T {
         try await set(data, key)
+        return try await removingAfterwards(key, during: body)
+    }
 
+    /// Runs `body`, then removes `key` whether or not it threw.
+    ///
+    /// For tests that must start with nothing stored, so they cannot use
+    /// ``storing(_:at:during:)`` but still have to clean up on failure.
+    func removingAfterwards<T>(
+        _ key: SecureStorageKey,
+        during body: () async throws -> T
+    ) async throws -> T {
         do {
             let result = try await body()
             try await remove(key)

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/SecureStorage+UniqueKeychain.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/SecureStorage+UniqueKeychain.swift
@@ -1,0 +1,11 @@
+import Foundation
+import SecureStorageKit
+import SecureStorageKitKeychain
+
+extension SecureStorage {
+    /// A Keychain-backed store scoped to a fresh, collision-free service, so each
+    /// test is isolated from every other run.
+    static var uniqueKeychain: SecureStorage {
+        .keychain(service: KeychainService("co.swiftleeds.securestoragekit.tests.\(UUID().uuidString)"))
+    }
+}

--- a/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/SecureStorage+UniqueKeychain.swift
+++ b/Packages/SecureStorageKit/Tests/SecureStorageKitKeychainTests/SecureStorage+UniqueKeychain.swift
@@ -2,10 +2,18 @@ import Foundation
 import SecureStorageKit
 import SecureStorageKitKeychain
 
+extension KeychainService {
+    /// A fresh, collision-free service, so each test is isolated from every
+    /// other test and from other runs. Tests run in parallel, so they cannot
+    /// share one service and clear it between cases.
+    static var unique: KeychainService {
+        KeychainService("co.swiftleeds.securestoragekit.tests.\(UUID().uuidString)")
+    }
+}
+
 extension SecureStorage {
-    /// A Keychain-backed store scoped to a fresh, collision-free service, so each
-    /// test is isolated from every other run.
+    /// A Keychain-backed store scoped to a fresh service.
     static var uniqueKeychain: SecureStorage {
-        .keychain(service: KeychainService("co.swiftleeds.securestoragekit.tests.\(UUID().uuidString)"))
+        .keychain(service: .unique)
     }
 }

--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		7804F8767E529D8F3A0D8BE4 /* KotlinLeeds.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = KotlinLeeds.entitlements; sourceTree = "<group>"; };
 		7B6278A12EEDDE1B00DE1473 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
 		7B8108412E5CA00E00CCB2F5 /* SwiftLeedsPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SwiftLeedsPackage; sourceTree = "<group>"; };
+		A11CE57000000000000000A1 /* SecureStorageKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SecureStorageKit; sourceTree = "<group>"; };
 		893A122D593379F84605F70C /* SwiftLeedsColors.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = SwiftLeedsColors.xcassets; sourceTree = "<group>"; };
 		AE1C800F289E9F3800996659 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		AE1C801328A7BCD000996659 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -419,10 +420,19 @@
 			path = Push;
 			sourceTree = "<group>";
 		};
+		A11CE57000000000000000B2 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				A11CE57000000000000000A1 /* SecureStorageKit */,
+			);
+			path = Packages;
+			sourceTree = "<group>";
+		};
 		AECB294A27417F9D00CDC983 = {
 			isa = PBXGroup;
 			children = (
 				7B8108412E5CA00E00CCB2F5 /* SwiftLeedsPackage */,
+				A11CE57000000000000000B2 /* Packages */,
 				74B14FAD28CB22B4004C0A40 /* SwiftLeedsWidgetExtension.entitlements */,
 				C1725A0182E1989D761551B2 /* KotlinLeedsWidgetExtension.entitlements */,
 				AECB295527417F9D00CDC983 /* SwiftLeeds */,

--- a/SwiftLeeds.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftLeeds.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "7b97790ca80d08686d9c9fcc756f857d9951541bb61167ef5df024519c64b182",
+  "originHash" : "96efbb911b53c92ca991dcf36ac2c4eafe49fb6abb7b9308be4ab570a476bf7a",
   "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
+      }
+    },
     {
       "identity" : "readabilitymodifier",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,42 @@
       "state" : {
         "revision" : "ce162150a090d5ae54a682d1f6be3862a3ad3ad4",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "8dc1fbf2f6255a73dec53b4648164884898db4c5",
+        "version" : "1.14.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {
@@ -26,6 +71,15 @@
       "state" : {
         "revision" : "467a3d17479887943ab917a379e62bbaff60ac8a",
         "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],


### PR DESCRIPTION
## What

Adds a new `SecureStorageKit` Swift package for storing small, sensitive values.

- **`SecureStorageKit`**: Interface. A `SecureStorage` client with `data` / `set` / `remove`, keyed by `SecureStorageKey`.
- **`SecureStorageKitKeychain`**: Keychain-backed implementation, via `SecureStorage.keychain(service:)`.

## Why

The new sign-in feature needs to keep the auth token across app launches. The Keychain encrypts values at rest, so it's the right place for a token. This is the first building block for that work.

## Notes

- The package is referenced by the Xcode project but not yet linked to a target. It'll get linked when the auth feature is wired up.
- There's no default live value. The Keychain needs a service name, so the app supplies the concrete store.

## How to test

```
    cd Packages/SecureStorageKit && swift test
```

## Security review

Four changes, from a review with the `swift-security` skill.

- **The token no longer travels.** It used to be copied into backups and restored onto a new phone. It's now tied to this device, and readable only while the phone is unlocked.
- **A locked phone no longer looks like broken storage.** That mattered, because we sign people out when storage fails. The errors now say which is which.
- **A damaged item no longer looks like "never signed in".** It reports a failure instead.
- **Keychain work moved off the calling thread**, so it can't block the UI. Two writes at once can no longer collide.

## Worth knowing when you review

- **Tests can't prove the device-binding.** Unit tests run on macOS against an older keychain that throws that setting away. So we check the request we send, not what comes back. Only a real device with a passcode can prove the rest.
- **We left out `kSecUseDataProtectionKeychain`.** It does nothing on iOS, and it breaks every test on macOS because the test binary isn't signed. It's worth adding when we ship a Mac app, and it's testable then.
- **Clearing stale items on first launch comes later**, with the app wiring. Keychain items outlive app deletion, so a reinstall can start with an old token.
