### PR TITLE
fix: pin package dependencies to the versions the app ships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,9 @@ playground.xcworkspace
 # hence it is not needed unless you have added a package configuration file to your project
 # .swiftpm
 
-# Local library packages resolve against the app's workspace Package.resolved,
-# so their own resolved files are redundant and cause churn.
-Packages/*/Package.resolved
+# Packages/*/Package.resolved is committed. Xcode ignores it in favour of the app's
+# workspace resolution, but `swift test` uses it, so without it CI resolves fresh and
+# tests different versions than the app ships.
 
 .build/
 .build-shared/

--- a/Packages/AuthenticationFeature/Package.resolved
+++ b/Packages/AuthenticationFeature/Package.resolved
@@ -1,0 +1,60 @@
+{
+  "originHash": "d45e2c195891debb51fc17170153540a7011fe943bb2675a0abde3236142e75a",
+  "pins": [
+    {
+      "identity": "combine-schedulers",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/combine-schedulers",
+      "state": {
+        "revision": "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "identity": "swift-clocks",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-clocks",
+      "state": {
+        "revision": "72d749bf341b78851203066ab421869b783ec42a",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "identity": "swift-concurrency-extras",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state": {
+        "revision": "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version": "1.4.0"
+      }
+    },
+    {
+      "identity": "swift-dependencies",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-dependencies",
+      "state": {
+        "revision": "8dc1fbf2f6255a73dec53b4648164884898db4c5",
+        "version": "1.14.1"
+      }
+    },
+    {
+      "identity": "swift-syntax",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/swiftlang/swift-syntax",
+      "state": {
+        "revision": "4799286537280063c85a32f09884cfbca301b1a1",
+        "version": "602.0.0"
+      }
+    },
+    {
+      "identity": "xctest-dynamic-overlay",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state": {
+        "revision": "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version": "1.11.0"
+      }
+    }
+  ],
+  "version": 3
+}

--- a/Packages/AuthenticationUI/Package.resolved
+++ b/Packages/AuthenticationUI/Package.resolved
@@ -1,0 +1,60 @@
+{
+  "originHash": "0d65dec6507cd66316d0292c2090fa8b1b5178f6f3e8377278b3f14f2bed26dd",
+  "pins": [
+    {
+      "identity": "combine-schedulers",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/combine-schedulers",
+      "state": {
+        "revision": "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "identity": "swift-clocks",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-clocks",
+      "state": {
+        "revision": "72d749bf341b78851203066ab421869b783ec42a",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "identity": "swift-concurrency-extras",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state": {
+        "revision": "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version": "1.4.0"
+      }
+    },
+    {
+      "identity": "swift-dependencies",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-dependencies",
+      "state": {
+        "revision": "8dc1fbf2f6255a73dec53b4648164884898db4c5",
+        "version": "1.14.1"
+      }
+    },
+    {
+      "identity": "swift-syntax",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/swiftlang/swift-syntax",
+      "state": {
+        "revision": "4799286537280063c85a32f09884cfbca301b1a1",
+        "version": "602.0.0"
+      }
+    },
+    {
+      "identity": "xctest-dynamic-overlay",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state": {
+        "revision": "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version": "1.11.0"
+      }
+    }
+  ],
+  "version": 3
+}

--- a/Packages/SecureStorageKit/Package.resolved
+++ b/Packages/SecureStorageKit/Package.resolved
@@ -1,0 +1,60 @@
+{
+  "originHash": "f3bcb04325cb0186ca70302d497f912fc09ef83d520230b31cf4b2f6380eb460",
+  "pins": [
+    {
+      "identity": "combine-schedulers",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/combine-schedulers",
+      "state": {
+        "revision": "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "identity": "swift-clocks",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-clocks",
+      "state": {
+        "revision": "72d749bf341b78851203066ab421869b783ec42a",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "identity": "swift-concurrency-extras",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state": {
+        "revision": "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version": "1.4.0"
+      }
+    },
+    {
+      "identity": "swift-dependencies",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-dependencies",
+      "state": {
+        "revision": "8dc1fbf2f6255a73dec53b4648164884898db4c5",
+        "version": "1.14.1"
+      }
+    },
+    {
+      "identity": "swift-syntax",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/swiftlang/swift-syntax",
+      "state": {
+        "revision": "4799286537280063c85a32f09884cfbca301b1a1",
+        "version": "602.0.0"
+      }
+    },
+    {
+      "identity": "xctest-dynamic-overlay",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state": {
+        "revision": "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version": "1.11.0"
+      }
+    }
+  ],
+  "version": 3
+}


### PR DESCRIPTION
## Problem

`Packages/*/Package.resolved` was gitignored, so every CI run resolved dependencies fresh. Two
things followed:

**We tested different versions than we ship.**

| Dependency | App ships | CI tested against |
|---|---|---|
| swift-dependencies | 1.14.1 | 1.15.0 |
| swift-concurrency-extras | 1.4.0 | 1.4.1 |
| swift-syntax | 602.0.0 | 603.0.2 |

**And it was non-deterministic.** A new upstream release inside the allowed range changes what CI
tests, with no commit to point at when it breaks.

The old `.gitignore` comment said these files were "redundant" because local packages resolve
against the app's workspace. That is true for the Xcode build, and stopped being true when CI
started running `swift test` per package.

## Solution

Commit each package's `Package.resolved`, pinned to the versions the app already ships.

Pinned down to match the app rather than up to the newer versions, so this PR changes no
behaviour. Upgrading those three is worth doing separately, where a regression has one obvious
cause.

## How to test

Checks should stay green. `swift test` in any package now uses the same versions the app builds
with.

To see the old behaviour: delete a package's `Package.resolved` and run `swift package resolve` —
it will pull newer versions again.

## Notes

- The app's workspace `Package.resolved` is untouched, so the app's own resolution is unchanged.
  Xcode ignores the per-package files.
- `LogKit` has no external dependencies, so it has no resolved file.
