### PR TITLE
ci: cache dependency sources between runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,18 @@ jobs:
         with:
           xcode-version: '26.5'
 
+      # Only dependency sources, never build products. Package.resolved pins exact
+      # revisions, so a restored checkout cannot differ from a fresh one.
+      - name: Cache dependency sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build-shared/repositories
+            .build-shared/checkouts
+          key: spm-deps-${{ runner.os }}-${{ hashFiles('Packages/*/Package.resolved') }}
+          restore-keys: |
+            spm-deps-${{ runner.os }}-
+
       - name: Run every package test suite
         run: |
           set -uo pipefail


### PR DESCRIPTION
## Problem

Every CI run fetches all six dependencies from GitHub. Runners start with no SwiftPM cache, so
nothing is reused between runs.

## Solution

Cache the dependency sources — `repositories/` and `checkouts/`, about 72MB — keyed on the
`Package.resolved` files committed in #116.

**Build products are deliberately excluded.** Caching those would save more, but a restored build
cache is the one failure mode worth avoiding: a green tick over code that was never really rebuilt.
Source checkouts carry no such risk, because `Package.resolved` pins exact revisions, so a restored
checkout cannot differ from a fresh one. That is also why the key has no Xcode version in it —
sources are compiler-independent.

## How to read the result

The **first** run on this branch is a cache miss and should be roughly unchanged. The **second** run
is the real measurement.

Baseline on `main`: **Test Swift Packages ≈ 1m16s**.

## Honest caveat

The benefit could not be measured locally. This machine has a 1.9GB SwiftPM global cache, so local
"cold" runs clone from a local mirror rather than the network — the saving measured there was 4s,
which is almost certainly wrong for a runner that has to fetch everything.

If the saving turns out to be trivial, this should be reverted rather than kept. A moving part that
earns nothing is worse than no moving part.

## How to test

Compare **Test Swift Packages** across two runs on this branch, and against `main`. Verify all 189
tests still run.
