### PR TITLE
feat(AuthenticationFeature): add auth HTTP middleware

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Authenticated.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Authenticated.swift
@@ -1,0 +1,15 @@
+import Dependencies
+import Foundation
+
+extension HTTPClient {
+    package func authenticated() -> HTTPClient {
+        HTTPClient { request in
+            @Dependency(\.sessionStore) var sessionStore
+            var request = request
+            if let session = try? await sessionStore.current() {
+                request.setValue("Bearer \(String(session.token))", forHTTPHeaderField: "Authorization")
+            }
+            return try await self.send(request)
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+SessionExpiry.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+SessionExpiry.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension HTTPClient {
+    package func interceptingSessionExpiry(onExpiry: @escaping @Sendable () async -> Void) -> HTTPClient {
+        HTTPClient { request in
+            let (data, response) = try await self.send(request)
+            if response.statusCode == 401, request.value(forHTTPHeaderField: "Authorization") != nil {
+                await onExpiry()
+            }
+            return (data, response)
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientAuthenticatedTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientAuthenticatedTests.swift
@@ -1,0 +1,36 @@
+import AuthenticationFeature
+import Dependencies
+import Foundation
+import Testing
+
+@Suite struct HTTPClientAuthenticatedTests {
+    private let url = URL(string: "https://example.com")!
+
+    @Test func whenSessionExists_shouldAttachBearer() async throws {
+        let spy = HTTPClientSpy(respondingWith: Data(), statusCode: 200)
+        let store = InMemorySessionStore(stored: Session(token: SessionToken("jwt-abc-123")))
+
+        _ = try await withDependencies {
+            $0.sessionStore = store.sessionStore
+        } operation: {
+            try await spy.httpClient.authenticated().send(URLRequest(url: url))
+        }
+
+        let request = try #require(await spy.requests.first)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer jwt-abc-123")
+    }
+
+    @Test func whenNoSession_shouldNotAttachBearer() async throws {
+        let spy = HTTPClientSpy(respondingWith: Data(), statusCode: 200)
+        let store = InMemorySessionStore()
+
+        _ = try await withDependencies {
+            $0.sessionStore = store.sessionStore
+        } operation: {
+            try await spy.httpClient.authenticated().send(URLRequest(url: url))
+        }
+
+        let request = try #require(await spy.requests.first)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientSessionExpiryTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientSessionExpiryTests.swift
@@ -1,0 +1,47 @@
+import AuthenticationFeature
+import Foundation
+import Testing
+
+@Suite struct HTTPClientSessionExpiryTests {
+    private let url = URL(string: "https://example.com")!
+
+    @Test func when401OnBearerRequest_shouldInvokeReaction() async throws {
+        let reaction = ReactionSpy()
+        var request = URLRequest(url: url)
+        request.setValue("Bearer x", forHTTPHeaderField: "Authorization")
+
+        _ = try await HTTPClient.responding(with: Data(), statusCode: 401)
+            .interceptingSessionExpiry { await reaction.record() }
+            .send(request)
+
+        #expect(await reaction.count == 1)
+    }
+
+    @Test func when401WithoutBearer_shouldNotInvokeReaction() async throws {
+        let reaction = ReactionSpy()
+        let request = URLRequest(url: url)
+
+        _ = try await HTTPClient.responding(with: Data(), statusCode: 401)
+            .interceptingSessionExpiry { await reaction.record() }
+            .send(request)
+
+        #expect(await reaction.count == 0)
+    }
+
+    @Test func whenSuccessOnBearerRequest_shouldNotInvokeReaction() async throws {
+        let reaction = ReactionSpy()
+        var request = URLRequest(url: url)
+        request.setValue("Bearer x", forHTTPHeaderField: "Authorization")
+
+        _ = try await HTTPClient.responding(with: Data(), statusCode: 200)
+            .interceptingSessionExpiry { await reaction.record() }
+            .send(request)
+
+        #expect(await reaction.count == 0)
+    }
+}
+
+private actor ReactionSpy {
+    private(set) var count = 0
+    func record() { count += 1 }
+}


### PR DESCRIPTION
## What
Two composable `(HTTPClient) -> HTTPClient` middleware transforms:
- `.authenticated()` — attaches `Authorization: Bearer` from the `SessionStore` when signed in (proceeds tokenless otherwise).
- `.interceptingSessionExpiry(onExpiry:)` — on a `401` to a bearer-carrying request, fires an injected reaction.

## Why
Cross-cutting auth concerns as reusable middleware. The pipeline is composed at the composition root (TBD), which is where the `onExpiry` reaction is bound to sign-out. Keeps policy out of the infrastructure adapter.