### PR TITLE
feat: log through LogKit

### DIFF
--- a/Packages/AuthenticationFeature/Package.swift
+++ b/Packages/AuthenticationFeature/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .library(name: "AuthenticationFeature", targets: ["AuthenticationFeature"]),
     ],
     dependencies: [
+        .package(path: "../LogKit"),
         .package(path: "../SecureStorageKit"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
     ],
@@ -20,6 +21,7 @@ let package = Package(
             name: "AuthenticationFeature",
             dependencies: [
                 .product(name: "Dependencies", package: "swift-dependencies"),
+                .product(name: "LogKit", package: "LogKit"),
                 .product(name: "SecureStorageKit", package: "SecureStorageKit"),
             ]
         ),
@@ -28,6 +30,7 @@ let package = Package(
             dependencies: [
                 "AuthenticationFeature",
                 .product(name: "Dependencies", package: "swift-dependencies"),
+                .product(name: "LogKit", package: "LogKit"),
                 .product(name: "SecureStorageKit", package: "SecureStorageKit"),
             ]
         ),

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
@@ -3,10 +3,8 @@ import Foundation
 import LogKit
 
 extension AttendeeMapper {
-    /// Records why a response was rejected, then rethrows it unchanged.
-    ///
-    /// Wraps the mapper rather than the repository because the repository has already narrowed the
-    /// failure to `AttendeeFetchError`, which carries no reason.
+    /// Wraps the mapper rather than the repository, which has already narrowed the failure to
+    /// `AttendeeFetchError` and lost the reason.
     func loggingFailures() -> AttendeeMapper {
         AttendeeMapper { data, response throws(AttendeeResponseFailure) in
             do throws(AttendeeResponseFailure) {
@@ -16,7 +14,7 @@ extension AttendeeMapper {
                 // building liveValue would capture whichever log existed first.
                 @Dependency(\.log) var log
                 log(.error, "profile", "The attendee response was rejected", fields: [
-                    .open("reason", .string("\(error)"))
+                    .open("reason", error)
                 ])
                 throw error
             }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
@@ -1,0 +1,25 @@
+import Dependencies
+import Foundation
+import LogKit
+
+extension AttendeeMapper {
+    /// Records why a response was rejected, then rethrows it unchanged.
+    ///
+    /// Wraps the mapper rather than the repository because the repository has already narrowed the
+    /// failure to `AttendeeFetchError`, which carries no reason.
+    func loggingFailures() -> AttendeeMapper {
+        AttendeeMapper { data, response throws(AttendeeResponseFailure) in
+            do throws(AttendeeResponseFailure) {
+                return try map(data, response)
+            } catch {
+                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+                // building liveValue would capture whichever log existed first.
+                @Dependency(\.log) var log
+                log(.error, "profile", "The attendee response was rejected", fields: [
+                    .open("reason", .string("\(error)"))
+                ])
+                throw error
+            }
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
@@ -28,8 +28,6 @@ extension AttendeeMapper {
 
 private enum AttendeeMapperKey: DependencyKey {
     static var liveValue: AttendeeMapper { .live.loggingFailures() }
-    /// Mapping is pure, so a test exercises the real thing. Logging still goes to `\.log`, which
-    /// defaults to writing nothing.
     static var testValue: AttendeeMapper { liveValue }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
@@ -1,18 +1,41 @@
+import Dependencies
 import Foundation
 
-enum AttendeeMapper {
-    static func map(_ data: Data, _ response: HTTPURLResponse) throws(AttendeeFetchError) -> Attendee {
+struct AttendeeMapper: Sendable {
+    var map: @Sendable (Data, HTTPURLResponse) throws(AttendeeResponseFailure) -> Attendee
+
+    init(map: @escaping @Sendable (Data, HTTPURLResponse) throws(AttendeeResponseFailure) -> Attendee) {
+        self.map = map
+    }
+}
+
+extension AttendeeMapper {
+    static let live = AttendeeMapper { data, response throws(AttendeeResponseFailure) in
         switch response.statusCode {
         case 200:
             do {
                 return try JSONDecoder().decode(AttendeeDTO.self, from: data).attendee()
             } catch {
-                throw .invalidResponse
+                throw .couldNotRead(error)
             }
         case 401:
             throw .unauthorized
         default:
-            throw .unknown
+            throw .unexpectedStatus(response.statusCode)
         }
+    }
+}
+
+private enum AttendeeMapperKey: DependencyKey {
+    static var liveValue: AttendeeMapper { .live.loggingFailures() }
+    /// Mapping is pure, so a test exercises the real thing. Logging still goes to `\.log`, which
+    /// defaults to writing nothing.
+    static var testValue: AttendeeMapper { liveValue }
+}
+
+extension DependencyValues {
+    var attendeeMapper: AttendeeMapper {
+        get { self[AttendeeMapperKey.self] }
+        set { self[AttendeeMapperKey.self] = newValue }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
@@ -6,6 +6,7 @@ extension AttendeeRepository: DependencyKey {
         AttendeeRepository { () async throws(AttendeeFetchError) -> Attendee in
             @Dependency(\.httpClient) var httpClient
             @Dependency(\.apiConfiguration) var apiConfiguration
+            @Dependency(\.attendeeMapper) var attendeeMapper
             let request = URLRequest(url: Endpoint.profile.url(baseURL: apiConfiguration.baseURL))
             let data: Data
             let response: HTTPURLResponse
@@ -14,7 +15,11 @@ extension AttendeeRepository: DependencyKey {
             } catch {
                 throw AttendeeFetchError.unknown
             }
-            return try AttendeeMapper.map(data, response)
+            do throws(AttendeeResponseFailure) {
+                return try attendeeMapper.map(data, response)
+            } catch {
+                throw AttendeeFetchError(error)
+            }
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeResponseFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeResponseFailure.swift
@@ -1,11 +1,24 @@
-/// Why a response could not become an `Attendee`, with enough detail to diagnose it.
-///
+import LogKit
+
 /// Internal on purpose: `AttendeeFetchError` is what callers see, and it carries no diagnostic
 /// payload. This is what middleware between the two gets to read.
 enum AttendeeResponseFailure: Error {
     case couldNotRead(any Error)
     case unauthorized
     case unexpectedStatus(Int)
+}
+
+extension AttendeeResponseFailure: LogDescribable {
+    var logDescription: String {
+        switch self {
+        case let .couldNotRead(cause):
+            "couldNotRead(\(String(logDescribing: cause)))"
+        case .unauthorized:
+            "unauthorized"
+        case let .unexpectedStatus(code):
+            "unexpectedStatus(\(code))"
+        }
+    }
 }
 
 extension AttendeeFetchError {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeResponseFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeResponseFailure.swift
@@ -1,0 +1,22 @@
+/// Why a response could not become an `Attendee`, with enough detail to diagnose it.
+///
+/// Internal on purpose: `AttendeeFetchError` is what callers see, and it carries no diagnostic
+/// payload. This is what middleware between the two gets to read.
+enum AttendeeResponseFailure: Error {
+    case couldNotRead(any Error)
+    case unauthorized
+    case unexpectedStatus(Int)
+}
+
+extension AttendeeFetchError {
+    init(_ failure: AttendeeResponseFailure) {
+        switch failure {
+        case .couldNotRead:
+            self = .invalidResponse
+        case .unauthorized:
+            self = .unauthorized
+        case .unexpectedStatus:
+            self = .unknown
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
@@ -86,6 +86,26 @@ import Testing
         #expect(recorder.events.map(\.level) == [.error])
     }
 
+    @Test func whenFieldIsMissing_shouldLogItsPath() async throws {
+        let recorder = LogRecorder()
+        let missingLastName = Data(#"{"ticket": {"first_name": "Ada"}}"#.utf8)
+
+        try? await withDependencies {
+            $0.httpClient = .responding(with: missingLastName, statusCode: 200)
+            $0.log = recorder.log
+        } operation: {
+            let sut = AttendeeRepository.liveValue
+            _ = try await sut.fetch()
+        }
+
+        let reason = try #require(recorder.events.first?.fields.first { $0.name == "reason" })
+        guard case let .string(text) = reason.value else {
+            Issue.record("expected the reason to be a string, got \(reason.value)")
+            return
+        }
+        #expect(text == "couldNotRead(keyNotFound ticket.last_name)")
+    }
+
     @Test func whenResponseIsValid_shouldLogNothing() async throws {
         let recorder = LogRecorder()
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
@@ -72,6 +72,34 @@ import Testing
         }
     }
 
+    @Test func whenResponseIsInvalid_shouldLogTheReason() async throws {
+        let recorder = LogRecorder()
+
+        try? await withDependencies {
+            $0.httpClient = .responding(with: attendeeJSON(reference: "!!!"), statusCode: 200)
+            $0.log = recorder.log
+        } operation: {
+            let sut = AttendeeRepository.liveValue
+            _ = try await sut.fetch()
+        }
+
+        #expect(recorder.events.map(\.level) == [.error])
+    }
+
+    @Test func whenResponseIsValid_shouldLogNothing() async throws {
+        let recorder = LogRecorder()
+
+        _ = try await withDependencies {
+            $0.httpClient = .responding(with: attendeeJSON(), statusCode: 200)
+            $0.log = recorder.log
+        } operation: {
+            let sut = AttendeeRepository.liveValue
+            return try await sut.fetch()
+        }
+
+        #expect(recorder.events.isEmpty)
+    }
+
     @Test func whenTransportFails_shouldThrowUnknown() async throws {
         await #expect(throws: AttendeeFetchError.unknown) {
             try await withDependencies {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/LogRecorder.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/LogRecorder.swift
@@ -1,0 +1,22 @@
+import Foundation
+import LogKit
+
+/// Captures every event written to its `log`, so a test can assert what was recorded.
+final class LogRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [LogEvent] = []
+
+    var events: [LogEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    var log: Log {
+        Log { [self] event in
+            lock.lock()
+            defer { lock.unlock() }
+            storage.append(event)
+        }
+    }
+}

--- a/Packages/LogKit/Package.resolved
+++ b/Packages/LogKit/Package.resolved
@@ -1,0 +1,60 @@
+{
+  "originHash": "8299df785ce95775862d6771cc7c4c178095cb35dc3b18a696a70525501567cc",
+  "pins": [
+    {
+      "identity": "combine-schedulers",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/combine-schedulers",
+      "state": {
+        "revision": "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "identity": "swift-clocks",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-clocks",
+      "state": {
+        "revision": "72d749bf341b78851203066ab421869b783ec42a",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "identity": "swift-concurrency-extras",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state": {
+        "revision": "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version": "1.4.0"
+      }
+    },
+    {
+      "identity": "swift-dependencies",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/swift-dependencies",
+      "state": {
+        "revision": "8dc1fbf2f6255a73dec53b4648164884898db4c5",
+        "version": "1.14.1"
+      }
+    },
+    {
+      "identity": "swift-syntax",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/swiftlang/swift-syntax",
+      "state": {
+        "revision": "4799286537280063c85a32f09884cfbca301b1a1",
+        "version": "602.0.0"
+      }
+    },
+    {
+      "identity": "xctest-dynamic-overlay",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state": {
+        "revision": "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version": "1.11.0"
+      }
+    }
+  ],
+  "version": 3
+}

--- a/Packages/LogKit/Package.swift
+++ b/Packages/LogKit/Package.swift
@@ -12,8 +12,16 @@ let package = Package(
         .library(name: "LogKit", targets: ["LogKit"]),
         .library(name: "LogKitUnified", targets: ["LogKitUnified"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
+    ],
     targets: [
-        .target(name: "LogKit"),
+        .target(
+            name: "LogKit",
+            dependencies: [
+                .product(name: "Dependencies", package: "swift-dependencies"),
+            ]
+        ),
         .target(
             name: "LogKitUnified",
             dependencies: ["LogKit"]

--- a/Packages/LogKit/Sources/LogKit/DecodingError+LogDescribable.swift
+++ b/Packages/LogKit/Sources/LogKit/DecodingError+LogDescribable.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// `DecodingError` renders readably on macOS but reflects into a dump on iOS, so logs would
+/// otherwise differ by platform. The debug description is dropped: it restates the case, and for a
+/// corrupted body it can quote the bytes the server sent.
+extension DecodingError: LogDescribable {
+    public var logDescription: String {
+        switch self {
+        case let .keyNotFound(key, context):
+            "keyNotFound \(Self.path(context, appending: key.stringValue))"
+        case let .typeMismatch(type, context):
+            "typeMismatch \(Self.path(context)) expected \(type)"
+        case let .valueNotFound(type, context):
+            "valueNotFound \(Self.path(context)) expected \(type)"
+        case .dataCorrupted:
+            "dataCorrupted"
+        @unknown default:
+            "\(self)"
+        }
+    }
+
+    private static func path(_ context: Context, appending key: String? = nil) -> String {
+        let components = context.codingPath.map(\.stringValue) + [key].compactMap { $0 }
+        return components.isEmpty ? "(root)" : components.joined(separator: ".")
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/Log+Dependency.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Dependency.swift
@@ -1,7 +1,6 @@
 import Dependencies
 
 extension Log: TestDependencyKey {
-    /// Writes nothing, so a test only logs when it asks to.
     public static let testValue = Log.none
 }
 

--- a/Packages/LogKit/Sources/LogKit/Log+Dependency.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Dependency.swift
@@ -1,0 +1,13 @@
+import Dependencies
+
+extension Log: TestDependencyKey {
+    /// Writes nothing, so a test only logs when it asks to.
+    public static let testValue = Log.none
+}
+
+extension DependencyValues {
+    public var log: Log {
+        get { self[Log.self] }
+        set { self[Log.self] = newValue }
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/LogDescribable.swift
+++ b/Packages/LogKit/Sources/LogKit/LogDescribable.swift
@@ -1,0 +1,47 @@
+/// A type that knows how it should read in a log.
+///
+/// Conform anything whose default rendering is unhelpful — notably framework errors, which reflect
+/// into a dump rather than describing themselves. Sensitivity is not part of this protocol: an
+/// error's text is like a `String`, so the call site classifies it.
+public protocol LogDescribable {
+    /// How this value should read in a log.
+    var logDescription: String { get }
+}
+
+extension String {
+    /// Creates the error's own log description, or its default rendering if it has none.
+    ///
+    /// - Parameter error: The error to describe.
+    public init(logDescribing error: any Error) {
+        self = (error as? LogDescribable)?.logDescription ?? "\(error)"
+    }
+}
+
+extension LogField {
+    /// A field carrying an error, safe to store or transmit anywhere.
+    ///
+    /// - Parameters:
+    ///   - name: The field's name.
+    ///   - error: The error to describe.
+    public static func open(_ name: FieldName, _ error: any Error) -> LogField {
+        .open(name, .string(String(logDescribing: error)))
+    }
+
+    /// A field carrying an error that may be correlated but never read.
+    ///
+    /// - Parameters:
+    ///   - name: The field's name.
+    ///   - error: The error to describe.
+    public static func hashed(_ name: FieldName, _ error: any Error) -> LogField {
+        .hashed(name, .string(String(logDescribing: error)))
+    }
+
+    /// A field carrying an error that must never leave the device.
+    ///
+    /// - Parameters:
+    ///   - name: The field's name.
+    ///   - error: The error to describe.
+    public static func secret(_ name: FieldName, _ error: any Error) -> LogField {
+        .secret(name, .string(String(logDescribing: error)))
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogDependencyTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogDependencyTests.swift
@@ -1,0 +1,24 @@
+import Dependencies
+import LogKit
+import Testing
+
+@Suite struct LogDependencyTests {
+    @Test func whenNotConfigured_shouldWriteNothing() {
+        @Dependency(\.log) var log
+
+        #expect(log.accepts(.critical, "any") == false)
+    }
+
+    @Test func whenConfigured_shouldUseTheGivenDestination() {
+        let recorder = LogRecorder()
+
+        withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            @Dependency(\.log) var log
+            log(.error, "any", "something happened")
+        }
+
+        #expect(recorder.events.map(\.message) == ["something happened"])
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogDescribableTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogDescribableTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import LogKit
+import Testing
+
+@Suite struct LogDescribableTests {
+    @Test func whenErrorDescribesItself_shouldUseThatDescription() {
+        #expect(String(logDescribing: Conforming.boom) == "CUSTOM")
+    }
+
+    @Test func whenErrorDoesNotDescribeItself_shouldFallBackToItsDefault() {
+        #expect(String(logDescribing: Plain.boom) == "boom")
+    }
+
+    @Test func whenFieldIsBuiltFromError_shouldUseItsLogDescription() {
+        #expect(LogField.open("reason", Conforming.boom) == .open("reason", "CUSTOM"))
+    }
+
+    @Test func whenFieldIsBuiltFromError_shouldKeepTheStatedSensitivity() {
+        #expect(LogField.secret("reason", Conforming.boom).sensitivity == .secret)
+        #expect(LogField.hashed("reason", Conforming.boom).sensitivity == .hashed)
+    }
+
+    @Test func whenKeyIsMissing_shouldNameThePathAndKey() throws {
+        struct Ticket: Decodable { let lastName: String }
+        struct Payload: Decodable { let ticket: Ticket }
+
+        let error = try #require(caught(decoding: #"{"ticket": {}}"#, as: Payload.self))
+
+        #expect(String(logDescribing: error) == "keyNotFound ticket.lastName")
+    }
+
+    @Test func whenTypeIsWrong_shouldNameTheExpectedType() throws {
+        struct Payload: Decodable { let count: Int }
+
+        let error = try #require(caught(decoding: #"{"count": "many"}"#, as: Payload.self))
+
+        #expect(String(logDescribing: error) == "typeMismatch count expected Int")
+    }
+
+    @Test func whenBodyIsNotJSON_shouldSayDataCorrupted() throws {
+        struct Payload: Decodable { let count: Int }
+
+        let error = try #require(caught(decoding: "not json", as: Payload.self))
+
+        #expect(String(logDescribing: error) == "dataCorrupted")
+    }
+}
+
+private enum Conforming: Error, LogDescribable {
+    case boom
+    var logDescription: String { "CUSTOM" }
+}
+
+private enum Plain: Error {
+    case boom
+}
+
+private func caught<T: Decodable>(decoding json: String, as type: T.Type) -> (any Error)? {
+    do {
+        _ = try JSONDecoder().decode(type, from: Data(json.utf8))
+        return nil
+    } catch {
+        return error
+    }
+}

--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		7B31C8F12ED0A7BF00FEEDF7 /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 7B31C8F02ED0A7BF00FEEDF7 /* Settings */; };
 		A11CE57000000000000000D1 /* AuthenticationUI in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C1 /* AuthenticationUI */; };
 		A11CE57000000000000000D2 /* AuthenticationFeature in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C2 /* AuthenticationFeature */; };
+		A11CE57000000000000000D5 /* LogKit in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C5 /* LogKit */; };
+		A11CE57000000000000000D6 /* LogKitUnified in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C6 /* LogKitUnified */; };
 		A11CE57000000000000000D3 /* SecureStorageKit in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C3 /* SecureStorageKit */; };
 		A11CE57000000000000000D4 /* SecureStorageKitKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C4 /* SecureStorageKitKeychain */; };
 		A11CE57000000000000000D5 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C5 /* Dependencies */; };
@@ -252,6 +254,7 @@
 		7B8108412E5CA00E00CCB2F5 /* SwiftLeedsPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SwiftLeedsPackage; sourceTree = "<group>"; };
 		A11CE57000000000000000A1 /* SecureStorageKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SecureStorageKit; sourceTree = "<group>"; };
 		A11CE57000000000000000A2 /* AuthenticationFeature */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AuthenticationFeature; sourceTree = "<group>"; };
+		A11CE57000000000000000A5 /* LogKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = LogKit; sourceTree = "<group>"; };
 		A11CE57000000000000000A3 /* AuthenticationUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AuthenticationUI; sourceTree = "<group>"; };
 		893A122D593379F84605F70C /* SwiftLeedsColors.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = SwiftLeedsColors.xcassets; sourceTree = "<group>"; };
 		AE1C800F289E9F3800996659 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -333,6 +336,8 @@
 				7B31C8EB2ED0959000FEEDF7 /* DesignKit in Frameworks */,
 				A11CE57000000000000000D1 /* AuthenticationUI in Frameworks */,
 				A11CE57000000000000000D2 /* AuthenticationFeature in Frameworks */,
+				A11CE57000000000000000D5 /* LogKit in Frameworks */,
+				A11CE57000000000000000D6 /* LogKitUnified in Frameworks */,
 				A11CE57000000000000000D3 /* SecureStorageKit in Frameworks */,
 				A11CE57000000000000000D4 /* SecureStorageKitKeychain in Frameworks */,
 				A11CE57000000000000000D5 /* Dependencies in Frameworks */,
@@ -437,6 +442,7 @@
 			children = (
 				A11CE57000000000000000A1 /* SecureStorageKit */,
 				A11CE57000000000000000A2 /* AuthenticationFeature */,
+				A11CE57000000000000000A5 /* LogKit */,
 				A11CE57000000000000000A3 /* AuthenticationUI */,
 			);
 			path = Packages;
@@ -714,6 +720,8 @@
 				7B8C3ECE2EE4A9F70089C6CF /* SharedAssets */,
 				A11CE57000000000000000C1 /* AuthenticationUI */,
 				A11CE57000000000000000C2 /* AuthenticationFeature */,
+				A11CE57000000000000000C5 /* LogKit */,
+				A11CE57000000000000000C6 /* LogKitUnified */,
 				A11CE57000000000000000C3 /* SecureStorageKit */,
 				A11CE57000000000000000C4 /* SecureStorageKitKeychain */,
 				A11CE57000000000000000C5 /* Dependencies */,
@@ -2003,6 +2011,14 @@
 		A11CE57000000000000000C2 /* AuthenticationFeature */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AuthenticationFeature;
+		};
+		A11CE57000000000000000C5 /* LogKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LogKit;
+		};
+		A11CE57000000000000000C6 /* LogKitUnified */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LogKitUnified;
 		};
 		A11CE57000000000000000C3 /* SecureStorageKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -2,6 +2,8 @@ import AuthenticationFeature
 import ColorTheme
 import Dependencies
 import Foundation
+import LogKit
+import LogKitUnified
 import SecureStorageKit
 import SecureStorageKitKeychain
 import SwiftUI
@@ -15,6 +17,12 @@ struct SwiftLeedsApp: App {
 
     init() {
         prepareDependencies {
+            // A fresh salt each launch, so hashed values correlate within a session but never
+            // between them. Without a bundle identifier there is no honest subsystem — this
+            // ships as two apps — so nothing is written rather than guessing at one.
+            $0.log = Bundle.main.bundleIdentifier
+                .map { Log.unified(subsystem: LogSubsystem($0), salt: .random()) }
+                ?? .none
             $0.secureStorage = .keychain(service: KeychainService("uk.co.swiftleeds.authentication"))
             $0.apiConfiguration = APIConfiguration(baseURL: URL(string: "https://\(ConferenceConfig.apiHost)")!)
             $0.httpClient = .live(onSessionExpiry: {
@@ -48,12 +56,17 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        guard let url = URL(string: Self.pushURL) else { print("⛔️ Invalid push URL"); return }
+        @Dependency(\.log) var log
+        guard let url = URL(string: Self.pushURL) else {
+            log(.error, "push", "The push URL is not a valid URL", fields: [
+                .open("pushURL", .string(Self.pushURL))
+            ])
+            return
+        }
         sendPushRegistrationDatails(to: url, deviceToken: deviceToken)
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        print("⛔️ Push registration failed:", error)
         handleFailedRegistration(application: application, error: error)
     }
 }

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -43,8 +43,6 @@ struct SwiftLeedsApp: App {
 
 // MARK: - AppDelegate
 final class AppDelegate: NSObject, UIApplicationDelegate {
-    static var pushURL: String { ConferenceConfig.pushURL }
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         URLCache.shared.diskCapacity = 100_000_000
 
@@ -57,9 +55,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         @Dependency(\.log) var log
-        guard let url = URL(string: Self.pushURL) else {
+        guard let url = URL(string: ConferenceConfig.pushURL) else {
             log(.error, "push", "The push URL is not a valid URL", fields: [
-                .open("pushURL", .string(Self.pushURL))
+                .open("pushURL", .string(ConferenceConfig.pushURL))
             ])
             return
         }

--- a/SwiftLeeds/Push/AppDelegate+Push.swift
+++ b/SwiftLeeds/Push/AppDelegate+Push.swift
@@ -1,12 +1,25 @@
+import Dependencies
+import LogKit
 import UIKit
 import UserNotifications
 
+private let push: LogCategory = "push"
+
 extension AppDelegate {
     func requestPushAuthorization(application: UIApplication) {
+        @Dependency(\.log) var log
         let notificatioNCenter = UNUserNotificationCenter.current()
         notificatioNCenter.requestAuthorization(options: [.badge, .sound, .alert]) { [weak self] isGranted, error in
-            guard isGranted else { print("⛔️ not granted"); return }
-            if let error = error { print("⛔️", error); return }
+            guard isGranted else {
+                log(.notice, push, "Notification permission was declined")
+                return
+            }
+            if let error {
+                log(.error, push, "Could not request notification permission", fields: [
+                    .open("error", .string("\(error)"))
+                ])
+                return
+            }
 
             notificatioNCenter.delegate = self
 
@@ -17,12 +30,16 @@ extension AppDelegate {
     }
 
     func sendPushRegistrationDatails(to url: URL, deviceToken: Data) {
+        @Dependency(\.log) var log
         var details = TokenDetails(token: deviceToken)
 
 #if DEBUG
         details.debug = true
-        print("🚀", details)
 #endif
+
+        log(.debug, push, "Registering for push", fields: [
+            .hashed("deviceToken", .string(deviceToken.map { String(format: "%02x", $0) }.joined()))
+        ])
 
         var request = URLRequest(url: url)
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -34,17 +51,24 @@ extension AppDelegate {
                 let (_, response) = try await URLSession.shared.data(for: request)
 
                 guard let statusCode = (response as? HTTPURLResponse)?.statusCode, 200..<399 ~= statusCode else {
-                    print("⛔️ Push registration failed, invalid response")
+                    log(.error, push, "Push registration was rejected", fields: [
+                        .open("statusCode", .integer((response as? HTTPURLResponse)?.statusCode ?? -1))
+                    ])
                     return
                 }
             } catch {
-                print("⛔️ Push registration failed due to unexpected network issue:", error)
+                log(.error, push, "Push registration could not reach the server", fields: [
+                    .open("error", .string("\(error)"))
+                ])
             }
         }
     }
 
     func handleFailedRegistration(application: UIApplication, error: Error) {
-        print("⛔️ Push registration failed:", error)
+        @Dependency(\.log) var log
+        log(.error, push, "The system refused push registration", fields: [
+            .open("error", .string("\(error)"))
+        ])
     }
 }
 


### PR DESCRIPTION
Phase 3 of the foundation work. `LogKit` was merged in #110 but nothing used it, and ten `print()`
calls remained. This adopts it.

## What changed

**Every `print()` in the app is gone**, replaced by a classified event. The one exception is
`ThemeManager`, which lives in the separate `ColorTheme` module — wiring LogKit in there for a single
line was not worth the dependency.

**LogKit is now in the Xcode project.** It was merged but never added, so it did not appear in the
navigator and the app could not use it.

**`Log` is a dependency**, declared in LogKit so the app and every feature share one key. It defaults
to `Log.none`, so nothing is written until a composition root configures it — and tests stay silent
unless they ask.

**A fresh salt each launch.** Hashed values can be matched across log lines within one session, never
between two. Nothing to store, and two log files from the same phone cannot be cross-referenced.

**Failed responses now say why.** `AttendeeMapper` records the underlying decode or parsing error
before the repository narrows it to `AttendeeFetchError`.

```
[error] The attendee response was rejected reason=couldNotRead(keyNotFound ticket.last_name)
```

`AttendeeFetchError` is unchanged — still three cases, no diagnostic payload. The detail is available
because the logging wraps the mapper, upstream of that conversion.

## Notable decisions

**Logging is a decorator, not inline code.** `AttendeeMapper` became a closure-struct registered with
a private `DependencyKey`, so it is composable without entering public API. `loggingFailures()` wraps
it, composed in `liveValue`.

**`LogDescribable` gives errors readable text.** `DecodingError` renders readably on macOS and as a
reflection dump on iOS, so logs differed by platform. Any error opts in by conforming; `.open`,
`.hashed` and `.secret` accept one directly, so the call site stays `.open("reason", error)`.

**The push device token is hashed, not printed.** It was previously dumped in full behind `#if DEBUG`.

## How to test

Checks should be green: 204 tests, up from 194.

To see it in Xcode's console, make `AttendeeMapper.live` throw and sign in — the rejection is logged
under subsystem `uk.co.swiftleeds.SwiftLeeds`, category `profile`.
