### PR TITLE
feat(AuthenticationFeature): add credential domain value objects

### DIFF
--- a/Packages/AuthenticationFeature/Package.swift
+++ b/Packages/AuthenticationFeature/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "AuthenticationFeature",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v13),
+    ],
+    products: [
+        .library(name: "AuthenticationFeature", targets: ["AuthenticationFeature"]),
+    ],
+    targets: [
+        .target(name: "AuthenticationFeature"),
+        .testTarget(
+            name: "AuthenticationFeatureTests",
+            dependencies: ["AuthenticationFeature"]
+        ),
+    ]
+)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/Credential.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/Credential.swift
@@ -1,0 +1,9 @@
+public struct Credential: Equatable, Hashable, Sendable {
+    public let email: EmailAddress
+    public let ticketReference: TicketReference
+
+    public init(email: EmailAddress, ticketReference: TicketReference) {
+        self.email = email
+        self.ticketReference = ticketReference
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct EmailAddress: Hashable, Sendable {
+public struct EmailAddress: Equatable, Hashable, Sendable {
     public enum ParsingError: Error, Equatable {
         case empty
     }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
@@ -26,3 +26,9 @@ extension String {
         self = email.stringValue
     }
 }
+
+// Redacted so the address can't leak via logs, interpolation, or reflection.
+extension EmailAddress: CustomStringConvertible, CustomDebugStringConvertible {
+    public var description: String { "•••" }
+    public var debugDescription: String { description }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
@@ -1,12 +1,15 @@
+import Foundation
+
 public struct EmailAddress: Hashable, Sendable {
     private let storage: String
 
-    /// Creates an email address from the given string.
+    /// Creates an email address from the given string, trimming surrounding whitespace.
     /// - Parameter value: The email address.
-    /// - Throws: ``ParsingError/empty`` if `value` is empty.
+    /// - Throws: ``ParsingError/empty`` if `value` is empty once trimmed.
     public init(_ value: String) throws(ParsingError) {
-        guard !value.isEmpty else { throw .empty }
-        self.storage = value
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw .empty }
+        self.storage = trimmed
     }
 
     fileprivate var stringValue: String { storage }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 public struct EmailAddress: Hashable, Sendable {
+    public enum ParsingError: Error, Equatable {
+        case empty
+    }
+
     private let storage: String
 
     /// Creates an email address from the given string, trimming surrounding whitespace.
@@ -13,10 +17,6 @@ public struct EmailAddress: Hashable, Sendable {
     }
 
     fileprivate var stringValue: String { storage }
-
-    public enum ParsingError: Error, Equatable {
-        case empty
-    }
 }
 
 extension String {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
@@ -1,0 +1,25 @@
+public struct EmailAddress: Hashable, Sendable {
+    private let storage: String
+
+    /// Creates an email address from the given string.
+    /// - Parameter value: The email address.
+    /// - Throws: ``ParsingError/empty`` if `value` is empty.
+    public init(_ value: String) throws(ParsingError) {
+        guard !value.isEmpty else { throw .empty }
+        self.storage = value
+    }
+
+    fileprivate var stringValue: String { storage }
+
+    public enum ParsingError: Error, Equatable {
+        case empty
+    }
+}
+
+extension String {
+    /// Creates a string from an email address.
+    /// - Parameter email: The email address to convert.
+    public init(_ email: EmailAddress) {
+        self = email.stringValue
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
@@ -31,3 +31,9 @@ extension String {
         self = ticketReference.stringValue
     }
 }
+
+// Redacted so the reference can't leak via logs, interpolation, or reflection.
+extension TicketReference: CustomStringConvertible, CustomDebugStringConvertible {
+    public var description: String { "•••" }
+    public var debugDescription: String { description }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TicketReference: Hashable, Sendable {
+public struct TicketReference: Equatable, Hashable, Sendable {
     public enum ParsingError: Error, Equatable {
         case invalidFormat
     }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
@@ -5,14 +5,18 @@ public struct TicketReference: Hashable, Sendable {
 
     private let storage: String
 
-    /// Creates a ticket reference from the given string.
+    /// Creates a ticket reference from the given string, normalising it to the
+    /// canonical `XXXX-#` form. The hyphen is optional in the input.
     /// - Parameter value: The ticket reference.
     /// - Throws: ``ParsingError/invalidFormat`` if `value` is not a valid ticket reference.
     public init(_ value: String) throws(ParsingError) {
-        guard value.wholeMatch(of: /[A-Z0-9]{4}-[0-9]{1,2}/) != nil else {
-            throw .invalidFormat
-        }
-        self.storage = value
+        let canonical = value
+            .wholeMatch(of: /([A-Z0-9]{4})-?([0-9]{1,2})/)
+            .map { match in "\(match.output.1)-\(match.output.2)" }
+
+        guard let canonical else { throw .invalidFormat }
+
+        self.storage = canonical
     }
 
     fileprivate var stringValue: String { storage }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct TicketReference: Hashable, Sendable {
     public enum ParsingError: Error, Equatable {
         case invalidFormat
@@ -6,11 +8,12 @@ public struct TicketReference: Hashable, Sendable {
     private let storage: String
 
     /// Creates a ticket reference from the given string, normalising it to the
-    /// canonical `XXXX-#` form. The hyphen is optional in the input.
+    /// canonical `XXXX-#` form. The hyphen is optional and the input is case-insensitive.
     /// - Parameter value: The ticket reference.
     /// - Throws: ``ParsingError/invalidFormat`` if `value` is not a valid ticket reference.
     public init(_ value: String) throws(ParsingError) {
         self.storage = try value
+            .uppercased()
             .wholeMatch(of: /([A-Z0-9]{4})-?([0-9]{1,2})/)
             .map { match in "\(match.output.1)-\(match.output.2)" }
             .unwrap(orThrow: ParsingError.invalidFormat)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
@@ -9,7 +9,7 @@ public struct TicketReference: Hashable, Sendable {
     /// - Parameter value: The ticket reference.
     /// - Throws: ``ParsingError/invalidFormat`` if `value` is not a valid ticket reference.
     public init(_ value: String) throws(ParsingError) {
-        guard value.wholeMatch(of: /[A-Z0-9]{4}-[0-9]/) != nil else {
+        guard value.wholeMatch(of: /[A-Z0-9]{4}-[0-9]{1,2}/) != nil else {
             throw .invalidFormat
         }
         self.storage = value

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
@@ -1,0 +1,27 @@
+public struct TicketReference: Hashable, Sendable {
+    public enum ParsingError: Error, Equatable {
+        case invalidFormat
+    }
+
+    private let storage: String
+
+    /// Creates a ticket reference from the given string.
+    /// - Parameter value: The ticket reference.
+    /// - Throws: ``ParsingError/invalidFormat`` if `value` is not a valid ticket reference.
+    public init(_ value: String) throws(ParsingError) {
+        guard value.wholeMatch(of: /[A-Z0-9]{4}-[0-9]/) != nil else {
+            throw .invalidFormat
+        }
+        self.storage = value
+    }
+
+    fileprivate var stringValue: String { storage }
+}
+
+extension String {
+    /// Creates a string from a ticket reference.
+    /// - Parameter ticketReference: The ticket reference to convert.
+    public init(_ ticketReference: TicketReference) {
+        self = ticketReference.stringValue
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
@@ -10,13 +10,10 @@ public struct TicketReference: Hashable, Sendable {
     /// - Parameter value: The ticket reference.
     /// - Throws: ``ParsingError/invalidFormat`` if `value` is not a valid ticket reference.
     public init(_ value: String) throws(ParsingError) {
-        let canonical = value
+        self.storage = try value
             .wholeMatch(of: /([A-Z0-9]{4})-?([0-9]{1,2})/)
             .map { match in "\(match.output.1)-\(match.output.2)" }
-
-        guard let canonical else { throw .invalidFormat }
-
-        self.storage = canonical
+            .unwrap(orThrow: ParsingError.invalidFormat)
     }
 
     fileprivate var stringValue: String { storage }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
@@ -8,11 +8,13 @@ public struct TicketReference: Hashable, Sendable {
     private let storage: String
 
     /// Creates a ticket reference from the given string, normalising it to the
-    /// canonical `XXXX-#` form. The hyphen is optional and the input is case-insensitive.
+    /// canonical `XXXX-#` form. Surrounding whitespace is trimmed, the hyphen is
+    /// optional, and the input is case-insensitive.
     /// - Parameter value: The ticket reference.
     /// - Throws: ``ParsingError/invalidFormat`` if `value` is not a valid ticket reference.
     public init(_ value: String) throws(ParsingError) {
         self.storage = try value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
             .uppercased()
             .wholeMatch(of: /([A-Z0-9]{4})-?([0-9]{1,2})/)
             .map { match in "\(match.output.1)-\(match.output.2)" }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Optional+Unwrap.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Optional+Unwrap.swift
@@ -1,0 +1,9 @@
+extension Optional {
+    /// Returns the wrapped value, or throws the given error when `nil`.
+    /// - Parameter error: The error to throw when this optional is `nil`.
+    /// - Returns: The unwrapped value.
+    func unwrap<Failure: Error>(orThrow error: @autoclosure () -> Failure) throws(Failure) -> Wrapped {
+        guard let value = self else { throw error() }
+        return value
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/CredentialTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/CredentialTests.swift
@@ -1,0 +1,16 @@
+import AuthenticationFeature
+import Testing
+
+@Suite struct CredentialTests {
+    @Test func whenDescribed_shouldRedactEmailAndTicket() throws {
+        let credential = Credential(
+            email: try EmailAddress("person@example.com"),
+            ticketReference: try TicketReference("ABCD-1")
+        )
+
+        let described = String(describing: credential)
+
+        #expect(!described.contains("person@example.com"))
+        #expect(!described.contains("ABCD-1"))
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
@@ -2,7 +2,7 @@ import AuthenticationFeature
 import Testing
 
 @Suite struct EmailAddressTests {
-    @Test func whenParsingValidEmail_shouldNotThrow() throws {
+    @Test func whenParsingValidEmailAddress_shouldReturnEmailAddress() throws {
         _ = try EmailAddress("person@example.com")
     }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
@@ -5,4 +5,10 @@ import Testing
     @Test func whenParsingValidEmail_shouldNotThrow() throws {
         _ = try EmailAddress("person@example.com")
     }
+
+    @Test func whenParsingEmptyString_shouldThrowEmpty() {
+        #expect(throws: EmailAddress.ParsingError.empty) {
+            try EmailAddress("")
+        }
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
@@ -11,4 +11,9 @@ import Testing
             try EmailAddress("")
         }
     }
+
+    @Test func whenParsingEmailWithSurroundingWhitespace_shouldTrim() throws {
+        let email = try EmailAddress("  person@example.com  ")
+        #expect(String(email) == "person@example.com")
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
@@ -1,0 +1,8 @@
+import AuthenticationFeature
+import Testing
+
+@Suite struct EmailAddressTests {
+    @Test func whenParsingValidEmail_shouldNotThrow() throws {
+        _ = try EmailAddress("person@example.com")
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
@@ -16,4 +16,9 @@ import Testing
         let email = try EmailAddress("  person@example.com  ")
         #expect(String(email) == "person@example.com")
     }
+
+    @Test func whenDescribed_shouldRedactValue() throws {
+        let email = try EmailAddress("person@example.com")
+        #expect(!String(describing: email).contains("person@example.com"))
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
@@ -12,7 +12,7 @@ import Testing
         }
     }
 
-    @Test func whenParsingEmailWithSurroundingWhitespace_shouldTrim() throws {
+    @Test func whenParsingEmailAddressWithSurroundingWhitespace_shouldTrim() throws {
         let email = try EmailAddress("  person@example.com  ")
         #expect(String(email) == "person@example.com")
     }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -1,0 +1,8 @@
+import AuthenticationFeature
+import Testing
+
+@Suite struct TicketReferenceTests {
+    @Test func whenParsingValidReference_shouldNotThrow() throws {
+        _ = try TicketReference("ABCD-1")
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -5,4 +5,9 @@ import Testing
     @Test func whenParsingValidReference_shouldNotThrow() throws {
         _ = try TicketReference("ABCD-1")
     }
+
+    @Test func whenParsingDoubleDigitReference_shouldReturnTicketReference() throws {
+        let reference = try TicketReference("ABCD-12")
+        #expect(String(reference) == "ABCD-12")
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -2,7 +2,7 @@ import AuthenticationFeature
 import Testing
 
 @Suite struct TicketReferenceTests {
-    @Test func whenParsingValidReference_shouldNotThrow() throws {
+    @Test func whenParsingValidTicketReference_shouldReturnTicketReference() throws {
         _ = try TicketReference("ABCD-1")
     }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -29,4 +29,11 @@ import Testing
         let reference = try TicketReference("  ABCD-1  ")
         #expect(String(reference) == "ABCD-1")
     }
+
+    @Test(arguments: ["ABC-1", "ABCDE-1", "ABCD-123", "ABCD-", "ABCD", ""])
+    func whenParsingMalformedReference_shouldThrowInvalidFormat(_ input: String) {
+        #expect(throws: TicketReference.ParsingError.invalidFormat) {
+            try TicketReference(input)
+        }
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -36,4 +36,9 @@ import Testing
             try TicketReference(input)
         }
     }
+
+    @Test func whenDescribed_shouldRedactValue() throws {
+        let reference = try TicketReference("ABCD-1")
+        #expect(!String(describing: reference).contains("ABCD-1"))
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -19,4 +19,9 @@ import Testing
         let reference = try TicketReference(input)
         #expect(String(reference) == expected)
     }
+
+    @Test func whenParsingLowercaseReference_shouldUppercase() throws {
+        let reference = try TicketReference("abcd-1")
+        #expect(String(reference) == "ABCD-1")
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -10,4 +10,13 @@ import Testing
         let reference = try TicketReference("ABCD-12")
         #expect(String(reference) == "ABCD-12")
     }
+
+    @Test(arguments: [("ABCD1", "ABCD-1"), ("ABCD12", "ABCD-12")])
+    func whenParsingReferenceWithoutHyphen_shouldNormaliseToHyphenated(
+        _ input: String,
+        _ expected: String
+    ) throws {
+        let reference = try TicketReference(input)
+        #expect(String(reference) == expected)
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -6,13 +6,13 @@ import Testing
         _ = try TicketReference("ABCD-1")
     }
 
-    @Test func whenParsingDoubleDigitReference_shouldReturnTicketReference() throws {
+    @Test func whenParsingDoubleDigitTicketReference_shouldReturnTicketReference() throws {
         let reference = try TicketReference("ABCD-12")
         #expect(String(reference) == "ABCD-12")
     }
 
     @Test(arguments: [("ABCD1", "ABCD-1"), ("ABCD12", "ABCD-12")])
-    func whenParsingReferenceWithoutHyphen_shouldNormaliseToHyphenated(
+    func whenParsingTicketReferenceWithoutHyphen_shouldNormaliseToHyphenated(
         _ input: String,
         _ expected: String
     ) throws {
@@ -20,18 +20,18 @@ import Testing
         #expect(String(reference) == expected)
     }
 
-    @Test func whenParsingLowercaseReference_shouldUppercase() throws {
+    @Test func whenParsingLowercaseTicketReference_shouldUppercase() throws {
         let reference = try TicketReference("abcd-1")
         #expect(String(reference) == "ABCD-1")
     }
 
-    @Test func whenParsingReferenceWithSurroundingWhitespace_shouldTrim() throws {
+    @Test func whenParsingTicketReferenceWithSurroundingWhitespace_shouldTrim() throws {
         let reference = try TicketReference("  ABCD-1  ")
         #expect(String(reference) == "ABCD-1")
     }
 
     @Test(arguments: ["ABC-1", "ABCDE-1", "ABCD-123", "ABCD-", "ABCD", ""])
-    func whenParsingMalformedReference_shouldThrowInvalidFormat(_ input: String) {
+    func whenParsingMalformedTicketReference_shouldThrowInvalidFormat(_ input: String) {
         #expect(throws: TicketReference.ParsingError.invalidFormat) {
             try TicketReference(input)
         }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -24,4 +24,9 @@ import Testing
         let reference = try TicketReference("abcd-1")
         #expect(String(reference) == "ABCD-1")
     }
+
+    @Test func whenParsingReferenceWithSurroundingWhitespace_shouldTrim() throws {
+        let reference = try TicketReference("  ABCD-1  ")
+        #expect(String(reference) == "ABCD-1")
+    }
 }

--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		7B6278A12EEDDE1B00DE1473 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
 		7B8108412E5CA00E00CCB2F5 /* SwiftLeedsPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SwiftLeedsPackage; sourceTree = "<group>"; };
 		A11CE57000000000000000A1 /* SecureStorageKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SecureStorageKit; sourceTree = "<group>"; };
+		A11CE57000000000000000A2 /* AuthenticationFeature */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AuthenticationFeature; sourceTree = "<group>"; };
 		893A122D593379F84605F70C /* SwiftLeedsColors.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = SwiftLeedsColors.xcassets; sourceTree = "<group>"; };
 		AE1C800F289E9F3800996659 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		AE1C801328A7BCD000996659 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -424,6 +425,7 @@
 			isa = PBXGroup;
 			children = (
 				A11CE57000000000000000A1 /* SecureStorageKit */,
+				A11CE57000000000000000A2 /* AuthenticationFeature */,
 			);
 			path = Packages;
 			sourceTree = "<group>";


### PR DESCRIPTION
## What

Adds a new `AuthenticationFeature` package with the domain value objects for sign-in:

- **`EmailAddress`**: Email address a user signs in with. Lenient; trims whitespace; rejects blank input.
- **`TicketReference`**: Tito ticket reference. Accepts forgiving input (`ABCD-1`, `ABCD-12`, `ABCD1`, `ABCD12`, any case, extra spaces) and stores canonical `XXXX-#` form.
- **`Credential`**: Bundles a validated email and ticket reference.
- **`Optional.unwrap(orThrow:)`**: Small combinator the parsers use. Functional programming is 👌 

All three are strong value types (`Equatable, Hashable, Sendable`). They redact themselves (`•••` -- can always change this if required), so an email or ticket can't leak via logs, string interpolation, or reflection. The real value is only available through the explicit `String(value)` conversion.

## Why

This is the first slice of the sign-in feature. Adding the domain first, with no networking or storage, locks down and tests the parsing rules before anything talks to the backend.

## Notes

- No external dependencies. Pure domain over `Foundation`.
- Package is referenced by the Xcode project but not yet linked to any target.

## How to test

```
    cd Packages/AuthenticationFeature && swift test
```