### PR TITLE
feat(LogKit): add a destination-agnostic logging seam

### DIFF
--- a/Packages/LogKit/Package.swift
+++ b/Packages/LogKit/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "LogKit",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v13),
+    ],
+    products: [
+        .library(name: "LogKit", targets: ["LogKit"]),
+    ],
+    targets: [
+        .target(name: "LogKit"),
+        .testTarget(
+            name: "LogKitTests",
+            dependencies: ["LogKit"]
+        ),
+    ]
+)

--- a/Packages/LogKit/Package.swift
+++ b/Packages/LogKit/Package.swift
@@ -10,12 +10,21 @@ let package = Package(
     ],
     products: [
         .library(name: "LogKit", targets: ["LogKit"]),
+        .library(name: "LogKitUnified", targets: ["LogKitUnified"]),
     ],
     targets: [
         .target(name: "LogKit"),
+        .target(
+            name: "LogKitUnified",
+            dependencies: ["LogKit"]
+        ),
         .testTarget(
             name: "LogKitTests",
             dependencies: ["LogKit"]
+        ),
+        .testTarget(
+            name: "LogKitUnifiedTests",
+            dependencies: ["LogKitUnified"]
         ),
     ]
 )

--- a/Packages/LogKit/Sources/LogKit/FieldName.swift
+++ b/Packages/LogKit/Sources/LogKit/FieldName.swift
@@ -1,0 +1,20 @@
+/// The name of a single logged field.
+public struct FieldName: Hashable, Sendable, ExpressibleByStringLiteral {
+    private let storage: String
+
+    public init(_ value: String) {
+        self.storage = value
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+
+    fileprivate var stringValue: String { storage }
+}
+
+extension String {
+    public init(_ name: FieldName) {
+        self = name.stringValue
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/Log+Combine.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Combine.swift
@@ -1,0 +1,21 @@
+extension Log {
+    /// A log that accepts every event and writes it nowhere.
+    ///
+    /// Use it to include a destination conditionally without branching, or to
+    /// silence logging entirely. Combining with it changes nothing.
+    public static let none = Log { _ in }
+
+    /// Writes each event to every given log, in order.
+    public static func combine(_ logs: [Log]) -> Log {
+        Log { event in
+            for log in logs {
+                log.write(event)
+            }
+        }
+    }
+
+    /// Writes each event to both logs.
+    public func combined(with other: Log) -> Log {
+        .combine([self, other])
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/Log+Combine.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Combine.swift
@@ -1,17 +1,22 @@
 extension Log {
-    /// A log that accepts every event and writes it nowhere.
+    /// A log that writes nowhere and accepts nothing.
     ///
     /// Use it to include a destination conditionally without branching, or to
     /// silence logging entirely. Combining with it changes nothing.
-    public static let none = Log { _ in }
+    public static let none = Log(accepts: { _, _ in false }, write: { _ in })
 
     /// Writes each event to every given log, in order.
     public static func combine(_ logs: [Log]) -> Log {
-        Log { event in
-            for log in logs {
-                log.write(event)
+        Log(
+            accepts: { level, category in
+                logs.contains { $0.accepts(level, category) }
+            },
+            write: { event in
+                for log in logs {
+                    log.write(event)
+                }
             }
-        }
+        )
     }
 
     /// Writes each event to both logs.

--- a/Packages/LogKit/Sources/LogKit/Log+Transform.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Transform.swift
@@ -1,12 +1,9 @@
 extension Log {
-    /// Rewrites each event on its way in.
+    /// Rewrites each event on its way in. A log consumes events rather than producing them,
+    /// so the transform runs before this log sees anything.
     ///
-    /// A log consumes events rather than producing them, so mapping runs
-    /// against the input: the transform happens before this log sees anything.
-    ///
-    /// The transform may change level or category, which cannot be known ahead
-    /// of the event, so the result accepts everything and lets `write` decide.
-    /// Use ``mappingFields(_:)`` when only fields change.
+    /// The transform may change level or category, so the result accepts everything and lets
+    /// `write` decide. Use ``mappingFields(_:)`` when only fields change.
     public func pullback(_ transform: @escaping @Sendable (LogEvent) -> LogEvent) -> Log {
         Log { event in write(transform(event)) }
     }

--- a/Packages/LogKit/Sources/LogKit/Log+Transform.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Transform.swift
@@ -3,60 +3,93 @@ extension Log {
     ///
     /// A log consumes events rather than producing them, so mapping runs
     /// against the input: the transform happens before this log sees anything.
+    ///
+    /// The transform may change level or category, which cannot be known ahead
+    /// of the event, so the result accepts everything and lets `write` decide.
+    /// Use ``mappingFields(_:)`` when only fields change.
     public func pullback(_ transform: @escaping @Sendable (LogEvent) -> LogEvent) -> Log {
         Log { event in write(transform(event)) }
     }
 
+    /// Rewrites only the fields, keeping the level and category, so the cheap
+    /// pre-check still applies.
+    public func mappingFields(_ transform: @escaping @Sendable (LogFields) -> LogFields) -> Log {
+        Log(accepts: accepts) { event in
+            write(
+                LogEvent(
+                    level: event.level,
+                    category: event.category,
+                    message: event.message,
+                    fields: transform(event.fields),
+                    source: event.source
+                )
+            )
+        }
+    }
+
     /// Passes on only the events satisfying the predicate.
+    ///
+    /// The predicate needs a whole event, so it cannot inform the pre-check.
     public func filtered(by isIncluded: @escaping @Sendable (LogEvent) -> Bool) -> Log {
-        Log { event in
+        Log(accepts: accepts) { event in
             guard isIncluded(event) else { return }
             write(event)
         }
     }
 
-    /// Drops anything less severe than `level`.
+    /// Drops anything less severe than `level`, before the event is built.
     public func atLeast(_ level: LogLevel) -> Log {
-        filtered { $0.level >= level }
+        Log(
+            accepts: { eventLevel, category in
+                eventLevel >= level && accepts(eventLevel, category)
+            },
+            write: { event in
+                guard event.level >= level else { return }
+                write(event)
+            }
+        )
     }
 
-    /// Passes on only the given categories.
+    /// Passes on only the given categories, before the event is built.
     public func only(_ categories: Set<LogCategory>) -> Log {
-        filtered { categories.contains($0.category) }
+        Log(
+            accepts: { level, category in
+                categories.contains(category) && accepts(level, category)
+            },
+            write: { event in
+                guard categories.contains(event.category) else { return }
+                write(event)
+            }
+        )
     }
 
     /// Removes secret fields before this log sees them.
     ///
     /// Put it in front of any destination that leaves the device.
     public func droppingSecrets() -> Log {
-        pullback { event in
-            LogEvent(
-                level: event.level,
-                category: event.category,
-                message: event.message,
-                fields: LogFields(event.fields.filter { $0.sensitivity != .secret }),
-                source: event.source
-            )
+        mappingFields { fields in
+            LogFields(fields.filter { $0.sensitivity != .secret })
         }
     }
 
     /// Adds context to every event, after the event's own fields.
     public func enriching(with fields: @escaping @Sendable () -> LogFields) -> Log {
-        pullback { event in
-            LogEvent(
-                level: event.level,
-                category: event.category,
-                message: event.message,
-                fields: event.fields.appending(contentsOf: fields()),
-                source: event.source
-            )
-        }
+        mappingFields { $0.appending(contentsOf: fields()) }
     }
 
     /// Writes only while consent is given.
     ///
-    /// Checked per event, so withdrawing consent takes effect immediately.
+    /// Checked per event, so withdrawing consent takes effect immediately, and
+    /// checked in the pre-check too, so a withheld consent costs nothing.
     public func consented(by isGranted: @escaping @Sendable () -> Bool) -> Log {
-        filtered { _ in isGranted() }
+        Log(
+            accepts: { level, category in
+                isGranted() && accepts(level, category)
+            },
+            write: { event in
+                guard isGranted() else { return }
+                write(event)
+            }
+        )
     }
 }

--- a/Packages/LogKit/Sources/LogKit/Log+Transform.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Transform.swift
@@ -1,0 +1,62 @@
+extension Log {
+    /// Rewrites each event on its way in.
+    ///
+    /// A log consumes events rather than producing them, so mapping runs
+    /// against the input: the transform happens before this log sees anything.
+    public func pullback(_ transform: @escaping @Sendable (LogEvent) -> LogEvent) -> Log {
+        Log { event in write(transform(event)) }
+    }
+
+    /// Passes on only the events satisfying the predicate.
+    public func filtered(by isIncluded: @escaping @Sendable (LogEvent) -> Bool) -> Log {
+        Log { event in
+            guard isIncluded(event) else { return }
+            write(event)
+        }
+    }
+
+    /// Drops anything less severe than `level`.
+    public func atLeast(_ level: LogLevel) -> Log {
+        filtered { $0.level >= level }
+    }
+
+    /// Passes on only the given categories.
+    public func only(_ categories: Set<LogCategory>) -> Log {
+        filtered { categories.contains($0.category) }
+    }
+
+    /// Removes secret fields before this log sees them.
+    ///
+    /// Put it in front of any destination that leaves the device.
+    public func droppingSecrets() -> Log {
+        pullback { event in
+            LogEvent(
+                level: event.level,
+                category: event.category,
+                message: event.message,
+                fields: LogFields(event.fields.filter { $0.sensitivity != .secret }),
+                source: event.source
+            )
+        }
+    }
+
+    /// Adds context to every event, after the event's own fields.
+    public func enriching(with fields: @escaping @Sendable () -> LogFields) -> Log {
+        pullback { event in
+            LogEvent(
+                level: event.level,
+                category: event.category,
+                message: event.message,
+                fields: event.fields.appending(contentsOf: fields()),
+                source: event.source
+            )
+        }
+    }
+
+    /// Writes only while consent is given.
+    ///
+    /// Checked per event, so withdrawing consent takes effect immediately.
+    public func consented(by isGranted: @escaping @Sendable () -> Bool) -> Log {
+        filtered { _ in isGranted() }
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/Log+Write.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Write.swift
@@ -1,0 +1,31 @@
+extension Log {
+    /// Records an event.
+    ///
+    /// `fields` is only evaluated once something would write the event, so a
+    /// log filtered out by level or category costs a single comparison.
+    ///
+    /// The source literals are defaulted here rather than inside
+    /// ``SourceLocation/here(file:function:line:)`` so they expand at the call
+    /// site rather than in this file.
+    public func callAsFunction(
+        _ level: LogLevel,
+        _ category: LogCategory,
+        _ message: LogMessage,
+        fields: @autoclosure @Sendable () -> LogFields = LogFields(),
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        guard accepts(level, category) else { return }
+
+        write(
+            LogEvent(
+                level: level,
+                category: category,
+                message: message,
+                fields: fields(),
+                source: SourceLocation(file: file, function: function, line: line)
+            )
+        )
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/Log+Write.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Write.swift
@@ -1,12 +1,11 @@
 extension Log {
     /// Records an event.
     ///
-    /// `fields` is only evaluated once something would write the event, so a
-    /// log filtered out by level or category costs a single comparison.
+    /// `fields` is only evaluated once something would write the event, so a log filtered out
+    /// by level or category costs a single comparison.
     ///
-    /// The source literals are defaulted here rather than inside
-    /// ``SourceLocation/here(file:function:line:)`` so they expand at the call
-    /// site rather than in this file.
+    /// The source literals must stay in this signature. Moved into a helper's defaults they
+    /// would expand there instead of at the call site.
     public func callAsFunction(
         _ level: LogLevel,
         _ category: LogCategory,

--- a/Packages/LogKit/Sources/LogKit/Log.swift
+++ b/Packages/LogKit/Sources/LogKit/Log.swift
@@ -3,9 +3,24 @@
 /// A destination is a `Log`, and so is any composition of destinations, so
 /// callers only ever hold one type.
 public struct Log: Sendable {
+    /// Whether an event with this level and category would reach anything.
+    ///
+    /// Consulted before an event is built, so a log nobody keeps costs only
+    /// this comparison. Answering `true` is always safe: `write` filters again.
+    public var accepts: @Sendable (LogLevel, LogCategory) -> Bool
+
     public var write: @Sendable (LogEvent) -> Void
 
-    public init(write: @escaping @Sendable (LogEvent) -> Void) {
+    public init(
+        accepts: @escaping @Sendable (LogLevel, LogCategory) -> Bool,
+        write: @escaping @Sendable (LogEvent) -> Void
+    ) {
+        self.accepts = accepts
         self.write = write
+    }
+
+    /// A destination that accepts everything.
+    public init(write: @escaping @Sendable (LogEvent) -> Void) {
+        self.init(accepts: { _, _ in true }, write: write)
     }
 }

--- a/Packages/LogKit/Sources/LogKit/Log.swift
+++ b/Packages/LogKit/Sources/LogKit/Log.swift
@@ -1,0 +1,11 @@
+/// Somewhere events are written.
+///
+/// A destination is a `Log`, and so is any composition of destinations, so
+/// callers only ever hold one type.
+public struct Log: Sendable {
+    public var write: @Sendable (LogEvent) -> Void
+
+    public init(write: @escaping @Sendable (LogEvent) -> Void) {
+        self.write = write
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogCategory.swift
+++ b/Packages/LogKit/Sources/LogKit/LogCategory.swift
@@ -1,0 +1,20 @@
+/// The area of the app an event came from, used to filter and group logs.
+public struct LogCategory: Hashable, Sendable, ExpressibleByStringLiteral {
+    private let storage: String
+
+    public init(_ value: String) {
+        self.storage = value
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+
+    fileprivate var stringValue: String { storage }
+}
+
+extension String {
+    public init(_ category: LogCategory) {
+        self = category.stringValue
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogEvent.swift
+++ b/Packages/LogKit/Sources/LogKit/LogEvent.swift
@@ -1,0 +1,22 @@
+/// Everything recorded about one logged occurrence.
+public struct LogEvent: Hashable, Sendable {
+    public let level: LogLevel
+    public let category: LogCategory
+    public let message: LogMessage
+    public let fields: LogFields
+    public let source: SourceLocation
+
+    public init(
+        level: LogLevel,
+        category: LogCategory,
+        message: LogMessage,
+        fields: LogFields = LogFields(),
+        source: SourceLocation = .here()
+    ) {
+        self.level = level
+        self.category = category
+        self.message = message
+        self.fields = fields
+        self.source = source
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogField.swift
+++ b/Packages/LogKit/Sources/LogKit/LogField.swift
@@ -1,0 +1,30 @@
+/// A single named value in a logged event, carrying how sensitive it is.
+///
+/// A field cannot be built without stating its sensitivity, so an unclassified
+/// value is unrepresentable.
+public struct LogField: Hashable, Sendable {
+    public let name: FieldName
+    public let value: LogValue
+    public let sensitivity: Sensitivity
+
+    private init(name: FieldName, value: LogValue, sensitivity: Sensitivity) {
+        self.name = name
+        self.value = value
+        self.sensitivity = sensitivity
+    }
+
+    /// A value safe to store or transmit anywhere.
+    public static func open(_ name: FieldName, _ value: LogValue) -> LogField {
+        LogField(name: name, value: value, sensitivity: .open)
+    }
+
+    /// A value that may be correlated but never read.
+    public static func hashed(_ name: FieldName, _ value: LogValue) -> LogField {
+        LogField(name: name, value: value, sensitivity: .hashed)
+    }
+
+    /// A value that must never leave the device.
+    public static func secret(_ name: FieldName, _ value: LogValue) -> LogField {
+        LogField(name: name, value: value, sensitivity: .secret)
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogFields.swift
+++ b/Packages/LogKit/Sources/LogKit/LogFields.swift
@@ -1,0 +1,32 @@
+/// An ordered collection of fields.
+///
+/// Order is a property of the type, not a convention: there is no subscript, no
+/// mutation and no way back to the storage, so fields stay in the order the
+/// author wrote them. Grouping for display is a destination's concern.
+public struct LogFields: Hashable, Sendable, ExpressibleByArrayLiteral {
+    private let storage: [LogField]
+
+    public init(_ fields: [LogField] = []) {
+        self.storage = fields
+    }
+
+    public init(arrayLiteral elements: LogField...) {
+        self.init(elements)
+    }
+
+    public var isEmpty: Bool { storage.isEmpty }
+
+    public func appending(_ field: LogField) -> LogFields {
+        LogFields(storage + [field])
+    }
+
+    public func appending(contentsOf other: LogFields) -> LogFields {
+        LogFields(storage + other.storage)
+    }
+}
+
+extension LogFields: Sequence {
+    public func makeIterator() -> IndexingIterator<[LogField]> {
+        storage.makeIterator()
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogLevel.swift
+++ b/Packages/LogKit/Sources/LogKit/LogLevel.swift
@@ -1,0 +1,13 @@
+/// The severity of a logged event, ordered from least to most severe.
+public enum LogLevel: Int, Comparable, Sendable, CaseIterable {
+    case debug
+    case info
+    case notice
+    case warning
+    case error
+    case critical
+
+    public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogLevel.swift
+++ b/Packages/LogKit/Sources/LogKit/LogLevel.swift
@@ -10,4 +10,22 @@ public enum LogLevel: Int, Comparable, Sendable, CaseIterable {
     public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
+
+    /// The level's name, for destinations that record it as text.
+    public var name: String {
+        switch self {
+        case .debug:
+            "debug"
+        case .info:
+            "info"
+        case .notice:
+            "notice"
+        case .warning:
+            "warning"
+        case .error:
+            "error"
+        case .critical:
+            "critical"
+        }
+    }
 }

--- a/Packages/LogKit/Sources/LogKit/LogMessage.swift
+++ b/Packages/LogKit/Sources/LogKit/LogMessage.swift
@@ -1,0 +1,39 @@
+/// The fixed part of a logged event.
+///
+/// Backed by `StaticString` so it can never carry interpolated data. That keeps
+/// messages searchable, and lets a destination treat them as safe to show in full.
+public struct LogMessage: Hashable, Sendable, ExpressibleByStringLiteral {
+    public typealias StringLiteralType = StaticString
+
+    private let storage: StaticString
+
+    public init(_ value: StaticString) {
+        self.storage = value
+    }
+
+    public init(stringLiteral value: StaticString) {
+        self.init(value)
+    }
+
+    public static func == (lhs: LogMessage, rhs: LogMessage) -> Bool {
+        lhs.storage.description == rhs.storage.description
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(storage.description)
+    }
+
+    fileprivate var staticValue: StaticString { storage }
+}
+
+extension StaticString {
+    public init(_ message: LogMessage) {
+        self = message.staticValue
+    }
+}
+
+extension String {
+    public init(_ message: LogMessage) {
+        self = message.staticValue.description
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogSalt.swift
+++ b/Packages/LogKit/Sources/LogKit/LogSalt.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Mixed into hashed values so their tokens cannot be reversed by guessing.
+///
+/// Required rather than defaulted: an unsalted token is guessable for the small
+/// value spaces we log, so the choice of lifetime belongs to whoever composes
+/// the destination. A salt generated per run correlates within one launch; a
+/// stored salt correlates across launches on one device.
+public struct LogSalt: Hashable, Sendable {
+    private let storage: Data
+
+    public init(_ value: Data) {
+        self.storage = value
+    }
+
+    public static func random(byteCount: Int = 16) -> LogSalt {
+        var generator = SystemRandomNumberGenerator()
+        let bytes = (0..<byteCount).map { _ in UInt8.random(in: .min ... .max, using: &generator) }
+        return LogSalt(Data(bytes))
+    }
+
+    fileprivate var dataValue: Data { storage }
+}
+
+extension Data {
+    public init(_ salt: LogSalt) {
+        self = salt.dataValue
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogSalt.swift
+++ b/Packages/LogKit/Sources/LogKit/LogSalt.swift
@@ -2,10 +2,8 @@ import Foundation
 
 /// Mixed into hashed values so their tokens cannot be reversed by guessing.
 ///
-/// Required rather than defaulted: an unsalted token is guessable for the small
-/// value spaces we log, so the choice of lifetime belongs to whoever composes
-/// the destination. A salt generated per run correlates within one launch; a
-/// stored salt correlates across launches on one device.
+/// Required rather than defaulted, because the lifetime is a decision: a salt generated per run
+/// correlates within one launch, a stored salt correlates across launches on one device.
 public struct LogSalt: Hashable, Sendable {
     private let storage: Data
 

--- a/Packages/LogKit/Sources/LogKit/LogSubsystem.swift
+++ b/Packages/LogKit/Sources/LogKit/LogSubsystem.swift
@@ -1,0 +1,22 @@
+/// Identifies the app a log came from, conventionally its bundle identifier.
+///
+/// Injected rather than defaulted: this project ships as more than one app.
+public struct LogSubsystem: Hashable, Sendable, ExpressibleByStringLiteral {
+    private let storage: String
+
+    public init(_ value: String) {
+        self.storage = value
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+
+    fileprivate var stringValue: String { storage }
+}
+
+extension String {
+    public init(_ subsystem: LogSubsystem) {
+        self = subsystem.stringValue
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogValue.swift
+++ b/Packages/LogKit/Sources/LogKit/LogValue.swift
@@ -1,0 +1,34 @@
+/// A logged value, kept typed so a structured destination can preserve numbers
+/// as numbers rather than flattening everything to text.
+public enum LogValue: Hashable, Sendable {
+    case string(String)
+    case integer(Int)
+    case double(Double)
+    case boolean(Bool)
+    case array([LogValue])
+    case dictionary([FieldName: LogValue])
+}
+
+extension LogValue: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+extension LogValue: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self = .integer(value)
+    }
+}
+
+extension LogValue: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) {
+        self = .double(value)
+    }
+}
+
+extension LogValue: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = .boolean(value)
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogValueConvertible.swift
+++ b/Packages/LogKit/Sources/LogKit/LogValueConvertible.swift
@@ -1,0 +1,23 @@
+/// A value that knows how it is logged and how sensitive it is.
+///
+/// Conform a type once and every field built from it is classified the same
+/// way. Standard library types deliberately do not conform: a `String` or `URL`
+/// has no inherent sensitivity, so those must be classified at the call site.
+public protocol LogValueConvertible {
+    var logValue: LogValue { get }
+    var sensitivity: Sensitivity { get }
+}
+
+extension LogField {
+    /// Builds a field from a value that classifies itself.
+    public init(_ name: FieldName, _ value: some LogValueConvertible) {
+        switch value.sensitivity {
+        case .open:
+            self = .open(name, value.logValue)
+        case .hashed:
+            self = .hashed(name, value.logValue)
+        case .secret:
+            self = .secret(name, value.logValue)
+        }
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/Loggable.swift
+++ b/Packages/LogKit/Sources/LogKit/Loggable.swift
@@ -1,0 +1,6 @@
+/// Something that projects itself as an ordered set of fields.
+///
+/// Conformed to by boundary types built for logging, never by domain models.
+public protocol Loggable {
+    var logFields: LogFields { get }
+}

--- a/Packages/LogKit/Sources/LogKit/Sensitivity.swift
+++ b/Packages/LogKit/Sources/LogKit/Sensitivity.swift
@@ -1,0 +1,12 @@
+/// How freely a logged value may travel.
+///
+/// Defined by meaning rather than by any one destination's privacy levels, so a
+/// unified-log, file or remote destination can each honour it in its own terms.
+public enum Sensitivity: Equatable, Hashable, Sendable {
+    /// Safe to store or transmit anywhere.
+    case open
+    /// Correlatable but never readable. A destination that cannot hash must drop it.
+    case hashed
+    /// Never leaves the device.
+    case secret
+}

--- a/Packages/LogKit/Sources/LogKit/SourceLocation.swift
+++ b/Packages/LogKit/Sources/LogKit/SourceLocation.swift
@@ -1,0 +1,20 @@
+/// Where in the source an event was logged.
+public struct SourceLocation: Hashable, Sendable {
+    public let file: String
+    public let function: String
+    public let line: Int
+
+    public init(file: String, function: String, line: Int) {
+        self.file = file
+        self.function = function
+        self.line = line
+    }
+
+    public static func here(
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) -> SourceLocation {
+        SourceLocation(file: file, function: function, line: line)
+    }
+}

--- a/Packages/LogKit/Sources/LogKitUnified/CorrelationToken.swift
+++ b/Packages/LogKit/Sources/LogKitUnified/CorrelationToken.swift
@@ -1,0 +1,63 @@
+import CryptoKit
+import Foundation
+import LogKit
+
+/// A short, stable stand-in for a value that must not be readable.
+///
+/// The same value and salt always produce the same token, so occurrences can be
+/// matched across log lines, and the value cannot be recovered from the token
+/// without the salt. Computed per field rather than over a group, so one
+/// value's token does not change when a neighbouring field does.
+///
+/// Salted because the values we log come from small spaces: a ticket reference
+/// has under two million possibilities, and the attendee list is already known
+/// to us, so an unsalted digest would be reversible by simply trying every
+/// candidate.
+struct CorrelationToken {
+    /// How much of the digest to keep, in bytes.
+    ///
+    /// HMAC-SHA256 produces 32 bytes. Keeping 8 of them leaves 64 bits, where a
+    /// coin-flip chance of any two values colliding needs roughly five billion
+    /// distinct values (the birthday bound, about 2^32). We log nothing close
+    /// to that, and a 16-character token keeps a log line readable where a
+    /// 64-character one would not.
+    private static let keptByteCount = 8
+
+    private let storage: String
+
+    /// Derives a token for `value`, keyed by `salt`.
+    ///
+    /// Uses HMAC rather than hashing the salt and value concatenated, because
+    /// HMAC is the standard construction for keying a digest and is not
+    /// susceptible to length-extension.
+    init(_ value: String, salt: LogSalt) {
+        let code = HMAC<SHA256>.authenticationCode(
+            for: Data(value.utf8),
+            using: SymmetricKey(data: Data(salt))
+        )
+
+        storage = code
+            .prefix(Self.keptByteCount)
+            .map(\.hexadecimalPair)
+            .joined()
+    }
+
+    fileprivate var stringValue: String { storage }
+}
+
+extension String {
+    init(_ token: CorrelationToken) {
+        self = token.stringValue
+    }
+}
+
+private extension UInt8 {
+    /// The byte as exactly two lowercase hexadecimal digits.
+    ///
+    /// The zero padding is load-bearing, not cosmetic: without it `0x0a` would
+    /// render as `a`, so tokens would vary in length and two different byte
+    /// sequences could produce the same string.
+    var hexadecimalPair: String {
+        String(format: "%02x", self)
+    }
+}

--- a/Packages/LogKit/Sources/LogKitUnified/CorrelationToken.swift
+++ b/Packages/LogKit/Sources/LogKitUnified/CorrelationToken.swift
@@ -4,32 +4,21 @@ import LogKit
 
 /// A short, stable stand-in for a value that must not be readable.
 ///
-/// The same value and salt always produce the same token, so occurrences can be
-/// matched across log lines, and the value cannot be recovered from the token
-/// without the salt. Computed per field rather than over a group, so one
-/// value's token does not change when a neighbouring field does.
+/// The same value and salt always produce the same token, so occurrences can be matched
+/// across log lines. Computed per field, so one value's token does not change when a
+/// neighbouring field does.
 ///
-/// Salted because the values we log come from small spaces: a ticket reference
-/// has under two million possibilities, and the attendee list is already known
-/// to us, so an unsalted digest would be reversible by simply trying every
-/// candidate.
+/// Salted because the values we log come from small spaces: an unsalted digest of a ticket
+/// reference would be reversible by trying every candidate.
 struct CorrelationToken {
-    /// How much of the digest to keep, in bytes.
-    ///
-    /// HMAC-SHA256 produces 32 bytes. Keeping 8 of them leaves 64 bits, where a
-    /// coin-flip chance of any two values colliding needs roughly five billion
-    /// distinct values (the birthday bound, about 2^32). We log nothing close
-    /// to that, and a 16-character token keeps a log line readable where a
-    /// 64-character one would not.
+    /// Bytes of the digest to keep. 64 bits is far more than the volume we log needs, and
+    /// keeps a token readable at 16 characters.
     private static let keptByteCount = 8
 
     private let storage: String
 
-    /// Derives a token for `value`, keyed by `salt`.
-    ///
-    /// Uses HMAC rather than hashing the salt and value concatenated, because
-    /// HMAC is the standard construction for keying a digest and is not
-    /// susceptible to length-extension.
+    /// Keyed with HMAC rather than hashing salt and value concatenated, which would be open
+    /// to length-extension.
     init(_ value: String, salt: LogSalt) {
         let code = HMAC<SHA256>.authenticationCode(
             for: Data(value.utf8),
@@ -54,9 +43,8 @@ extension String {
 private extension UInt8 {
     /// The byte as exactly two lowercase hexadecimal digits.
     ///
-    /// The zero padding is load-bearing, not cosmetic: without it `0x0a` would
-    /// render as `a`, so tokens would vary in length and two different byte
-    /// sequences could produce the same string.
+    /// The zero padding is load-bearing: without it `0x0a` renders as `a`, so two different
+    /// byte sequences could produce the same string.
     var hexadecimalPair: String {
         String(format: "%02x", self)
     }

--- a/Packages/LogKit/Sources/LogKitUnified/Log+Unified.swift
+++ b/Packages/LogKit/Sources/LogKitUnified/Log+Unified.swift
@@ -4,11 +4,15 @@ import os
 extension Log {
     /// Writes to Apple's unified logging system.
     ///
-    /// Fields are grouped by sensitivity and each group is interpolated once,
-    /// because `OSLogMessage` must be a literal at the call site and cannot be
-    /// assembled from runtime data. Within a group, fields keep the order they
-    /// were written.
-    public static func unified(subsystem: LogSubsystem) -> Log {
+    /// Hashed values are replaced with a salted token computed per field, so
+    /// one value keeps the same token when its neighbours change. Because the
+    /// tokens are already non-reversible, every non-secret field is rendered in
+    /// one pass and keeps the order it was written. Secrets go in a separate
+    /// interpolation the system redacts.
+    ///
+    /// `OSLogMessage` must be a literal at the call site, so the number of
+    /// interpolations is fixed and fields cannot be interpolated individually.
+    public static func unified(subsystem: LogSubsystem, salt: LogSalt) -> Log {
         // One Logger per category, kept because creating one is not free and
         // categories are few and long-lived.
         let loggers = LoggerCache(subsystem: String(subsystem))
@@ -16,21 +20,19 @@ extension Log {
         return Log { event in
             let logger = loggers.logger(for: event.category)
 
-            // Recorded explicitly because OSLogType has no warning: notice and
-            // warning would otherwise both read as `default` in Console.
+            // Written out because OSLogType has no warning: notice and warning
+            // would otherwise both read as `default` in Console.
             let level = "[\(event.level.name)]"
-            let open = event.fields.filter { $0.sensitivity == .open }.rendered
-            let hashed = event.fields.filter { $0.sensitivity == .hashed }.rendered
-            let secret = event.fields.filter { $0.sensitivity == .secret }.rendered
+            let fields = event.fields.rendered(salt: salt)
+            let secrets = event.fields.renderedSecrets
 
             logger.log(
                 level: event.level.osLogType,
                 """
                 \(level, privacy: .public) \
                 \(String(event.message), privacy: .public) \
-                \(open, privacy: .public) \
-                \(hashed, privacy: .private(mask: .hash)) \
-                \(secret, privacy: .sensitive)
+                \(fields, privacy: .public) \
+                \(secrets, privacy: .sensitive)
                 """
             )
         }

--- a/Packages/LogKit/Sources/LogKitUnified/Log+Unified.swift
+++ b/Packages/LogKit/Sources/LogKitUnified/Log+Unified.swift
@@ -4,24 +4,18 @@ import os
 extension Log {
     /// Writes to Apple's unified logging system.
     ///
-    /// Hashed values are replaced with a salted token computed per field, so
-    /// one value keeps the same token when its neighbours change. Because the
-    /// tokens are already non-reversible, every non-secret field is rendered in
-    /// one pass and keeps the order it was written. Secrets go in a separate
-    /// interpolation the system redacts.
+    /// Non-secret fields render in one pass and keep their written order; secrets go in a
+    /// separate interpolation the system redacts.
     ///
-    /// `OSLogMessage` must be a literal at the call site, so the number of
-    /// interpolations is fixed and fields cannot be interpolated individually.
+    /// `OSLogMessage` must be a literal at the call site, so the number of interpolations is
+    /// fixed and fields cannot be interpolated individually.
     public static func unified(subsystem: LogSubsystem, salt: LogSalt) -> Log {
-        // One Logger per category, kept because creating one is not free and
-        // categories are few and long-lived.
         let loggers = LoggerCache(subsystem: String(subsystem))
 
         return Log { event in
             let logger = loggers.logger(for: event.category)
 
-            // Written out because OSLogType has no warning: notice and warning
-            // would otherwise both read as `default` in Console.
+            // OSLogType has no warning, so notice and warning would both read as `default`.
             let level = "[\(event.level.name)]"
             let fields = event.fields.rendered(salt: salt)
             let secrets = event.fields.renderedSecrets

--- a/Packages/LogKit/Sources/LogKitUnified/Log+Unified.swift
+++ b/Packages/LogKit/Sources/LogKitUnified/Log+Unified.swift
@@ -1,0 +1,56 @@
+import LogKit
+import os
+
+extension Log {
+    /// Writes to Apple's unified logging system.
+    ///
+    /// Fields are grouped by sensitivity and each group is interpolated once,
+    /// because `OSLogMessage` must be a literal at the call site and cannot be
+    /// assembled from runtime data. Within a group, fields keep the order they
+    /// were written.
+    public static func unified(subsystem: LogSubsystem) -> Log {
+        // One Logger per category, kept because creating one is not free and
+        // categories are few and long-lived.
+        let loggers = LoggerCache(subsystem: String(subsystem))
+
+        return Log { event in
+            let logger = loggers.logger(for: event.category)
+
+            // Recorded explicitly because OSLogType has no warning: notice and
+            // warning would otherwise both read as `default` in Console.
+            let level = "[\(event.level.name)]"
+            let open = event.fields.filter { $0.sensitivity == .open }.rendered
+            let hashed = event.fields.filter { $0.sensitivity == .hashed }.rendered
+            let secret = event.fields.filter { $0.sensitivity == .secret }.rendered
+
+            logger.log(
+                level: event.level.osLogType,
+                """
+                \(level, privacy: .public) \
+                \(String(event.message), privacy: .public) \
+                \(open, privacy: .public) \
+                \(hashed, privacy: .private(mask: .hash)) \
+                \(secret, privacy: .sensitive)
+                """
+            )
+        }
+    }
+}
+
+private final class LoggerCache: @unchecked Sendable {
+    private let subsystem: String
+    private let lock = OSAllocatedUnfairLock(initialState: [LogCategory: Logger]())
+
+    init(subsystem: String) {
+        self.subsystem = subsystem
+    }
+
+    func logger(for category: LogCategory) -> Logger {
+        lock.withLock { cache in
+            if let existing = cache[category] { return existing }
+            let logger = Logger(subsystem: subsystem, category: String(category))
+            cache[category] = logger
+            return logger
+        }
+    }
+}

--- a/Packages/LogKit/Sources/LogKitUnified/LogLevel+OSLogType.swift
+++ b/Packages/LogKit/Sources/LogKitUnified/LogLevel+OSLogType.swift
@@ -1,0 +1,25 @@
+import LogKit
+import os
+
+extension LogLevel {
+    /// The nearest unified-logging type.
+    ///
+    /// Unified logging has no warning level, so warnings map to `default`
+    /// alongside notice; the level is still carried in the event itself.
+    var osLogType: OSLogType {
+        switch self {
+        case .debug:
+            .debug
+        case .info:
+            .info
+        case .notice:
+            .default
+        case .warning:
+            .default
+        case .error:
+            .error
+        case .critical:
+            .fault
+        }
+    }
+}

--- a/Packages/LogKit/Sources/LogKitUnified/LogValue+Rendering.swift
+++ b/Packages/LogKit/Sources/LogKitUnified/LogValue+Rendering.swift
@@ -25,8 +25,29 @@ extension LogValue {
 }
 
 extension Sequence<LogField> {
-    /// Renders fields as `name=value` pairs, keeping the order they were written.
-    var rendered: String {
-        map { "\(String($0.name))=\($0.value.rendered)" }.joined(separator: " ")
+    /// Renders fields as `name=value` pairs in the order they were written,
+    /// replacing hashed values with their correlation token.
+    ///
+    /// Secrets are excluded: they are rendered separately so unified logging
+    /// can redact them.
+    func rendered(salt: LogSalt) -> String {
+        compactMap { field in
+            switch field.sensitivity {
+            case .open:
+                "\(String(field.name))=\(field.value.rendered)"
+            case .hashed:
+                "\(String(field.name))=\(String(CorrelationToken(field.value.rendered, salt: salt)))"
+            case .secret:
+                nil
+            }
+        }
+        .joined(separator: " ")
+    }
+
+    /// Renders only the secret values, for an interpolation the system redacts.
+    var renderedSecrets: String {
+        filter { $0.sensitivity == .secret }
+            .map { "\(String($0.name))=\($0.value.rendered)" }
+            .joined(separator: " ")
     }
 }

--- a/Packages/LogKit/Sources/LogKitUnified/LogValue+Rendering.swift
+++ b/Packages/LogKit/Sources/LogKitUnified/LogValue+Rendering.swift
@@ -1,0 +1,32 @@
+import LogKit
+
+extension LogValue {
+    /// Flattens a value for a destination that can only carry text.
+    var rendered: String {
+        switch self {
+        case let .string(value):
+            value
+        case let .integer(value):
+            String(value)
+        case let .double(value):
+            String(value)
+        case let .boolean(value):
+            String(value)
+        case let .array(values):
+            "[" + values.map(\.rendered).joined(separator: ", ") + "]"
+        case let .dictionary(values):
+            "[" + values
+                .map { (String($0.key), $0.value.rendered) }
+                .sorted { $0.0 < $1.0 }
+                .map { "\($0.0): \($0.1)" }
+                .joined(separator: ", ") + "]"
+        }
+    }
+}
+
+extension Sequence<LogField> {
+    /// Renders fields as `name=value` pairs, keeping the order they were written.
+    var rendered: String {
+        map { "\(String($0.name))=\($0.value.rendered)" }.joined(separator: " ")
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogCombineTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogCombineTests.swift
@@ -1,0 +1,78 @@
+import LogKit
+import Testing
+
+@Suite struct LogCombineTests {
+    @Test func whenCombiningTwoLogs_shouldWriteToBoth() {
+        let first = LogRecorder()
+        let second = LogRecorder()
+        let sut = Log.combine([first.log, second.log])
+
+        sut.write(.stub("shared"))
+
+        #expect(first.events.map(\.message) == ["shared"])
+        #expect(second.events.map(\.message) == ["shared"])
+    }
+
+    @Test func whenCombiningNoLogs_shouldMatchNone() {
+        let viaEmpty = LogRecorder()
+        let viaNone = LogRecorder()
+
+        Log.combine([.combine([]), viaEmpty.log]).write(.stub("empty"))
+        Log.combine([.none, viaNone.log]).write(.stub("empty"))
+
+        #expect(viaEmpty.events == viaNone.events)
+    }
+
+    @Test func whenSameLogAppearsTwice_shouldWriteTwice() {
+        let recorder = LogRecorder()
+        let sut = Log.combine([recorder.log, recorder.log])
+
+        sut.write(.stub("twice"))
+
+        #expect(recorder.events.count == 2)
+    }
+
+    @Test func whenNoneIsOnTheLeft_shouldMatchLogAlone() {
+        let combined = LogRecorder()
+        let alone = LogRecorder()
+
+        Log.combine([.none, combined.log]).write(.stub("identity"))
+        alone.log.write(.stub("identity"))
+
+        #expect(combined.events == alone.events)
+    }
+
+    @Test func whenNoneIsOnTheRight_shouldMatchLogAlone() {
+        let combined = LogRecorder()
+        let alone = LogRecorder()
+
+        Log.combine([combined.log, .none]).write(.stub("identity"))
+        alone.log.write(.stub("identity"))
+
+        #expect(combined.events == alone.events)
+    }
+
+    @Test func whenGroupedEitherWay_shouldProduceSameEvents() {
+        let left = LogRecorder()
+        let right = LogRecorder()
+
+        let leftGrouped = Log.combine([Log.combine([left.log, left.log]), left.log])
+        let rightGrouped = Log.combine([right.log, Log.combine([right.log, right.log])])
+
+        leftGrouped.write(.stub("associative"))
+        rightGrouped.write(.stub("associative"))
+
+        #expect(left.events == right.events)
+    }
+
+    @Test func whenCombinedWithAnother_shouldWriteToBoth() {
+        let first = LogRecorder()
+        let second = LogRecorder()
+        let sut = first.log.combined(with: second.log)
+
+        sut.write(.stub("pair"))
+
+        #expect(first.events.count == 1)
+        #expect(second.events.count == 1)
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogFieldTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogFieldTests.swift
@@ -1,0 +1,28 @@
+import LogKit
+import Testing
+
+@Suite struct LogFieldTests {
+    @Test func whenBuiltAsOpen_shouldCarryOpenSensitivity() {
+        let sut = LogField.open("category", "push")
+
+        #expect(sut.sensitivity == .open)
+        #expect(sut.value == .string("push"))
+        #expect(sut.name == "category")
+    }
+
+    @Test func whenBuiltAsHashed_shouldCarryHashedSensitivity() {
+        let sut = LogField.hashed("email", "ada@example.com")
+
+        #expect(sut.sensitivity == .hashed)
+    }
+
+    @Test func whenBuiltAsSecret_shouldCarrySecretSensitivity() {
+        let sut = LogField.secret("token", "abc123")
+
+        #expect(sut.sensitivity == .secret)
+    }
+
+    @Test func whenSensitivitiesDiffer_shouldNotBeEqual() {
+        #expect(LogField.open("a", 1) != LogField.hashed("a", 1))
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogFieldsTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogFieldsTests.swift
@@ -1,0 +1,41 @@
+import LogKit
+import Testing
+
+@Suite struct LogFieldsTests {
+    @Test func whenBuiltFromArrayLiteral_shouldKeepWrittenOrder() {
+        let sut: LogFields = [.open("first", 1), .open("second", 2), .open("third", 3)]
+
+        #expect(sut.map(\.name) == ["first", "second", "third"])
+    }
+
+    @Test func whenSameFieldsInDifferentOrder_shouldNotBeEqual() {
+        let first = LogField.open("a", 1)
+        let second = LogField.hashed("b", "x")
+
+        #expect(LogFields([first, second]) != LogFields([second, first]))
+    }
+
+    @Test func whenAppendingField_shouldPlaceItLast() {
+        let sut = LogFields([.open("first", 1)]).appending(.open("second", 2))
+
+        #expect(sut.map(\.name) == ["first", "second"])
+    }
+
+    @Test func whenAppendingFields_shouldKeepBothSequencesInOrder() {
+        let sut = LogFields([.open("a", 1)]).appending(contentsOf: LogFields([.open("b", 2), .open("c", 3)]))
+
+        #expect(sut.map(\.name) == ["a", "b", "c"])
+    }
+
+    @Test func whenAppending_shouldLeaveOriginalUnchanged() {
+        let sut = LogFields([.open("only", 1)])
+
+        _ = sut.appending(.open("extra", 2))
+
+        #expect(sut.map(\.name) == ["only"])
+    }
+
+    @Test func whenBuiltWithNoFields_shouldBeEmpty() {
+        #expect(LogFields().isEmpty)
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogLevelNameTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogLevelNameTests.swift
@@ -1,0 +1,13 @@
+import LogKit
+import Testing
+
+@Suite struct LogLevelNameTests {
+    @Test(arguments: zip(LogLevel.allCases, ["debug", "info", "notice", "warning", "error", "critical"]))
+    func whenNamed_shouldMatchItsCase(_ level: LogLevel, _ expected: String) {
+        #expect(level.name == expected)
+    }
+
+    @Test func whenNoticeAndWarningShareAnOSLogType_shouldStillHaveDistinctNames() {
+        #expect(LogLevel.notice.name != LogLevel.warning.name)
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogLevelTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogLevelTests.swift
@@ -1,0 +1,12 @@
+import LogKit
+import Testing
+
+@Suite struct LogLevelTests {
+    @Test func whenComparingSeverities_shouldOrderDebugLowestAndCriticalHighest() {
+        #expect(LogLevel.allCases.sorted() == [.debug, .info, .notice, .warning, .error, .critical])
+    }
+
+    @Test func whenLevelIsMoreSevere_shouldCompareGreater() {
+        #expect(LogLevel.error > LogLevel.notice)
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogMessageTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogMessageTests.swift
@@ -1,0 +1,22 @@
+import LogKit
+import Testing
+
+@Suite struct LogMessageTests {
+    @Test func whenBuiltFromSameLiteral_shouldBeEqual() {
+        let sut: LogMessage = "push registration failed"
+
+        #expect(sut == LogMessage("push registration failed"))
+    }
+
+    @Test func whenBuiltFromDifferentLiteral_shouldNotBeEqual() {
+        let sut: LogMessage = "push registration failed"
+
+        #expect(sut != LogMessage("sign in failed"))
+    }
+
+    @Test func whenConvertedToString_shouldReturnLiteral() {
+        let sut: LogMessage = "theme unavailable"
+
+        #expect(String(sut) == "theme unavailable")
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogRecorder.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogRecorder.swift
@@ -1,0 +1,33 @@
+import Foundation
+import LogKit
+
+/// Captures every event written to its `log`, so a test can assert exactly what
+/// a composition produced.
+final class LogRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [LogEvent] = []
+
+    var events: [LogEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    var log: Log {
+        Log { [self] event in
+            lock.lock()
+            defer { lock.unlock() }
+            storage.append(event)
+        }
+    }
+}
+
+extension LogEvent {
+    static func stub(
+        _ message: LogMessage = "event",
+        level: LogLevel = .info,
+        category: LogCategory = "test"
+    ) -> LogEvent {
+        LogEvent(level: level, category: category, message: message)
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogTransformTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogTransformTests.swift
@@ -1,0 +1,113 @@
+import LogKit
+import Testing
+
+@Suite struct LogTransformTests {
+    @Test func whenPullingBack_shouldRewriteEventBeforeWriting() {
+        let recorder = LogRecorder()
+        let sut = recorder.log.pullback { event in
+            LogEvent(level: .critical, category: event.category, message: event.message)
+        }
+
+        sut.write(.stub("raised", level: .debug))
+
+        #expect(recorder.events.map(\.level) == [.critical])
+    }
+
+    @Test func whenFilteredOut_shouldWriteNothing() {
+        let recorder = LogRecorder()
+        let sut = recorder.log.filtered { _ in false }
+
+        sut.write(.stub())
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func whenBelowMinimumLevel_shouldWriteNothing() {
+        let recorder = LogRecorder()
+        let sut = recorder.log.atLeast(.error)
+
+        sut.write(.stub("quiet", level: .notice))
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func whenAtOrAboveMinimumLevel_shouldWriteEvent() {
+        let recorder = LogRecorder()
+        let sut = recorder.log.atLeast(.error)
+
+        sut.write(.stub("loud", level: .error))
+        sut.write(.stub("louder", level: .critical))
+
+        #expect(recorder.events.map(\.message) == ["loud", "louder"])
+    }
+
+    @Test func whenCategoryIsNotListed_shouldWriteNothing() {
+        let recorder = LogRecorder()
+        let sut = recorder.log.only(["push"])
+
+        sut.write(.stub("theme", category: "theme"))
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func whenCategoryIsListed_shouldWriteEvent() {
+        let recorder = LogRecorder()
+        let sut = recorder.log.only(["push", "theme"])
+
+        sut.write(.stub("registered", category: "push"))
+
+        #expect(recorder.events.map(\.message) == ["registered"])
+    }
+
+    @Test func whenDroppingSecrets_shouldRemoveOnlySecretFields() {
+        let recorder = LogRecorder()
+        let sut = recorder.log.droppingSecrets()
+
+        sut.write(
+            LogEvent(
+                level: .info,
+                category: "auth",
+                message: "signed in",
+                fields: [.open("scheme", "ticket"), .secret("token", "abc"), .hashed("email", "a@b.c")]
+            )
+        )
+
+        #expect(recorder.events.first?.fields.map(\.name) == ["scheme", "email"])
+    }
+
+    @Test func whenEnriching_shouldAppendContextAfterEventFields() {
+        let recorder = LogRecorder()
+        let sut = recorder.log.enriching { [.open("build", "42")] }
+
+        sut.write(
+            LogEvent(level: .info, category: "app", message: "launched", fields: [.open("cold", true)])
+        )
+
+        #expect(recorder.events.first?.fields.map(\.name) == ["cold", "build"])
+    }
+
+    @Test func whenConsentIsWithheld_shouldWriteNothing() {
+        let recorder = LogRecorder()
+        let sut = recorder.log.consented { false }
+
+        sut.write(.stub())
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func whenConsentIsWithdrawnBetweenEvents_shouldStopWriting() {
+        let recorder = LogRecorder()
+        let consent = Consent()
+        let sut = recorder.log.consented { consent.isGranted }
+
+        sut.write(.stub("before"))
+        consent.isGranted = false
+        sut.write(.stub("after"))
+
+        #expect(recorder.events.map(\.message) == ["before"])
+    }
+}
+
+private final class Consent: @unchecked Sendable {
+    var isGranted = true
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogValueConvertibleTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogValueConvertibleTests.swift
@@ -1,0 +1,40 @@
+import LogKit
+import Testing
+
+@Suite struct LogValueConvertibleTests {
+    @Test func whenBuiltFromConvertibleValue_shouldTakeItsSensitivity() {
+        let sut = LogField("email", EmailStub())
+
+        #expect(sut.sensitivity == .hashed)
+        #expect(sut.value == .string("ada@example.com"))
+    }
+
+    @Test func whenBuiltWithExplicitSensitivity_shouldOverrideTheTypesDefault() {
+        let sut = LogField.open("email", EmailStub().logValue)
+
+        #expect(sut.sensitivity == .open)
+    }
+
+    @Test func whenComposingLoggable_shouldProduceFieldsInWrittenOrder() {
+        let sut = CredentialStub()
+
+        #expect(sut.logFields.map(\.name) == ["email", "reference"])
+        #expect(sut.logFields.map(\.sensitivity) == [.hashed, .hashed])
+    }
+}
+
+private struct EmailStub: LogValueConvertible {
+    var logValue: LogValue { .string("ada@example.com") }
+    var sensitivity: Sensitivity { .hashed }
+}
+
+private struct ReferenceStub: LogValueConvertible {
+    var logValue: LogValue { .string("ABCD-1") }
+    var sensitivity: Sensitivity { .hashed }
+}
+
+private struct CredentialStub: Loggable {
+    var logFields: LogFields {
+        [LogField("email", EmailStub()), LogField("reference", ReferenceStub())]
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogValueTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogValueTests.swift
@@ -1,0 +1,40 @@
+import LogKit
+import Testing
+
+@Suite struct LogValueTests {
+    @Test func whenWrittenAsStringLiteral_shouldBeString() {
+        let sut: LogValue = "ada"
+
+        #expect(sut == .string("ada"))
+    }
+
+    @Test func whenWrittenAsIntegerLiteral_shouldBeInteger() {
+        let sut: LogValue = 42
+
+        #expect(sut == .integer(42))
+    }
+
+    @Test func whenWrittenAsFloatLiteral_shouldBeDouble() {
+        let sut: LogValue = 1.5
+
+        #expect(sut == .double(1.5))
+    }
+
+    @Test func whenWrittenAsBooleanLiteral_shouldBeBoolean() {
+        let sut: LogValue = true
+
+        #expect(sut == .boolean(true))
+    }
+
+    @Test func whenNumberIsStored_shouldStayNumberRatherThanText() {
+        let sut: LogValue = 200
+
+        #expect(sut != .string("200"))
+    }
+
+    @Test func whenNested_shouldPreserveStructure() {
+        let sut = LogValue.dictionary(["status": 200, "tags": .array(["a", "b"])])
+
+        #expect(sut == .dictionary(["status": .integer(200), "tags": .array([.string("a"), .string("b")])]))
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogWriteTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogWriteTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import LogKit
+import Testing
+
+@Suite struct LogWriteTests {
+    @Test func whenLevelIsBelowMinimum_shouldNotBuildFields() {
+        let recorder = LogRecorder()
+        let counter = CallCounter()
+        let sut = recorder.log.atLeast(.error)
+
+        sut(.debug, "push", "ignored", fields: counter.record())
+
+        #expect(counter.count == 0)
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func whenCategoryIsNotListed_shouldNotBuildFields() {
+        let recorder = LogRecorder()
+        let counter = CallCounter()
+        let sut = recorder.log.only(["push"])
+
+        sut(.error, "theme", "ignored", fields: counter.record())
+
+        #expect(counter.count == 0)
+    }
+
+    @Test func whenConsentIsWithheld_shouldNotBuildFields() {
+        let recorder = LogRecorder()
+        let counter = CallCounter()
+        let sut = recorder.log.consented { false }
+
+        sut(.error, "push", "ignored", fields: counter.record())
+
+        #expect(counter.count == 0)
+    }
+
+    @Test func whenEventIsAccepted_shouldBuildFieldsExactlyOnce() {
+        let counter = CallCounter()
+        let sut = Log.combine([LogRecorder().log, LogRecorder().log, LogRecorder().log])
+
+        sut(.error, "push", "kept", fields: counter.record())
+
+        #expect(counter.count == 1)
+    }
+
+    @Test func whenWritingToNone_shouldNotBuildFields() {
+        let counter = CallCounter()
+
+        Log.none(.critical, "push", "nowhere", fields: counter.record())
+
+        #expect(counter.count == 0)
+    }
+
+    @Test func whenOneOfManyDestinationsAccepts_shouldStillWrite() {
+        let quiet = LogRecorder()
+        let loud = LogRecorder()
+        let sut = Log.combine([quiet.log.atLeast(.critical), loud.log.atLeast(.debug)])
+
+        sut(.info, "push", "partial")
+
+        #expect(quiet.events.isEmpty)
+        #expect(loud.events.map(\.message) == ["partial"])
+    }
+
+    @Test func whenRecordingEvent_shouldCaptureCallSite() {
+        let recorder = LogRecorder()
+
+        recorder.log(.info, "push", "located")
+
+        #expect(recorder.events.first?.source.file.hasSuffix("LogWriteTests.swift") == true)
+    }
+}
+
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func record() -> LogFields {
+        lock.lock()
+        defer { lock.unlock() }
+        storage += 1
+        return [.open("built", true)]
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/SourceLocationTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/SourceLocationTests.swift
@@ -1,0 +1,12 @@
+import LogKit
+import Testing
+
+@Suite struct SourceLocationTests {
+    @Test func whenCapturedHere_shouldRecordCallingFileAndFunction() {
+        let sut = SourceLocation.here()
+
+        #expect(sut.file.hasSuffix("SourceLocationTests.swift"))
+        #expect(sut.function.hasPrefix("whenCapturedHere"))
+        #expect(sut.line > 0)
+    }
+}

--- a/Packages/LogKit/Tests/LogKitUnifiedTests/CorrelationTokenTests.swift
+++ b/Packages/LogKit/Tests/LogKitUnifiedTests/CorrelationTokenTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import LogKit
+import Testing
+
+@testable import LogKitUnified
+
+@Suite struct CorrelationTokenTests {
+    private let salt = LogSalt(Data("fixed-for-tests".utf8))
+
+    @Test func whenSameValueAndSalt_shouldProduceSameToken() {
+        let first = String(CorrelationToken("ada@example.com", salt: salt))
+        let second = String(CorrelationToken("ada@example.com", salt: salt))
+
+        #expect(first == second)
+    }
+
+    @Test func whenDifferentValues_shouldProduceDifferentTokens() {
+        let ada = String(CorrelationToken("ada@example.com", salt: salt))
+        let grace = String(CorrelationToken("grace@example.com", salt: salt))
+
+        #expect(ada != grace)
+    }
+
+    @Test func whenSaltDiffers_shouldProduceDifferentTokenForSameValue() {
+        let mine = String(CorrelationToken("ada@example.com", salt: salt))
+        let theirs = String(CorrelationToken("ada@example.com", salt: LogSalt(Data("other".utf8))))
+
+        #expect(mine != theirs)
+    }
+
+    @Test func whenTokenised_shouldNotContainTheOriginalValue() {
+        let sut = String(CorrelationToken("ada@example.com", salt: salt))
+
+        #expect(!sut.contains("ada"))
+        #expect(!sut.contains("@"))
+    }
+
+    @Test func whenTokenised_shouldBeSixteenHexadecimalCharacters() {
+        let sut = String(CorrelationToken("ada@example.com", salt: salt))
+        let isHexadecimal = sut.allSatisfy(\.isHexDigit)
+
+        #expect(sut.count == 16)
+        #expect(isHexadecimal)
+    }
+
+    @Test func whenAnyByteIsBelowSixteen_shouldStillProduceTwoCharactersPerByte() {
+        // Zero padding means every token is the same length whatever the bytes.
+        let lengths = (0..<64).map { index in
+            String(CorrelationToken("value-\(index)", salt: salt)).count
+        }
+
+        #expect(Set(lengths) == [16])
+    }
+
+    @Test func whenGeneratedRandomly_shouldDifferBetweenSalts() {
+        #expect(LogSalt.random() != LogSalt.random())
+    }
+}

--- a/Packages/LogKit/Tests/LogKitUnifiedTests/LogLevelOSLogTypeTests.swift
+++ b/Packages/LogKit/Tests/LogKitUnifiedTests/LogLevelOSLogTypeTests.swift
@@ -1,0 +1,19 @@
+import LogKit
+import Testing
+import os
+
+@testable import LogKitUnified
+
+@Suite struct LogLevelOSLogTypeTests {
+    @Test func whenMappingLevels_shouldUseNearestUnifiedType() {
+        #expect(LogLevel.debug.osLogType == .debug)
+        #expect(LogLevel.info.osLogType == .info)
+        #expect(LogLevel.notice.osLogType == .default)
+        #expect(LogLevel.error.osLogType == .error)
+        #expect(LogLevel.critical.osLogType == .fault)
+    }
+
+    @Test func whenMappingWarning_shouldFallBackToDefaultSinceUnifiedHasNone() {
+        #expect(LogLevel.warning.osLogType == .default)
+    }
+}

--- a/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
+++ b/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
@@ -1,18 +1,22 @@
+import Foundation
 import LogKit
 import Testing
 
 @testable import LogKitUnified
 
 @Suite struct LogUnifiedTests {
+    private let subsystem: LogSubsystem = "uk.co.swiftleeds.tests"
+    private let salt = LogSalt(Data("fixed-for-tests".utf8))
+
     @Test func whenBuilt_shouldAcceptEveryLevelAndCategory() {
-        let sut = Log.unified(subsystem: "uk.co.swiftleeds.tests")
+        let sut = Log.unified(subsystem: subsystem, salt: salt)
 
         #expect(sut.accepts(.debug, "push"))
         #expect(sut.accepts(.critical, "theme"))
     }
 
     @Test func whenWritingEveryLevelAndSensitivity_shouldReachUnifiedLogging() {
-        let sut = Log.unified(subsystem: "uk.co.swiftleeds.tests")
+        let sut = Log.unified(subsystem: subsystem, salt: salt)
 
         for level in LogLevel.allCases {
             sut(
@@ -22,6 +26,7 @@ import Testing
                 fields: [
                     .open("category", "registration"),
                     .hashed("email", "ada@example.com"),
+                    .hashed("reference", "ABCD-1"),
                     .secret("token", "abc123"),
                 ]
             )
@@ -31,7 +36,7 @@ import Testing
     }
 
     @Test func whenSameCategoryIsUsedTwice_shouldReuseItsLogger() {
-        let sut = Log.unified(subsystem: "uk.co.swiftleeds.tests")
+        let sut = Log.unified(subsystem: subsystem, salt: salt)
 
         sut(.info, "push", "first")
         sut(.info, "push", "second")

--- a/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
+++ b/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
@@ -1,0 +1,41 @@
+import LogKit
+import Testing
+
+@testable import LogKitUnified
+
+@Suite struct LogUnifiedTests {
+    @Test func whenBuilt_shouldAcceptEveryLevelAndCategory() {
+        let sut = Log.unified(subsystem: "uk.co.swiftleeds.tests")
+
+        #expect(sut.accepts(.debug, "push"))
+        #expect(sut.accepts(.critical, "theme"))
+    }
+
+    @Test func whenWritingEveryLevelAndSensitivity_shouldReachUnifiedLogging() {
+        let sut = Log.unified(subsystem: "uk.co.swiftleeds.tests")
+
+        for level in LogLevel.allCases {
+            sut(
+                level,
+                "push",
+                "exercised every sensitivity",
+                fields: [
+                    .open("category", "registration"),
+                    .hashed("email", "ada@example.com"),
+                    .secret("token", "abc123"),
+                ]
+            )
+        }
+
+        #expect(sut.accepts(.info, "push"))
+    }
+
+    @Test func whenSameCategoryIsUsedTwice_shouldReuseItsLogger() {
+        let sut = Log.unified(subsystem: "uk.co.swiftleeds.tests")
+
+        sut(.info, "push", "first")
+        sut(.info, "push", "second")
+
+        #expect(sut.accepts(.info, "push"))
+    }
+}

--- a/Packages/LogKit/Tests/LogKitUnifiedTests/LogValueRenderingTests.swift
+++ b/Packages/LogKit/Tests/LogKitUnifiedTests/LogValueRenderingTests.swift
@@ -1,9 +1,12 @@
+import Foundation
 import LogKit
 import Testing
 
 @testable import LogKitUnified
 
 @Suite struct LogValueRenderingTests {
+    private let salt = LogSalt(Data("fixed-for-tests".utf8))
+
     @Test func whenRenderingScalars_shouldUseTheirTextForm() {
         #expect(LogValue.string("ada").rendered == "ada")
         #expect(LogValue.integer(200).rendered == "200")
@@ -20,13 +23,54 @@ import Testing
         #expect(sut.rendered == "[again: false, status: 200]")
     }
 
-    @Test func whenRenderingFields_shouldKeepWrittenOrder() {
-        let sut: LogFields = [.open("second", 2), .open("first", 1)]
+    @Test func whenRenderingFields_shouldKeepWrittenOrderAcrossSensitivities() {
+        let sut: LogFields = [.open("second", 2), .hashed("first", "x"), .open("third", 3)]
 
-        #expect(sut.rendered == "second=2 first=1")
+        let rendered = sut.rendered(salt: salt)
+
+        #expect(rendered.hasPrefix("second=2 first="))
+        #expect(rendered.hasSuffix(" third=3"))
+    }
+
+    @Test func whenFieldIsHashed_shouldRenderTokenRatherThanValue() {
+        let sut: LogFields = [.hashed("email", "ada@example.com")]
+
+        #expect(!sut.rendered(salt: salt).contains("ada@example.com"))
+        #expect(sut.rendered(salt: salt).hasPrefix("email="))
+    }
+
+    @Test func whenNeighbouringFieldChanges_shouldKeepSameTokenForUnchangedField() {
+        let first: LogFields = [.hashed("email", "ada@example.com"), .open("reference", "ABCD-1")]
+        let second: LogFields = [.hashed("email", "ada@example.com"), .open("reference", "WXYZ-9")]
+
+        let firstToken = first.rendered(salt: salt).split(separator: " ")[0]
+        let secondToken = second.rendered(salt: salt).split(separator: " ")[0]
+
+        #expect(firstToken == secondToken)
+    }
+
+    @Test func whenTwoFieldsAreHashed_shouldTokeniseEachSeparately() {
+        let sut: LogFields = [.hashed("email", "ada@example.com"), .hashed("reference", "ABCD-1")]
+
+        let parts = sut.rendered(salt: salt).split(separator: " ")
+
+        #expect(parts.count == 2)
+        #expect(parts[0] != parts[1])
+    }
+
+    @Test func whenFieldIsSecret_shouldBeExcludedFromTheRenderedFields() {
+        let sut: LogFields = [.open("scheme", "ticket"), .secret("token", "abc")]
+
+        #expect(sut.rendered(salt: salt) == "scheme=ticket")
+    }
+
+    @Test func whenRenderingSecrets_shouldIncludeOnlySecretFields() {
+        let sut: LogFields = [.open("scheme", "ticket"), .secret("token", "abc")]
+
+        #expect(sut.renderedSecrets == "token=abc")
     }
 
     @Test func whenRenderingNoFields_shouldProduceEmptyText() {
-        #expect(LogFields().rendered.isEmpty)
+        #expect(LogFields().rendered(salt: salt).isEmpty)
     }
 }

--- a/Packages/LogKit/Tests/LogKitUnifiedTests/LogValueRenderingTests.swift
+++ b/Packages/LogKit/Tests/LogKitUnifiedTests/LogValueRenderingTests.swift
@@ -1,0 +1,32 @@
+import LogKit
+import Testing
+
+@testable import LogKitUnified
+
+@Suite struct LogValueRenderingTests {
+    @Test func whenRenderingScalars_shouldUseTheirTextForm() {
+        #expect(LogValue.string("ada").rendered == "ada")
+        #expect(LogValue.integer(200).rendered == "200")
+        #expect(LogValue.boolean(true).rendered == "true")
+    }
+
+    @Test func whenRenderingArray_shouldKeepElementOrder() {
+        #expect(LogValue.array(["a", "b", "c"]).rendered == "[a, b, c]")
+    }
+
+    @Test func whenRenderingDictionary_shouldSortKeysForStableOutput() {
+        let sut = LogValue.dictionary(["status": 200, "again": false])
+
+        #expect(sut.rendered == "[again: false, status: 200]")
+    }
+
+    @Test func whenRenderingFields_shouldKeepWrittenOrder() {
+        let sut: LogFields = [.open("second", 2), .open("first", 1)]
+
+        #expect(sut.rendered == "second=2 first=1")
+    }
+
+    @Test func whenRenderingNoFields_shouldProduceEmptyText() {
+        #expect(LogFields().rendered.isEmpty)
+    }
+}


### PR DESCRIPTION
## Problem

* The app has no logging at all: 10 `print()` calls and zero OSLog usage.
* One of them ships and leaks. `SwiftLeeds/App/SwiftLeedsApp.swift:67` prints every query item of an incoming universal link and is **not** `#if DEBUG` gated. (The device-token print in `AppDelegate+Push.swift` **is** gated, so that one does not ship.)
* `EmailAddress`, `TicketReference` and `SessionToken` override `description` to return `•••`. That breaks the `CustomStringConvertible` contract, makes `po` useless in LLDB, turns test failures into `••• == •••`, and does not actually protect anything, since `String(x)` still returns the value.
* We will want a remote log destination in the coming months, so a seam is needed now rather than later.

## Solution

A small package with the abstraction split from the implementation, mirroring `SecureStorageKit` / `SecureStorageKitKeychain`.

* **`LogKit`** is pure: no `import os`, so it builds anywhere and is fully testable.
* **`LogKitUnified`** is the only place `os.Logger` appears.

### Privacy is a property of the data, not of string syntax

`OSLogMessage` cannot be passed through any wrapper. A parameter, a stored variable and an `@autoclosure` all fail to compile with `argument must be a string interpolation`, because `os_log` stores raw arguments in a binary buffer and formats lazily, so the format string must be known at compile time. So a field carries its own `Sensitivity` and each destination renders at its own literal call site.

* A `LogField` cannot be built without stating `.open`, `.hashed` or `.secret`, so an unclassified value is unrepresentable.
* `LogValueConvertible` lets a type declare its classification once, so call sites cannot get it wrong. Standard library types deliberately do not conform: a `String` or `URL` has no inherent sensitivity.
* `Sensitivity` is defined by meaning, not by OSLog's privacy levels, so a file or remote destination can honour it too.

### Hashed fields are tokenised individually, and salted

`.hashed` means "correlatable but never readable". Handing a joined string to OSLog's `mask.hash` gave the second half but not the first: the same email produced a different hash whenever a sibling field changed.

```
joined-A  (email=ada@example.com  reference=ABCD-1)  <mask.hash: 'BY0ybg224OyOGtQV5yjdsw=='>
joined-B  (email=ada@example.com  reference=WXYZ-9)  <mask.hash: '9hLFM7+e8IwMLDl2zyoErA=='>
```

Each field now gets its own HMAC-SHA256 token, truncated to 64 bits for readability. Because the tokens are already non-reversible, every non-secret field is rendered in one ordered pass, which also restores the field order the old grouping had scrambled.

The salt is a **required** parameter of `Log.unified(subsystem:salt:)`, not a default, because an unsalted token is guessable for the values we log: a ticket reference has under two million possibilities and we already hold the attendee list. The composition root chooses the lifetime, so a per-run salt can become a persisted one later without touching the Kit.

### Composition

`Log` is a monoid. `.none` is the identity, `combine` the operation, so a destination can be included conditionally with no branching: `combine([unified, isRemoteEnabled ? remote : .none])`. Identity and associativity are covered by tests. Transformations are contravariant, so they are `pullback`, with `filtered`, `atLeast`, `only`, `droppingSecrets`, `enriching` and `consented` built on two primitives.

**Nothing is built for a log that will be dropped.** `Log` carries a cheap `accepts(level, category)` check consulted before an event is constructed, so a filtered-out log costs one comparison. `combine` builds the event once no matter how many destinations receive it.

### Ordering is a type invariant

`LogFields` guarantees field order by construction rather than by convention. Every attempt to break it is rejected by the compiler:

| Attempt | Compiler |
|---|---|
| Reach `storage` | `'storage' is inaccessible due to 'private' protection level` |
| Subscript | `value of type 'LogFields' has no subscripts` |
| `sort()` in place | `value of type 'LogFields' has no member 'sort'` |
| Assign a reversed array | `cannot assign value of type 'Array<LogField>' to type 'LogFields'` |
| Dictionary literal | `cannot convert value of type '[String : LogField]' to specified type 'LogFields'` |

## How to test

```bash
git fetch origin feat/logging-kit
git checkout feat/logging-kit

cd Packages/LogKit
swift test                # 73 tests
swift build -c release
```

Then confirm the privacy behaviour against the real unified log:

```bash
swift test --filter LogUnifiedTests
/usr/bin/log show --last 60s --info \
  --predicate 'subsystem == "uk.co.swiftleeds.tests"' --style compact
```

Expected, and confirmed locally:

```
Df  [uk.co.swiftleeds.tests:push] [notice]  exercised every sensitivity category=registration email=15cb2f07ab3f5874 reference=91480dd947f023c9 <private>
Df  [uk.co.swiftleeds.tests:push] [warning] exercised every sensitivity category=registration email=15cb2f07ab3f5874 reference=91480dd947f023c9 <private>
```

* The message and the `.open` field are readable.
* Each `.hashed` field has its own stable token, so it can be matched across lines but not read.
* The `.secret` field is `<private>`.
* Fields appear in the order they were written.
* The level name is written out because `OSLogType` has no warning, so `notice` and `warning` would otherwise both display as `default`.

Redaction only applies when no debugger is attached. `swift test` qualifies, so this is verifiable on macOS without a device.

## Notes

* Every commit builds in debug and release and passes its own tests independently.
* Nothing consumes this package yet. Replacing the `print()` calls is the next PR, and it belongs on the authentication chain, because it needs the `prepareDependencies` block and the Xcode `Packages` group that only exist there.
* `apple/swift-log` was considered and rejected as the API: it has no privacy or sensitivity concept, and `LoggingSystem.bootstrap` is global one-shot state that cannot be overridden per test. It remains a good candidate as a **destination** behind `Log`, which would also align with the Vapor backend.
