### PR TITLE
ci: build every pull request, not only those targeting main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   build-swiftleeds:


### PR DESCRIPTION
## Problem

* The `pull_request` trigger filtered on `branches: [ main ]`, which matches the PR's **base** branch.
* Our feature work is stacked — each PR targets its parent, not `main`.
* So most of the chain got no CI. `feat/attendee-qr-code`, `fix/authentication-sign-out-sync`, `feat/authentication-app-wiring` and `feat/authentication-ui` have **never had a single run**.
* They were not failing. They were not being built at all, which is worse — it looks green because nothing reported.

## Solution

* Drop the `branches` filter from the `pull_request` trigger so every PR is built whatever its base.
* `push` keeps its `branches: [ main ]` filter, so pushes to feature branches do not double up with their PR runs.
* The repo is public, so the extra runs cost nothing.

## How to test

* This PR targets `main`, so it runs either way.
* The real check comes after merge: open or update any PR in the stack and confirm both jobs now appear on it.
