### PR TITLE
feat(AuthenticationFeature): add live network transport and auth gateway

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/AuthenticationError.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/AuthenticationError.swift
@@ -1,0 +1,4 @@
+public enum AuthenticationError: Error, Equatable {
+    case invalidCredentials
+    case unknown
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SessionToken.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SessionToken.swift
@@ -1,8 +1,10 @@
+import Foundation
+
 package struct SessionToken: Equatable, Hashable, Sendable {
     private let storage: String
 
     package init(_ value: String) {
-        self.storage = value
+        storage = value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     fileprivate var stringValue: String { storage }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/APIConfiguration.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/APIConfiguration.swift
@@ -1,0 +1,21 @@
+import Dependencies
+import Foundation
+
+public struct APIConfiguration: Sendable {
+    public let baseURL: URL
+
+    public init(baseURL: URL) {
+        self.baseURL = baseURL
+    }
+}
+
+extension APIConfiguration: TestDependencyKey {
+    public static let testValue = APIConfiguration(baseURL: URL(string: "https://example.com")!)
+}
+
+extension DependencyValues {
+    public var apiConfiguration: APIConfiguration {
+        get { self[APIConfiguration.self] }
+        set { self[APIConfiguration.self] = newValue }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -1,0 +1,25 @@
+import Dependencies
+import Foundation
+
+extension AuthGateway: DependencyKey {
+    package static var liveValue: AuthGateway {
+        AuthGateway { credential in
+            @Dependency(\.httpClient) var httpClient
+            @Dependency(\.apiConfiguration) var apiConfiguration
+
+            var request = URLRequest(url: Endpoint.login.url(baseURL: apiConfiguration.baseURL))
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            let data: Data
+            let response: HTTPURLResponse
+            do {
+                request.httpBody = try JSONEncoder().encode(LoginRequestDTO(credential))
+                (data, response) = try await httpClient.send(request)
+            } catch {
+                throw AuthenticationError.unknown
+            }
+            return try LoginMapper.map(data, response)
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum Endpoint {
+    case profile
+
+    func url(baseURL: URL) -> URL {
+        switch self {
+        // The backend overloads `login/ticket` (GET) as the profile endpoint.
+        case .profile: baseURL.appending(path: "api/v1/login/ticket")
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
@@ -1,12 +1,15 @@
 import Foundation
 
 enum Endpoint {
+    case login
     case profile
 
     func url(baseURL: URL) -> URL {
         switch self {
-        // The backend overloads `login/ticket` (GET) as the profile endpoint.
-        case .profile: baseURL.appending(path: "api/v1/login/ticket")
+        case .login:
+            baseURL.appending(path: "api/v1/login/ticket")
+        case .profile:
+            baseURL.appending(path: "api/v1/login/ticket")
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+URLSession.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+URLSession.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension HTTPClient {
+    package static func urlSession(_ session: URLSession = .shared) -> HTTPClient {
+        HTTPClient { request in
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw URLError(.badServerResponse)
+            }
+            return (data, http)
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum LoginMapper {
+    static func map(_ data: Data, _ response: HTTPURLResponse) throws(AuthenticationError) -> SessionToken {
+        switch response.statusCode {
+        case 200:
+            return SessionToken(String(decoding: data, as: UTF8.self))
+        case 401:
+            throw .invalidCredentials
+        default:
+            throw .unknown
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestDTO.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestDTO.swift
@@ -1,0 +1,20 @@
+struct LoginRequestDTO: Encodable {
+    let email: String
+    let ticket: String
+
+    enum CodingKeys: String, CodingKey {
+        case email, ticket, event
+    }
+
+    init(_ credential: Credential) {
+        email = String(credential.email)
+        ticket = String(credential.ticketReference)
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(email, forKey: .email)
+        try container.encode(ticket, forKey: .ticket)
+        try container.encodeNil(forKey: .event)
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
@@ -5,10 +5,12 @@ extension AttendeeRepository: DependencyKey {
     package static var liveValue: AttendeeRepository {
         AttendeeRepository { () async throws(AttendeeFetchError) -> Attendee in
             @Dependency(\.httpClient) var httpClient
+            @Dependency(\.apiConfiguration) var apiConfiguration
+            let request = URLRequest(url: Endpoint.profile.url(baseURL: apiConfiguration.baseURL))
             let data: Data
             let response: HTTPURLResponse
             do {
-                (data, response) = try await httpClient.send(URLRequest(url: profileURL))
+                (data, response) = try await httpClient.send(request)
             } catch {
                 throw AttendeeFetchError.unknown
             }
@@ -16,7 +18,3 @@ extension AttendeeRepository: DependencyKey {
         }
     }
 }
-
-// The backend overloads `GET login/ticket` as the profile endpoint; that quirk is hidden here (the ACL).
-// Host hardcoded as a temporary stopgap; move to a config dependency in a follow-up PR.
-private let profileURL = URL(string: "https://swiftleeds.co.uk/api/v1/login/ticket")!

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLiveTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLiveTests.swift
@@ -1,0 +1,60 @@
+import AuthenticationFeature
+import Dependencies
+import Foundation
+import Testing
+
+@Suite struct AuthGatewayLiveTests {
+    @Test func whenServerReturnsJWT_shouldReturnSessionToken() async throws {
+        let token = try await withDependencies {
+            $0.httpClient = .responding(with: Data("jwt-abc-123".utf8), statusCode: 200)
+        } operation: {
+            try await AuthGateway.liveValue.authenticate(credential())
+        }
+
+        #expect(token == SessionToken("jwt-abc-123"))
+    }
+
+    @Test func whenServerReturnsUnauthorized_shouldThrowInvalidCredentials() async throws {
+        await #expect(throws: AuthenticationError.invalidCredentials) {
+            try await withDependencies {
+                $0.httpClient = .responding(with: Data(), statusCode: 401)
+            } operation: {
+                try await AuthGateway.liveValue.authenticate(credential())
+            }
+        }
+    }
+
+    @Test func whenServerReturnsOtherStatus_shouldThrowUnknown() async throws {
+        await #expect(throws: AuthenticationError.unknown) {
+            try await withDependencies {
+                $0.httpClient = .responding(with: Data(), statusCode: 500)
+            } operation: {
+                try await AuthGateway.liveValue.authenticate(credential())
+            }
+        }
+    }
+
+    @Test func whenAuthenticating_shouldPOSTCredentialWithNullEvent() async throws {
+        let spy = HTTPClientSpy(respondingWith: Data("jwt".utf8), statusCode: 200)
+
+        _ = try await withDependencies {
+            $0.httpClient = spy.httpClient
+        } operation: {
+            try await AuthGateway.liveValue.authenticate(credential())
+        }
+
+        let request = try #require(await spy.requests.first)
+        #expect(request.httpMethod == "POST")
+        let body = try JSONSerialization.jsonObject(with: #require(request.httpBody)) as? [String: Any]
+        #expect(body?["email"] as? String == "attendee@example.com")
+        #expect(body?["ticket"] as? String == "ABCD-12")
+        #expect(body?["event"] is NSNull)
+    }
+}
+
+private func credential() throws -> Credential {
+    try Credential(
+        email: EmailAddress("attendee@example.com"),
+        ticketReference: TicketReference("ABCD-12")
+    )
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientSpy.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientSpy.swift
@@ -1,0 +1,23 @@
+import AuthenticationFeature
+import Foundation
+
+actor HTTPClientSpy {
+    private(set) var requests: [URLRequest] = []
+    private let data: Data
+    private let statusCode: Int
+
+    init(respondingWith data: Data, statusCode: Int) {
+        self.data = data
+        self.statusCode = statusCode
+    }
+
+    nonisolated var httpClient: HTTPClient {
+        HTTPClient { request in await self.handle(request) }
+    }
+
+    private func handle(_ request: URLRequest) -> (Data, HTTPURLResponse) {
+        requests.append(request)
+        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        return (data, response)
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
@@ -1,0 +1,45 @@
+import AuthenticationFeature
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct HTTPClientURLSessionTests {
+    private let url = URL(string: "https://example.com")!
+
+    @Test func whenServerResponds_shouldReturnDataAndHTTPResponse() async throws {
+        let expected = Data("hello".utf8)
+        URLProtocolStub.stub(
+            data: expected,
+            response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+            error: nil
+        )
+        let sut = HTTPClient.urlSession(URLProtocolStub.session())
+
+        let (data, response) = try await sut.send(URLRequest(url: url))
+
+        #expect(data == expected)
+        #expect(response.statusCode == 200)
+    }
+
+    @Test func whenTransportFails_shouldThrow() async {
+        URLProtocolStub.stub(data: nil, response: nil, error: URLError(.notConnectedToInternet))
+        let sut = HTTPClient.urlSession(URLProtocolStub.session())
+
+        await #expect(throws: (any Error).self) {
+            _ = try await sut.send(URLRequest(url: url))
+        }
+    }
+
+    @Test func whenResponseIsNotHTTP_shouldThrow() async {
+        URLProtocolStub.stub(
+            data: Data(),
+            response: URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil),
+            error: nil
+        )
+        let sut = HTTPClient.urlSession(URLProtocolStub.session())
+
+        await #expect(throws: (any Error).self) {
+            _ = try await sut.send(URLRequest(url: url))
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionTokenTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionTokenTests.swift
@@ -6,4 +6,9 @@ import Testing
         let token = SessionToken("jwt-abc-123")
         #expect(!String(describing: token).contains("jwt-abc-123"))
     }
+
+    @Test func whenCreatedWithSurroundingWhitespace_shouldTrim() {
+        let sut = SessionToken("  jwt-abc-123\n")
+        #expect(String(sut) == "jwt-abc-123")
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLProtocolStub.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLProtocolStub.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+final class URLProtocolStub: URLProtocol {
+    struct Stub {
+        let data: Data?
+        let response: URLResponse?
+        let error: Error?
+    }
+
+    nonisolated(unsafe) static var stub: Stub?
+
+    static func stub(data: Data?, response: URLResponse?, error: Error?) {
+        stub = Stub(data: data, response: response, error: error)
+    }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        if let error = Self.stub?.error {
+            client?.urlProtocol(self, didFailWithError: error)
+        } else {
+            if let data = Self.stub?.data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            if let response = Self.stub?.response {
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Why
The real network layer and live sign-in, behind our own `HTTPClient` seam.

## Notes
- We wrap `URLSession` behind a seam we own and test that implementation with a `URLProtocolStub`. Higher layers stub the seam.