### PR TITLE
feat(AuthenticationFeature): add authentication models

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Application/AuthStatus.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Application/AuthStatus.swift
@@ -1,0 +1,30 @@
+import Dependencies
+
+public struct AuthStatus: Sendable {
+    public var current: @Sendable () async -> AuthenticationState
+
+    public init(current: @escaping @Sendable () async -> AuthenticationState) {
+        self.current = current
+    }
+}
+
+extension AuthStatus: DependencyKey {
+    public static var liveValue: AuthStatus {
+        AuthStatus {
+            @Dependency(\.sessionStore) var sessionStore
+            let session = try? await sessionStore.current()
+            return session.map { .signedIn(SignedInProof($0)) } ?? .signedOut
+        }
+    }
+
+    public static let testValue = AuthStatus(
+        current: unimplemented("AuthStatus.current", placeholder: .signedOut)
+    )
+}
+
+extension DependencyValues {
+    public var authStatus: AuthStatus {
+        get { self[AuthStatus.self] }
+        set { self[AuthStatus.self] = newValue }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Application/SignIn.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Application/SignIn.swift
@@ -18,7 +18,7 @@ extension SignIn {
             @Dependency(\.authGateway) var authGateway
             @Dependency(\.sessionStore) var sessionStore
             let token = try await authGateway.authenticate(credential)
-            try await sessionStore.establish(Session(token))
+            try await sessionStore.establish(Session(token: token))
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Application/SignIn.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Application/SignIn.swift
@@ -1,24 +1,33 @@
 import Dependencies
 
-package struct SignIn: Sendable {
+public struct SignIn: Sendable {
     private var perform: @Sendable (Credential) async throws -> Void
 
     private init(perform: @escaping @Sendable (Credential) async throws -> Void) {
         self.perform = perform
     }
 
-    package func callAsFunction(_ credential: Credential) async throws {
+    public func callAsFunction(_ credential: Credential) async throws {
         try await perform(credential)
     }
 }
 
-extension SignIn {
-    package static var live: SignIn {
+extension SignIn: DependencyKey {
+    public static var liveValue: SignIn {
         SignIn { credential in
             @Dependency(\.authGateway) var authGateway
             @Dependency(\.sessionStore) var sessionStore
             let token = try await authGateway.authenticate(credential)
             try await sessionStore.establish(Session(token: token))
         }
+    }
+
+    public static let testValue = SignIn(perform: unimplemented("SignIn"))
+}
+
+extension DependencyValues {
+    public var signIn: SignIn {
+        get { self[SignIn.self] }
+        set { self[SignIn.self] = newValue }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Application/SignOut.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Application/SignOut.swift
@@ -1,22 +1,31 @@
 import Dependencies
 
-package struct SignOut: Sendable {
+public struct SignOut: Sendable {
     private var perform: @Sendable () async throws -> Void
 
     private init(perform: @escaping @Sendable () async throws -> Void) {
         self.perform = perform
     }
 
-    package func callAsFunction() async throws {
+    public func callAsFunction() async throws {
         try await perform()
     }
 }
 
-extension SignOut {
-    package static var live: SignOut {
+extension SignOut: DependencyKey {
+    public static var liveValue: SignOut {
         SignOut {
             @Dependency(\.sessionStore) var sessionStore
             try await sessionStore.clear()
         }
+    }
+
+    public static let testValue = SignOut(perform: unimplemented("SignOut"))
+}
+
+extension DependencyValues {
+    public var signOut: SignOut {
+        get { self[SignOut.self] }
+        set { self[SignOut.self] = newValue }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/AuthenticationState.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/AuthenticationState.swift
@@ -1,0 +1,4 @@
+public enum AuthenticationState: Equatable, Hashable, Sendable {
+    case signedIn(SignedInProof)
+    case signedOut
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/Session.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/Session.swift
@@ -2,7 +2,7 @@
 package struct Session: Equatable, Hashable, Sendable {
     package let token: SessionToken
 
-    package init(_ token: SessionToken) {
+    package init(token: SessionToken) {
         self.token = token
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignedInProof.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignedInProof.swift
@@ -1,0 +1,5 @@
+/// A token-free, un-forgeable capability proving its holder is signed in.
+/// Only `AuthenticationFeature` can mint one (the `init` is `package`), so possession is proof.
+public struct SignedInProof: Equatable, Hashable, Sendable {
+    package init() {}
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignedInProof.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignedInProof.swift
@@ -1,5 +1,6 @@
 /// A token-free, un-forgeable capability proving its holder is signed in.
-/// Only `AuthenticationFeature` can mint one (the `init` is `package`), so possession is proof.
+/// Minting requires a `Session` — evidence of a real sign-in, which only `AuthenticationFeature`
+/// can produce — but the session is not retained, so the proof carries no token.
 public struct SignedInProof: Equatable, Hashable, Sendable {
-    package init() {}
+    package init(_: Session) {}
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/CachedSession.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/CachedSession.swift
@@ -10,6 +10,6 @@ extension CachedSession {
     }
 
     var session: Session {
-        Session(SessionToken(token))
+        Session(token: SessionToken(token))
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Application/FetchProfile.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Application/FetchProfile.swift
@@ -1,22 +1,37 @@
 import Dependencies
 
-package struct FetchProfile: Sendable {
-    private var perform: @Sendable () async throws(AttendeeFetchError) -> Attendee
+public struct FetchProfile: Sendable {
+    private var perform: @Sendable () async throws(AttendeeFetchError) -> Profile
 
-    private init(perform: @escaping @Sendable () async throws(AttendeeFetchError) -> Attendee) {
+    private init(perform: @escaping @Sendable () async throws(AttendeeFetchError) -> Profile) {
         self.perform = perform
     }
 
-    package func callAsFunction() async throws(AttendeeFetchError) -> Attendee {
+    public func callAsFunction() async throws -> Profile {
         try await perform()
     }
 }
 
-extension FetchProfile {
-    package static var live: FetchProfile {
-        FetchProfile { () async throws(AttendeeFetchError) -> Attendee in
+extension FetchProfile: DependencyKey {
+    public static var liveValue: FetchProfile {
+        FetchProfile { () async throws(AttendeeFetchError) -> Profile in
             @Dependency(\.attendeeRepository) var attendeeRepository
-            return try await attendeeRepository.fetch()
+            let attendee = try await attendeeRepository.fetch()
+            return Profile(attendee)
         }
+    }
+
+    public static let testValue = FetchProfile(
+        perform: { () async throws(AttendeeFetchError) -> Profile in
+            reportIssue("FetchProfile is unimplemented")
+            throw .unknown
+        }
+    )
+}
+
+extension DependencyValues {
+    public var fetchProfile: FetchProfile {
+        get { self[FetchProfile.self] }
+        set { self[FetchProfile.self] = newValue }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Domain/Profile.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Domain/Profile.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct Profile: Equatable, Hashable, Sendable {
+    public let name: String
+    public let emailAddress: String
+    public let avatarURL: URL
+    public let qrCodeURL: URL
+    public let ticketReference: String
+
+    public init(
+        name: String,
+        emailAddress: String,
+        avatarURL: URL,
+        qrCodeURL: URL,
+        ticketReference: String
+    ) {
+        self.name = name
+        self.emailAddress = emailAddress
+        self.avatarURL = avatarURL
+        self.qrCodeURL = qrCodeURL
+        self.ticketReference = ticketReference
+    }
+}
+
+extension Profile {
+    package init(_ attendee: Attendee) {
+        self.init(
+            name: String(attendee.name),
+            emailAddress: String(attendee.emailAddress),
+            avatarURL: URL(attendee.avatarURL),
+            qrCodeURL: URL(attendee.qrCodeURL),
+            ticketReference: String(attendee.ticketReference)
+        )
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthStatusTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthStatusTests.swift
@@ -1,0 +1,30 @@
+import AuthenticationFeature
+import Dependencies
+import Testing
+
+@Suite struct AuthStatusTests {
+    @Test func whenSessionExists_shouldReportSignedIn() async {
+        let session = Session(token: SessionToken("jwt-abc-123"))
+        let store = InMemorySessionStore(stored: session)
+
+        let state = await withDependencies {
+            $0.sessionStore = store.sessionStore
+        } operation: {
+            await AuthStatus.liveValue.current()
+        }
+
+        #expect(state == .signedIn(SignedInProof(session)))
+    }
+
+    @Test func whenNoSession_shouldReportSignedOut() async {
+        let store = InMemorySessionStore()
+
+        let state = await withDependencies {
+            $0.sessionStore = store.sessionStore
+        } operation: {
+            await AuthStatus.liveValue.current()
+        }
+
+        #expect(state == .signedOut)
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileTests.swift
@@ -4,17 +4,17 @@ import Foundation
 import Testing
 
 @Suite struct FetchProfileTests {
-    @Test func whenRepositoryReturnsAttendee_shouldReturnSameAttendee() async throws {
-        let expected = try makeAttendee()
+    @Test func whenRepositoryReturnsAttendee_shouldReturnMappedProfile() async throws {
+        let attendee = try makeAttendee()
 
-        let attendee = try await withDependencies {
-            $0.attendeeRepository = .returning(expected)
+        let profile = try await withDependencies {
+            $0.attendeeRepository = .returning(attendee)
         } operation: {
-            let sut = FetchProfile.live
+            let sut = FetchProfile.liveValue
             return try await sut()
         }
 
-        #expect(attendee == expected)
+        #expect(profile == expectedProfile())
     }
 
     @Test func whenRepositoryFails_shouldRethrowError() async throws {
@@ -22,7 +22,7 @@ import Testing
             try await withDependencies {
                 $0.attendeeRepository = .failing(with: .unauthorized)
             } operation: {
-                let sut = FetchProfile.live
+                let sut = FetchProfile.liveValue
                 return try await sut()
             }
         }
@@ -36,5 +36,15 @@ private func makeAttendee() throws -> Attendee {
         avatarURL: AvatarURL(URL(string: "https://example.com/avatar.png")!),
         qrCodeURL: QRCodeURL(URL(string: "https://example.com/qr.png")!),
         ticketReference: try TicketReference("ABCD-12")
+    )
+}
+
+private func expectedProfile() -> Profile {
+    Profile(
+        name: "Ada Lovelace",
+        emailAddress: "ada@example.com",
+        avatarURL: URL(string: "https://example.com/avatar.png")!,
+        qrCodeURL: URL(string: "https://example.com/qr.png")!,
+        ticketReference: "ABCD-12"
     )
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @Suite struct SessionStoreTests {
     @Test func whenSessionEstablished_shouldReadBackSameSession() async throws {
-        let session = Session(SessionToken("jwt-abc-123"))
+        let session = Session(token: SessionToken("jwt-abc-123"))
 
         try await withDependencies {
             $0.secureStorage = SecureStorageSpy().secureStorage

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInTests.swift
@@ -10,7 +10,7 @@ import Testing
             $0.authGateway = .returning(SessionToken("jwt-abc-123"))
             $0.sessionStore = store.sessionStore
         } operation: {
-            let sut = SignIn.live
+            let sut = SignIn.liveValue
             try await sut(credential())
         }
 
@@ -21,7 +21,7 @@ import Testing
         try await withDependencies {
             $0.authGateway = .failing(with: StubError.authenticationFailed)
         } operation: {
-            let sut = SignIn.live
+            let sut = SignIn.liveValue
             await #expect(throws: StubError.authenticationFailed) {
                 try await sut(credential())
             }
@@ -35,7 +35,7 @@ import Testing
             $0.authGateway = .failing(with: StubError.authenticationFailed)
             $0.sessionStore = store.sessionStore
         } operation: {
-            let sut = SignIn.live
+            let sut = SignIn.liveValue
             _ = try? await sut(credential())
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutTests.swift
@@ -9,7 +9,7 @@ import Testing
         try await withDependencies {
             $0.sessionStore = store.sessionStore
         } operation: {
-            let sut = SignOut.live
+            let sut = SignOut.liveValue
             try await sut()
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite struct SignOutTests {
     @Test func whenSignedOut_shouldClearStoredSession() async throws {
-        let store = InMemorySessionStore(stored: Session(SessionToken("jwt-abc-123")))
+        let store = InMemorySessionStore(stored: Session(token: SessionToken("jwt-abc-123")))
 
         try await withDependencies {
             $0.sessionStore = store.sessionStore


### PR DESCRIPTION
## What
The public, token-free read model the UI/app will consume. Promoting write-side use cases to public:

## Why
The UI needs to read auth state and the profile, and invoke sign-in/out, without ever seeing `Session`/`SessionToken`.

## How to test
```
cd Packages/AuthenticationFeature && swift test
```
