### PR TITLE
fix(AuthenticationUI): keep the account UI in step with sign-out

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Application/FetchProfile.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Application/FetchProfile.swift
@@ -7,7 +7,7 @@ public struct FetchProfile: Sendable {
         self.perform = perform
     }
 
-    public func callAsFunction() async throws -> Profile {
+    public func callAsFunction() async throws(AttendeeFetchError) -> Profile {
         try await perform()
     }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileTests.swift
@@ -27,6 +27,23 @@ import Testing
             }
         }
     }
+
+    @Test func whenRepositoryFails_shouldThrowExhaustivelyCatchableError() async {
+        var caught: AttendeeFetchError?
+
+        await withDependencies {
+            $0.attendeeRepository = .failing(with: .unauthorized)
+        } operation: {
+            let sut = FetchProfile.liveValue
+            do throws(AttendeeFetchError) {
+                _ = try await sut()
+            } catch {
+                caught = error
+            }
+        }
+
+        #expect(caught == .unauthorized)
+    }
 }
 
 private func makeAttendee() throws -> Attendee {

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountDetailView/AccountDetailView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountDetailView/AccountDetailView.swift
@@ -3,6 +3,8 @@ import Foundation
 import SwiftUI
 
 package struct AccountDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+
     private let profile: Profile
     private let signOut: @MainActor () async -> Void
 
@@ -42,7 +44,10 @@ package struct AccountDetailView: View {
             }
 
             Section {
-                SignOutButton(signOut: signOut)
+                SignOutButton {
+                    await signOut()
+                    dismiss()
+                }
             }
         }
         .navigationTitle(profile.name.formatted())

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView+ViewModel.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView+ViewModel.swift
@@ -10,6 +10,7 @@ extension AccountView {
         @Dependency(\.authStatus) private var authStatus
 
         package private(set) var state: AccountViewState = .loading
+        private var signInRequired = false
 
         package init() {}
 
@@ -18,8 +19,18 @@ extension AccountView {
             case .signedIn(let proof):
                 state = .signedIn(proof)
             case .signedOut:
-                state = .signedOut
+                state = .signedOut(signInRequired: signInRequired)
             }
+        }
+
+        package func signedOut(_ reason: SignOutReason) async {
+            signInRequired = reason == .signInRequired
+            await load()
+        }
+
+        package func signedIn() async {
+            signInRequired = false
+            await load()
         }
     }
 }

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView+ViewModel.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView+ViewModel.swift
@@ -6,16 +6,10 @@ extension AccountView {
     @MainActor
     @Observable
     package final class ViewModel {
-        package enum State: Equatable {
-            case loading
-            case signedOut
-            case signedIn(SignedInProof)
-        }
-
         @ObservationIgnored
         @Dependency(\.authStatus) private var authStatus
 
-        package private(set) var state: State = .loading
+        package private(set) var state: AccountViewState = .loading
 
         package init() {}
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView.swift
@@ -7,49 +7,15 @@ public struct AccountView: View {
     public init() {}
 
     public var body: some View {
-        content
-            .task { await viewModel.load() }
-    }
-
-    @ViewBuilder private var content: some View {
-        switch viewModel.state {
-        case .loading:
-            NameplatePlaceholder()
-        case .signedOut:
-            signedOut
-        case .signedIn:
-            ProfileCard(onSignOut: { Task { await viewModel.load() } })
-        }
-    }
-
-    private var signedOut: some View {
-        NavigationLink {
-            SignInDestination(onSignedIn: { Task { await viewModel.load() } })
-        } label: {
-            Nameplate(Text("Sign In"), role: .unresolved) {
-                Avatar(url: nil) {
-                    Image(systemName: "person")
-                }
-            }
-        }
+        AccountViewContent(
+            state: viewModel.state,
+            onSignOut: { Task { await viewModel.load() } },
+            onSignedIn: { Task { await viewModel.load() } }
+        )
+        .task { await viewModel.load() }
     }
 }
 
-private struct SignInDestination: View {
-    @Environment(\.dismiss) private var dismiss
-
-    let onSignedIn: @MainActor () -> Void
-
-    var body: some View {
-        SignInView(onSignedIn: {
-            onSignedIn()
-            dismiss()
-        })
-        .navigationTitle("Sign In")
-    }
-}
-
-#if DEBUG
 #Preview {
     NavigationStack {
         List {
@@ -57,4 +23,3 @@ private struct SignInDestination: View {
         }
     }
 }
-#endif

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView.swift
@@ -9,8 +9,8 @@ public struct AccountView: View {
     public var body: some View {
         AccountViewContent(
             state: viewModel.state,
-            onSignOut: { _ in Task { await viewModel.load() } },
-            onSignedIn: { Task { await viewModel.load() } }
+            onSignOut: { reason in Task { await viewModel.signedOut(reason) } },
+            onSignedIn: { Task { await viewModel.signedIn() } }
         )
         .task { await viewModel.load() }
     }

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountView.swift
@@ -9,7 +9,7 @@ public struct AccountView: View {
     public var body: some View {
         AccountViewContent(
             state: viewModel.state,
-            onSignOut: { Task { await viewModel.load() } },
+            onSignOut: { _ in Task { await viewModel.load() } },
             onSignedIn: { Task { await viewModel.load() } }
         )
         .task { await viewModel.load() }

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewContent.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewContent.swift
@@ -17,6 +17,19 @@ package struct AccountViewContent: View {
     }
 
     package var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            content
+
+            if case .signedOut(signInRequired: true) = state {
+                Text("Your sign-in expired. Sign in again to see your account details.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
         switch state {
         case .loading:
             NameplatePlaceholder()
@@ -58,7 +71,8 @@ private struct SignInDestination: View {
     NavigationStack {
         List {
             AccountViewContent(state: .loading, onSignOut: { _ in }, onSignedIn: {})
-            AccountViewContent(state: .signedOut, onSignOut: { _ in }, onSignedIn: {})
+            AccountViewContent(state: .signedOut(signInRequired: false), onSignOut: { _ in }, onSignedIn: {})
+            AccountViewContent(state: .signedOut(signInRequired: true), onSignOut: { _ in }, onSignedIn: {})
         }
     }
 }
@@ -66,7 +80,7 @@ private struct SignInDestination: View {
 #Preview("Signed out, compact") {
     NavigationStack {
         List {
-            AccountViewContent(state: .signedOut, onSignOut: { _ in }, onSignedIn: {})
+            AccountViewContent(state: .signedOut(signInRequired: true), onSignOut: { _ in }, onSignedIn: {})
         }
         .nameplateStyle(.compact)
     }

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewContent.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewContent.swift
@@ -3,12 +3,12 @@ import SwiftUI
 
 package struct AccountViewContent: View {
     private let state: AccountViewState
-    private let onSignOut: @MainActor () -> Void
+    private let onSignOut: @MainActor (SignOutReason) -> Void
     private let onSignedIn: @MainActor () -> Void
 
     package init(
         state: AccountViewState,
-        onSignOut: @escaping @MainActor () -> Void,
+        onSignOut: @escaping @MainActor (SignOutReason) -> Void,
         onSignedIn: @escaping @MainActor () -> Void
     ) {
         self.state = state
@@ -57,8 +57,8 @@ private struct SignInDestination: View {
 #Preview("Every state") {
     NavigationStack {
         List {
-            AccountViewContent(state: .loading, onSignOut: {}, onSignedIn: {})
-            AccountViewContent(state: .signedOut, onSignOut: {}, onSignedIn: {})
+            AccountViewContent(state: .loading, onSignOut: { _ in }, onSignedIn: {})
+            AccountViewContent(state: .signedOut, onSignOut: { _ in }, onSignedIn: {})
         }
     }
 }
@@ -66,7 +66,7 @@ private struct SignInDestination: View {
 #Preview("Signed out, compact") {
     NavigationStack {
         List {
-            AccountViewContent(state: .signedOut, onSignOut: {}, onSignedIn: {})
+            AccountViewContent(state: .signedOut, onSignOut: { _ in }, onSignedIn: {})
         }
         .nameplateStyle(.compact)
     }

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewContent.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewContent.swift
@@ -1,0 +1,73 @@
+import AuthenticationFeature
+import SwiftUI
+
+package struct AccountViewContent: View {
+    private let state: AccountViewState
+    private let onSignOut: @MainActor () -> Void
+    private let onSignedIn: @MainActor () -> Void
+
+    package init(
+        state: AccountViewState,
+        onSignOut: @escaping @MainActor () -> Void,
+        onSignedIn: @escaping @MainActor () -> Void
+    ) {
+        self.state = state
+        self.onSignOut = onSignOut
+        self.onSignedIn = onSignedIn
+    }
+
+    package var body: some View {
+        switch state {
+        case .loading:
+            NameplatePlaceholder()
+        case .signedOut:
+            signedOut
+        case .signedIn:
+            ProfileCard(onSignOut: onSignOut)
+        }
+    }
+
+    private var signedOut: some View {
+        NavigationLink {
+            SignInDestination(onSignedIn: onSignedIn)
+        } label: {
+            Nameplate(Text("Sign In"), role: .unresolved) {
+                Avatar(url: nil) {
+                    Image(systemName: "person")
+                }
+            }
+        }
+    }
+}
+
+private struct SignInDestination: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let onSignedIn: @MainActor () -> Void
+
+    var body: some View {
+        SignInView(onSignedIn: {
+            onSignedIn()
+            dismiss()
+        })
+        .navigationTitle("Sign In")
+    }
+}
+
+#Preview("Every state") {
+    NavigationStack {
+        List {
+            AccountViewContent(state: .loading, onSignOut: {}, onSignedIn: {})
+            AccountViewContent(state: .signedOut, onSignOut: {}, onSignedIn: {})
+        }
+    }
+}
+
+#Preview("Signed out, compact") {
+    NavigationStack {
+        List {
+            AccountViewContent(state: .signedOut, onSignOut: {}, onSignedIn: {})
+        }
+        .nameplateStyle(.compact)
+    }
+}

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewState.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewState.swift
@@ -1,0 +1,7 @@
+import AuthenticationFeature
+
+package enum AccountViewState: Equatable {
+    case loading
+    case signedOut
+    case signedIn(SignedInProof)
+}

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewState.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountView/AccountViewState.swift
@@ -2,6 +2,6 @@ import AuthenticationFeature
 
 package enum AccountViewState: Equatable {
     case loading
-    case signedOut
+    case signedOut(signInRequired: Bool)
     case signedIn(SignedInProof)
 }

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Avatar.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Avatar.swift
@@ -90,7 +90,6 @@ package extension Avatar where Content == AvatarImage, Placeholder == Failure {
     }
 }
 
-#if DEBUG
 #Preview("Avatar styles") {
     VStack(spacing: 24) {
         HStack(spacing: 16) {
@@ -122,4 +121,3 @@ package extension Avatar where Content == AvatarImage, Placeholder == Failure {
     }
     .padding()
 }
-#endif

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Nameplate.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Nameplate.swift
@@ -54,7 +54,6 @@ package extension Nameplate where Title == Text, Detail == EmptyView {
     }
 }
 
-#if DEBUG
 private let previewAvatarURL = URL(string: "https://example.com/missing.png")
 
 #Preview("Prominent") {
@@ -116,4 +115,3 @@ private let previewAvatarURL = URL(string: "https://example.com/missing.png")
         }
     }
 }
-#endif

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCard+ViewModel.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCard+ViewModel.swift
@@ -12,24 +12,29 @@ extension ProfileCard {
         @Dependency(\.signOut) private var _signOut
 
         package private(set) var state: ProfileCardState = .loading
-        private let onSignOut: @MainActor () -> Void
+        private let onSignOut: @MainActor (SignOutReason) -> Void
 
-        package init(onSignOut: @escaping @MainActor () -> Void) {
+        package init(onSignOut: @escaping @MainActor (SignOutReason) -> Void) {
             self.onSignOut = onSignOut
         }
 
         package func load() async {
             state = .loading
-            do {
+            do throws(AttendeeFetchError) {
                 state = .loaded(try await fetchProfile())
             } catch {
-                state = .failed
+                switch error {
+                case .unauthorized:
+                    onSignOut(.signInRequired)
+                case .unknown:
+                    state = .failed
+                }
             }
         }
 
         package func signOut() async {
             try? await _signOut()
-            onSignOut()
+            onSignOut(.userRequested)
         }
     }
 }

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCard.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCard.swift
@@ -4,7 +4,7 @@ import SwiftUI
 package struct ProfileCard: View {
     @State private var viewModel: ViewModel
 
-    package init(onSignOut: @escaping @MainActor () -> Void) {
+    package init(onSignOut: @escaping @MainActor (SignOutReason) -> Void) {
         _viewModel = State(wrappedValue: ViewModel(onSignOut: onSignOut))
     }
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCardContent.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCardContent.swift
@@ -45,7 +45,7 @@ package struct ProfileCardContent: View {
 
     private var failed: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("We couldn't load your profile.")
+            Text("We couldn't load your account.")
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/SignOutReason.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/SignOutReason.swift
@@ -1,0 +1,4 @@
+package enum SignOutReason: Equatable {
+    case userRequested
+    case signInRequired
+}

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/AccountView/AccountViewModelTests.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/AccountView/AccountViewModelTests.swift
@@ -25,7 +25,45 @@ import Testing
 
             await sut.load()
 
-            #expect(sut.state == .signedOut)
+            #expect(sut.state == .signedOut(signInRequired: false))
+        }
+    }
+
+    @Test func whenSignedOutBecauseSignInIsRequired_shouldRequireSignIn() async {
+        await withDependencies {
+            $0.authStatus = AuthStatus { .signedOut }
+        } operation: {
+            let sut = AccountView.ViewModel()
+
+            await sut.signedOut(.signInRequired)
+
+            #expect(sut.state == .signedOut(signInRequired: true))
+        }
+    }
+
+    @Test func whenUserRequestedSignOut_shouldNotRequireSignIn() async {
+        await withDependencies {
+            $0.authStatus = AuthStatus { .signedOut }
+        } operation: {
+            let sut = AccountView.ViewModel()
+
+            await sut.signedOut(.userRequested)
+
+            #expect(sut.state == .signedOut(signInRequired: false))
+        }
+    }
+
+    @Test func whenSignedInAgain_shouldStopRequiringSignIn() async {
+        let proof = SignedInProof()
+        await withDependencies {
+            $0.authStatus = AuthStatus { .signedIn(proof) }
+        } operation: {
+            let sut = AccountView.ViewModel()
+            await sut.signedOut(.signInRequired)
+
+            await sut.signedIn()
+
+            #expect(sut.state == .signedIn(proof))
         }
     }
 

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/ProfileCard/ProfileCardViewModelTests.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/ProfileCard/ProfileCardViewModelTests.swift
@@ -11,7 +11,7 @@ import Testing
         await withDependencies {
             $0.fetchProfile = FetchProfile { profile }
         } operation: {
-            let sut = ProfileCard.ViewModel(onSignOut: {})
+            let sut = ProfileCard.ViewModel(onSignOut: { _ in })
 
             await sut.load()
 
@@ -25,7 +25,7 @@ import Testing
                 throw .unknown
             }
         } operation: {
-            let sut = ProfileCard.ViewModel(onSignOut: {})
+            let sut = ProfileCard.ViewModel(onSignOut: { _ in })
 
             await sut.load()
 
@@ -33,16 +33,53 @@ import Testing
         }
     }
 
-    @Test func whenSignOutRequested_shouldSignalSignOut() async {
-        await confirmation("signals sign out") { signedOut in
+    @Test func whenCredentialsAreRejected_shouldRequireSignIn() async {
+        var captured: SignOutReason?
+
+        await withDependencies {
+            $0.fetchProfile = FetchProfile { () async throws(AttendeeFetchError) -> Profile in
+                throw .unauthorized
+            }
+        } operation: {
+            let sut = ProfileCard.ViewModel(onSignOut: { captured = $0 })
+
+            await sut.load()
+
+            #expect(sut.state != .failed)
+        }
+
+        #expect(captured == .signInRequired)
+    }
+
+    @Test func whenCredentialsAreRejected_shouldNotSignOutAgain() async {
+        await confirmation("signs out", expectedCount: 0) { signedOut in
             await withDependencies {
-                $0.signOut = SignOut {}
+                $0.fetchProfile = FetchProfile { () async throws(AttendeeFetchError) -> Profile in
+                    throw .unauthorized
+                }
+                $0.signOut = SignOut { signedOut() }
             } operation: {
-                let sut = ProfileCard.ViewModel(onSignOut: { signedOut() })
+                let sut = ProfileCard.ViewModel(onSignOut: { _ in })
+
+                await sut.load()
+            }
+        }
+    }
+
+    @Test func whenSignOutRequested_shouldSignalUserRequestedSignOut() async {
+        var captured: SignOutReason?
+
+        await confirmation("signs out") { signedOut in
+            await withDependencies {
+                $0.signOut = SignOut { signedOut() }
+            } operation: {
+                let sut = ProfileCard.ViewModel(onSignOut: { captured = $0 })
 
                 await sut.signOut()
             }
         }
+
+        #expect(captured == .userRequested)
     }
 
     @Test func whenLoading_shouldNotLeak() async {
@@ -51,7 +88,7 @@ import Testing
         await withDependencies {
             $0.fetchProfile = FetchProfile { profile }
         } operation: {
-            let sut = ProfileCard.ViewModel(onSignOut: {})
+            let sut = ProfileCard.ViewModel(onSignOut: { _ in })
             weakSUT = sut
             await sut.load()
         }


### PR DESCRIPTION
# fix(AuthenticationUI): keep the account UI in step with sign-out

## Problem

* A rejected credential (HTTP 401) cleared the stored token, but nothing told the UI. The Settings row still looked signed in, showing "We couldn't load your profile" with a Try Again button that could never succeed.
* Signing out from the account detail screen left that screen on top. Account details stayed readable after the user had signed out.
* `AccountView` owned its own fetch, so its states could not be previewed without stubbing a dependency.

## Solution

* `FetchProfile` now throws `AttendeeFetchError`, so a rejected credential reaches the view model intact.
* `ProfileCard` reports sign-out upwards with a reason: the user asked, or they need to sign in again. The UI learns nothing about how signing in works.
* When the app signs a user out, the account row explains why. When the user signs themselves out, it defaults to standard copy.
* `AccountView` is split into a shell that fetches and a content view that is a pure function of state, matching `ProfileCard`. Every state now previews with no dependency stubbing.
* The notice lives inside the signed-out case, so a signed-in state with a pending notice cannot be built.
* `AccountDetailView` dismisses itself on sign-out.

## Screenshots

TODO

| Signed out | Signed out, after the app signed you out | Detail screen | Failed load |
|---|---|---|---|
| | | | |

## How to test

### Automated
```bash
git fetch && git checkout fix/authentication-sign-out-sync

cd Packages/AuthenticationFeature && swift test
cd ../AuthenticationUI && swift test
swift build -c release
```

### Manual

* Sign in with a real email and ticket reference. The card shows your name and email.
* Open the account detail screen, then sign out. The detail screen closes and the row goes back to "Sign In", with **no** explanation.
* To check the 401 path, temporarily make `SessionStore.current` return a junk token so the profile request comes back 401. The card disappears, the row goes back to "Sign In", and the explanation **does** appear. Revert the edit afterwards.
* Open `AccountViewContent.swift` in Xcode previews to see all three states side by side.
