### PR TITLE
fix: stop leaking universal-link query items, and make response failures diagnosable

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Domain/AttendeeFetchError.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Domain/AttendeeFetchError.swift
@@ -1,4 +1,6 @@
 public enum AttendeeFetchError: Error, Equatable {
     case unauthorized
+    /// The server answered, but not with something we accept.
+    case invalidResponse
     case unknown
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
@@ -4,10 +4,11 @@ enum AttendeeMapper {
     static func map(_ data: Data, _ response: HTTPURLResponse) throws(AttendeeFetchError) -> Attendee {
         switch response.statusCode {
         case 200:
-            guard let dto = try? JSONDecoder().decode(AttendeeDTO.self, from: data),
-                  let attendee = try? dto.attendee()
-            else { throw .unknown }
-            return attendee
+            do {
+                return try JSONDecoder().decode(AttendeeDTO.self, from: data).attendee()
+            } catch {
+                throw .invalidResponse
+            }
         case 401:
             throw .unauthorized
         default:

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
@@ -8,7 +8,7 @@ import Testing
         let expected = try expectedAttendee()
 
         let attendee = try await withDependencies {
-            $0.httpClient = .responding(with: attendeeJSON, statusCode: 200)
+            $0.httpClient = .responding(with: attendeeJSON(), statusCode: 200)
         } operation: {
             let sut = AttendeeRepository.liveValue
             return try await sut.fetch()
@@ -20,7 +20,7 @@ import Testing
     @Test func whenServerReturnsUnauthorized_shouldThrowUnauthorized() async throws {
         await #expect(throws: AttendeeFetchError.unauthorized) {
             try await withDependencies {
-                $0.httpClient = .responding(with: attendeeJSON, statusCode: 401)
+                $0.httpClient = .responding(with: attendeeJSON(), statusCode: 401)
             } operation: {
                 let sut = AttendeeRepository.liveValue
                 return try await sut.fetch()
@@ -31,7 +31,7 @@ import Testing
     @Test func whenServerReturnsOtherStatus_shouldThrowUnknown() async throws {
         await #expect(throws: AttendeeFetchError.unknown) {
             try await withDependencies {
-                $0.httpClient = .responding(with: attendeeJSON, statusCode: 500)
+                $0.httpClient = .responding(with: attendeeJSON(), statusCode: 500)
             } operation: {
                 let sut = AttendeeRepository.liveValue
                 return try await sut.fetch()
@@ -39,10 +39,32 @@ import Testing
         }
     }
 
-    @Test func whenServerReturnsInvalidJSON_shouldThrowUnknown() async throws {
-        await #expect(throws: AttendeeFetchError.unknown) {
+    @Test func whenServerReturnsInvalidJSON_shouldThrowInvalidResponse() async throws {
+        await #expect(throws: AttendeeFetchError.invalidResponse) {
             try await withDependencies {
                 $0.httpClient = .responding(with: Data("not json".utf8), statusCode: 200)
+            } operation: {
+                let sut = AttendeeRepository.liveValue
+                return try await sut.fetch()
+            }
+        }
+    }
+
+    @Test func whenServerReturnsUnparsableTicketReference_shouldThrowInvalidResponse() async throws {
+        await #expect(throws: AttendeeFetchError.invalidResponse) {
+            try await withDependencies {
+                $0.httpClient = .responding(with: attendeeJSON(reference: "!!!"), statusCode: 200)
+            } operation: {
+                let sut = AttendeeRepository.liveValue
+                return try await sut.fetch()
+            }
+        }
+    }
+
+    @Test func whenServerReturnsUnparsableEmailAddress_shouldThrowInvalidResponse() async throws {
+        await #expect(throws: AttendeeFetchError.invalidResponse) {
+            try await withDependencies {
+                $0.httpClient = .responding(with: attendeeJSON(email: ""), statusCode: 200)
             } operation: {
                 let sut = AttendeeRepository.liveValue
                 return try await sut.fetch()
@@ -64,19 +86,24 @@ import Testing
 
 private enum StubError: Error { case transport }
 
-private let attendeeJSON = Data("""
-{
-    "ticket": {
-        "first_name": "Ada",
-        "last_name": "Lovelace",
-        "email": "ada@example.com",
-        "avatar_url": "https://example.com/avatar.png",
-        "qr_url": "https://example.com/qr.png",
-        "reference": "ABCD-12",
-        "slug": "ti_pxqFKr9pPWd6VeYKvMBKpjQ"
+private func attendeeJSON(
+    email: String = "ada@example.com",
+    reference: String = "ABCD-12"
+) -> Data {
+    Data("""
+    {
+        "ticket": {
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "email": "\(email)",
+            "avatar_url": "https://example.com/avatar.png",
+            "qr_url": "https://example.com/qr.png",
+            "reference": "\(reference)",
+            "slug": "ti_pxqFKr9pPWd6VeYKvMBKpjQ"
+        }
     }
+    """.utf8)
 }
-""".utf8)
 
 private func expectedAttendee() throws -> Attendee {
     Attendee(

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
@@ -109,7 +109,7 @@ private func expectedAttendee() throws -> Attendee {
     Attendee(
         name: PersonNameComponents(givenName: "Ada", familyName: "Lovelace"),
         emailAddress: try EmailAddress("ada@example.com"),
-        avatarURL: AvatarURL(URL(string: "https://example.com/avatar.png")!),
+        avatarURL: AvatarURL(try #require(URL(string: "https://example.com/avatar.png"))),
         ticketReference: try TicketReference("ABCD-12"),
         ticketSlug: try TicketSlug("ti_pxqFKr9pPWd6VeYKvMBKpjQ")
     )

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileTests.swift
@@ -14,7 +14,7 @@ import Testing
             return try await sut()
         }
 
-        #expect(profile == expectedProfile())
+        #expect(profile == (try expectedProfile()))
     }
 
     @Test func whenRepositoryFails_shouldRethrowError() async throws {
@@ -50,18 +50,18 @@ private func makeAttendee() throws -> Attendee {
     Attendee(
         name: PersonNameComponents(givenName: "Ada", familyName: "Lovelace"),
         emailAddress: try EmailAddress("ada@example.com"),
-        avatarURL: AvatarURL(URL(string: "https://example.com/avatar.png")!),
+        avatarURL: AvatarURL(try #require(URL(string: "https://example.com/avatar.png"))),
         ticketReference: try TicketReference("ABCD-12"),
         ticketSlug: try TicketSlug("ti_abc")
     )
 }
 
-private func expectedProfile() -> Profile {
+private func expectedProfile() throws -> Profile {
     Profile(
         name: PersonNameComponents(givenName: "Ada", familyName: "Lovelace"),
         emailAddress: "ada@example.com",
-        avatarURL: URL(string: "https://example.com/avatar.png")!,
+        avatarURL: try #require(URL(string: "https://example.com/avatar.png")),
         ticketReference: "ABCD-12",
-        ticketSlug: try! TicketSlug("ti_abc")
+        ticketSlug: try TicketSlug("ti_abc")
     )
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientAuthenticatedTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientAuthenticatedTests.swift
@@ -4,7 +4,11 @@ import Foundation
 import Testing
 
 @Suite struct HTTPClientAuthenticatedTests {
-    private let url = URL(string: "https://example.com")!
+    private let url: URL
+
+    init() throws {
+        url = try #require(URL(string: "https://example.com"))
+    }
 
     @Test func whenSessionExists_shouldAttachBearer() async throws {
         let spy = HTTPClientSpy(respondingWith: Data(), statusCode: 200)

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientSessionExpiryTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientSessionExpiryTests.swift
@@ -3,7 +3,11 @@ import Foundation
 import Testing
 
 @Suite struct HTTPClientSessionExpiryTests {
-    private let url = URL(string: "https://example.com")!
+    private let url: URL
+
+    init() throws {
+        url = try #require(URL(string: "https://example.com"))
+    }
 
     @Test func when401OnBearerRequest_shouldInvokeReaction() async throws {
         let reaction = ReactionSpy()

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientSpy.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientSpy.swift
@@ -12,12 +12,19 @@ actor HTTPClientSpy {
     }
 
     nonisolated var httpClient: HTTPClient {
-        HTTPClient { request in await self.handle(request) }
+        HTTPClient { request in try await self.handle(request) }
     }
 
-    private func handle(_ request: URLRequest) -> (Data, HTTPURLResponse) {
+    private func handle(_ request: URLRequest) throws -> (Data, HTTPURLResponse) {
         requests.append(request)
-        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: statusCode,
+                  httpVersion: nil,
+                  headerFields: nil
+              )
+        else { throw StubFailure.couldNotBuildResponse }
         return (data, response)
     }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientStub.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientStub.swift
@@ -1,15 +1,21 @@
 import AuthenticationFeature
 import Foundation
 
+enum StubFailure: Error {
+    case couldNotBuildResponse
+}
+
 extension HTTPClient {
     static func responding(with data: Data, statusCode: Int) -> HTTPClient {
         HTTPClient { request in
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: statusCode,
-                httpVersion: nil,
-                headerFields: nil
-            )!
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: statusCode,
+                      httpVersion: nil,
+                      headerFields: nil
+                  )
+            else { throw StubFailure.couldNotBuildResponse }
             return (data, response)
         }
     }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
@@ -4,13 +4,19 @@ import Testing
 
 @Suite(.serialized)
 struct HTTPClientURLSessionTests {
-    private let url = URL(string: "https://example.com")!
+    private let url: URL
+
+    init() throws {
+        url = try #require(URL(string: "https://example.com"))
+    }
 
     @Test func whenServerResponds_shouldReturnDataAndHTTPResponse() async throws {
         let expected = Data("hello".utf8)
         URLProtocolStub.stub(
             data: expected,
-            response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+            response: try #require(
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            ),
             error: nil
         )
         let sut = HTTPClient.urlSession(URLProtocolStub.session())

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCard+ViewModel.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCard+ViewModel.swift
@@ -26,7 +26,7 @@ extension ProfileCard {
                 switch error {
                 case .unauthorized:
                     onSignOut(.signInRequired)
-                case .unknown:
+                case .invalidResponse, .unknown:
                     state = .failed
                 }
             }

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/ProfileCard/ProfileCardViewModelTests.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/ProfileCard/ProfileCardViewModelTests.swift
@@ -33,6 +33,24 @@ import Testing
         }
     }
 
+    @Test func whenResponseIsInvalid_shouldReportFailureWithoutSigningOut() async {
+        var captured: SignOutReason?
+
+        await withDependencies {
+            $0.fetchProfile = FetchProfile { () async throws(AttendeeFetchError) -> Profile in
+                throw .invalidResponse
+            }
+        } operation: {
+            let sut = ProfileCard.ViewModel(onSignOut: { captured = $0 })
+
+            await sut.load()
+
+            #expect(sut.state == .failed)
+        }
+
+        #expect(captured == nil)
+    }
+
     @Test func whenCredentialsAreRejected_shouldRequireSignIn() async {
         var captured: SignOutReason?
 

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/ProfileCard/ProfileCardViewModelTests.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/ProfileCard/ProfileCardViewModelTests.swift
@@ -6,8 +6,8 @@ import Testing
 
 @MainActor
 @Suite struct ProfileCardViewModelTests {
-    @Test func whenProfileLoads_shouldBeLoaded() async {
-        let profile = makeProfile()
+    @Test func whenProfileLoads_shouldBeLoaded() async throws {
+        let profile = try makeProfile()
         await withDependencies {
             $0.fetchProfile = FetchProfile { profile }
         } operation: {
@@ -100,8 +100,8 @@ import Testing
         #expect(captured == .userRequested)
     }
 
-    @Test func whenLoading_shouldNotLeak() async {
-        let profile = makeProfile()
+    @Test func whenLoading_shouldNotLeak() async throws {
+        let profile = try makeProfile()
         weak var weakSUT: ProfileCard.ViewModel?
         await withDependencies {
             $0.fetchProfile = FetchProfile { profile }
@@ -113,13 +113,13 @@ import Testing
         #expect(weakSUT == nil)
     }
 
-    private func makeProfile() -> Profile {
+    private func makeProfile() throws -> Profile {
         Profile(
             name: PersonNameComponents(givenName: "Ada", familyName: "Lovelace"),
             emailAddress: "ada@example.com",
-            avatarURL: URL(string: "https://example.com/avatar.png")!,
+            avatarURL: try #require(URL(string: "https://example.com/avatar.png")),
             ticketReference: "ABCD-1",
-            ticketSlug: try! TicketSlug("ti_abc")
+            ticketSlug: try TicketSlug("ti_abc")
         )
     }
 }

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -29,7 +29,6 @@ struct SwiftLeedsApp: App {
             Tabs()
                 .environmentObject(appState)
                 .environmentObject(themeManager)
-                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb, perform: handleUserActivity)
         }
     }
 }
@@ -56,14 +55,5 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print("⛔️ Push registration failed:", error)
         handleFailedRegistration(application: application, error: error)
-    }
-}
-
-private extension SwiftLeedsApp {
-    func handleUserActivity(_ userActivity: NSUserActivity) {
-        guard let incomingURL = userActivity.webpageURL, let components = URLComponents(
-              url: incomingURL, resolvingAgainstBaseURL: true), let queryItems = components.queryItems
-        else { return }
-        print(queryItems)
     }
 }


### PR DESCRIPTION
Phase 2 of the foundation work: one privacy defect, one diagnosability defect, and a test-safety
sweep.

## 1. A universal link leaked its query items

`SwiftLeedsApp` printed every query item from an incoming link to the console, in release builds.

The handler did nothing else — it parsed the URL and printed. It has been there since the App Clip
work. Removed the handler and its registration rather than only the `print`, because the leftover
would have been an unused binding and a warning.

**No user-visible change.** The `applinks:swiftleeds.co.uk` entitlement still claims the domain, so
tapping a link still opens the app. The App Clip is a separate target and handles no activities.

## 2. A broken server contract looked like a network blip

`AttendeeMapper` wrapped both the decode and the domain mapping in `try?` and threw `.unknown`. So a
malformed body, a rejected email, a rejected ticket reference and a transport failure were all the
same error.

Now a response the server sent but we cannot accept throws `.invalidResponse`. Parsing stays strict:
a value that fails its rule is not valid, and rejecting it is correct. What changed is only that the
failure can be told apart — which is what Phase 3 will log.

**The compiler found a question worth answering.** Adding the case broke an exhaustive switch in
`ProfileCard.ViewModel`, which raised: should an invalid response sign the user out? No. Their
credentials are fine; the server sent something we cannot read. A new test pins that.

## 3. Force unwraps in tests

A force unwrap in a test crashes the whole run instead of failing one test, so twelve were removed
across eight files:

- Test doubles now throw `StubFailure` instead of force-unwrapping an `HTTPURLResponse`
- Three suites moved their `url` into a throwing `init` using `#require`
- Fixtures use `#require` and plain `try`

Four remain in `Sources/`, deliberately: they are constant literals in previews and fixtures that
cannot fail, and every way of removing them makes the code worse. Left with this note rather than
silently.

## How to test

Checks should be green. 192 tests, up from 189.

Each new test was watched failing first. The three mapper tests reported *"expected `.invalidResponse`
… but `.unknown` was thrown instead"* before the fix. The view-model test was proved by making an
invalid response sign the user out, and it failed.
