### PR TITLE
ci: pin the runner image and select Xcode explicitly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,26 +6,33 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  DEVELOPER_DIR: /Applications/Xcode_26.0.1.app/Contents/Developer
-
 jobs:
   build-swiftleeds:
     name: Build SwiftLeeds (DEBUG)
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout iOS Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.5'
 
       - name: Build SwiftLeeds via Fastlane
         run: fastlane build_swiftleeds
 
   build-kotlinleeds:
     name: Build KotlinLeeds (DEBUG)
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout iOS Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.5'
 
       - name: Build KotlinLeeds via Fastlane
         run: fastlane build_kotlinleeds


### PR DESCRIPTION
## Problem

* Every CI build has failed since 8 August, on every branch and both jobs.
* The last green run was 30 April. Nothing has pushed to `main` since, so `main` is broken too — it just has not run yet.
* `macos-latest` moved to the `macos-26` image on 28 July. That image ships Xcode 26.5 and 26.6.
* Our workflow hardcoded `DEVELOPER_DIR` to `Xcode_26.0.1`, which the new image no longer provisions.
* Device builds failed with `iOS 26.0 is not installed`. Simulator builds failed with `No simulator runtime version from ["23C54", "23E254a", "23F77"] available to use with iphonesimulator SDK version 23A339`. Both are the same fault: the pinned Xcode's SDK does not match anything installed.
* This is not caused by any branch. `.github/` and `fastlane/` are byte-identical between `main` and the feature branches.

## Solution

* Pin `runs-on` to `macos-26` instead of `macos-latest`, so a GitHub image roll cannot break every branch at once with no commit to blame.
* Replace the hardcoded `DEVELOPER_DIR` with `maxim-lobanov/setup-xcode`, pinned to 26.5. A missing Xcode now fails immediately with a clear message, instead of failing five minutes into a build.
* Bump `actions/checkout` from v2 to v4.

## How to test

* This PR is its own test: the workflow runs on pull requests targeting `main`, so both jobs going green here is the verification.
* Check the run log shows `Xcode 26.5` selected and no `DEVELOPER_DIR` override.
* Once merged, rebase the feature chain on `main` and their builds should go green without touching any feature code.
