### PR TITLE
fix(SwiftLeeds): hide the event picker when there is only one event

### DIFF
--- a/SwiftLeeds/Views/My Conference/MyConferenceView.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceView.swift
@@ -31,7 +31,7 @@ struct MyConferenceView: View {
             .background(Color.listBackground)
             .navigationTitle("Schedule")
             .toolbar {
-                if let currentEvent = viewModel.currentEvent {
+                if let currentEvent = viewModel.currentEvent, viewModel.events.count > 1 {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Menu {
                             ForEach(viewModel.events) { event in
@@ -44,7 +44,6 @@ struct MyConferenceView: View {
                                 Text(currentEvent.name)
                                 Image(systemName: "chevron.up.chevron.down")
                                     .font(.caption)
-
                             }
                         }
                         .accentColor(Color("AccentColor"))


### PR DESCRIPTION
## Problem

The Schedule toolbar showed an event picker whenever an event had loaded, even when there was
nothing to pick between. Tapping it opened a menu with one option that changed nothing.

KotlinLeeds is in its first year, so it will only ever have one event. The picker is noise there.

## Solution

Show the picker only when there is more than one event to choose from.

SwiftLeeds is unaffected: it has several years of conferences, so attendees can still browse
previous years.

This also hides the picker when the events list is empty, which previously opened an empty menu.

## Screenshots

| Before | After |
|---|---|
|<img width="300" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-16 at 11 15 42" src="https://github.com/user-attachments/assets/bd7d3a9c-24bd-425c-81a8-4222fb6e14bd" />|<img width="300" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-16 at 11 16 14" src="https://github.com/user-attachments/assets/bd3ff099-edce-445d-bca1-ae93baf96948" />|

## How to test

Run the **KotlinLeeds** scheme and open the Schedule tab. There should be no picker in the top
right.

Then run **SwiftLeeds** and open the Schedule tab. The picker should still be there, and still
switch between years.
