### PR TITLE
feat(LogKit): build a field from any loggable value

### DIFF
--- a/Packages/LogKit/Sources/LogKit/LogDescribable.swift
+++ b/Packages/LogKit/Sources/LogKit/LogDescribable.swift
@@ -24,7 +24,7 @@ extension LogField {
     ///   - name: The field's name.
     ///   - error: The error to describe.
     public static func open(_ name: FieldName, _ error: any Error) -> LogField {
-        .open(name, .string(String(logDescribing: error)))
+        .open(name, String(logDescribing: error))
     }
 
     /// A field carrying an error that may be correlated but never read.
@@ -33,7 +33,7 @@ extension LogField {
     ///   - name: The field's name.
     ///   - error: The error to describe.
     public static func hashed(_ name: FieldName, _ error: any Error) -> LogField {
-        .hashed(name, .string(String(logDescribing: error)))
+        .hashed(name, String(logDescribing: error))
     }
 
     /// A field carrying an error that must never leave the device.
@@ -42,6 +42,6 @@ extension LogField {
     ///   - name: The field's name.
     ///   - error: The error to describe.
     public static func secret(_ name: FieldName, _ error: any Error) -> LogField {
-        .secret(name, .string(String(logDescribing: error)))
+        .secret(name, String(logDescribing: error))
     }
 }

--- a/Packages/LogKit/Sources/LogKit/LogField.swift
+++ b/Packages/LogKit/Sources/LogKit/LogField.swift
@@ -14,17 +14,17 @@ public struct LogField: Hashable, Sendable {
     }
 
     /// A value safe to store or transmit anywhere.
-    public static func open(_ name: FieldName, _ value: LogValue) -> LogField {
-        LogField(name: name, value: value, sensitivity: .open)
+    public static func open(_ name: FieldName, _ value: some LogValueRepresentable) -> LogField {
+        LogField(name: name, value: value.logValue, sensitivity: .open)
     }
 
     /// A value that may be correlated but never read.
-    public static func hashed(_ name: FieldName, _ value: LogValue) -> LogField {
-        LogField(name: name, value: value, sensitivity: .hashed)
+    public static func hashed(_ name: FieldName, _ value: some LogValueRepresentable) -> LogField {
+        LogField(name: name, value: value.logValue, sensitivity: .hashed)
     }
 
     /// A value that must never leave the device.
-    public static func secret(_ name: FieldName, _ value: LogValue) -> LogField {
-        LogField(name: name, value: value, sensitivity: .secret)
+    public static func secret(_ name: FieldName, _ value: some LogValueRepresentable) -> LogField {
+        LogField(name: name, value: value.logValue, sensitivity: .secret)
     }
 }

--- a/Packages/LogKit/Sources/LogKit/LogValueConvertible.swift
+++ b/Packages/LogKit/Sources/LogKit/LogValueConvertible.swift
@@ -3,8 +3,8 @@
 /// Conform a type once and every field built from it is classified the same
 /// way. Standard library types deliberately do not conform: a `String` or `URL`
 /// has no inherent sensitivity, so those must be classified at the call site.
-public protocol LogValueConvertible {
-    var logValue: LogValue { get }
+/// They conform to ``LogValueRepresentable`` alone.
+public protocol LogValueConvertible: LogValueRepresentable {
     var sensitivity: Sensitivity { get }
 }
 

--- a/Packages/LogKit/Sources/LogKit/LogValueRepresentable.swift
+++ b/Packages/LogKit/Sources/LogKit/LogValueRepresentable.swift
@@ -1,0 +1,30 @@
+/// A value that can be written into a log.
+///
+/// Sensitivity is deliberately not part of this protocol. A `String` or `Int`
+/// has no inherent sensitivity, so the call site states it by choosing
+/// ``LogField/open(_:_:)``, ``LogField/hashed(_:_:)`` or
+/// ``LogField/secret(_:_:)``. A type that does carry its own sensitivity
+/// conforms to ``LogValueConvertible`` instead.
+public protocol LogValueRepresentable {
+    var logValue: LogValue { get }
+}
+
+extension LogValue: LogValueRepresentable {
+    public var logValue: LogValue { self }
+}
+
+extension String: LogValueRepresentable {
+    public var logValue: LogValue { .string(self) }
+}
+
+extension Int: LogValueRepresentable {
+    public var logValue: LogValue { .integer(self) }
+}
+
+extension Double: LogValueRepresentable {
+    public var logValue: LogValue { .double(self) }
+}
+
+extension Bool: LogValueRepresentable {
+    public var logValue: LogValue { .boolean(self) }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogFieldValueTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogFieldValueTests.swift
@@ -1,0 +1,51 @@
+import LogKit
+import Testing
+
+/// Every value here is held in a variable rather than written as a literal.
+/// `LogValue` is `ExpressibleByStringLiteral`, so a literal would compile even
+/// without these conformances and would hide the gap these cover.
+@Suite struct LogFieldValueTests {
+    @Test func whenBuiltFromStringVariable_shouldNeedNoExplicitCase() {
+        let value = "https://example.com/push"
+
+        #expect(LogField.open("url", value).value == .string(value))
+    }
+
+    @Test func whenBuiltFromIntegerVariable_shouldStayNumber() {
+        let value = 401
+
+        #expect(LogField.open("status", value).value == .integer(value))
+    }
+
+    @Test func whenBuiltFromDoubleVariable_shouldStayDouble() {
+        let value = 1.5
+
+        #expect(LogField.open("duration", value).value == .double(value))
+    }
+
+    @Test func whenBuiltFromBooleanVariable_shouldStayBoolean() {
+        let value = true
+
+        #expect(LogField.open("retried", value).value == .boolean(value))
+    }
+
+    @Test func whenBuiltFromLogValueVariable_shouldPassItThrough() {
+        let value = LogValue.array(["a", "b"])
+
+        #expect(LogField.open("tags", value).value == value)
+    }
+
+    @Test(arguments: [Sensitivity.open, .hashed, .secret])
+    func whenBuiltFromVariable_shouldKeepTheChosenSensitivity(sensitivity: Sensitivity) {
+        let value = "ada@example.com"
+
+        let sut = switch sensitivity {
+        case .open: LogField.open("email", value)
+        case .hashed: LogField.hashed("email", value)
+        case .secret: LogField.secret("email", value)
+        }
+
+        #expect(sut.sensitivity == sensitivity)
+        #expect(sut.value == .string(value))
+    }
+}

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -57,7 +57,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         @Dependency(\.log) var log
         guard let url = URL(string: ConferenceConfig.pushURL) else {
             log(.error, "push", "The push URL is not a valid URL", fields: [
-                .open("pushURL", .string(ConferenceConfig.pushURL))
+                .open("pushURL", ConferenceConfig.pushURL)
             ])
             return
         }

--- a/SwiftLeeds/Push/AppDelegate+Push.swift
+++ b/SwiftLeeds/Push/AppDelegate+Push.swift
@@ -16,7 +16,7 @@ extension AppDelegate {
             }
             if let error {
                 log(.error, push, "Could not request notification permission", fields: [
-                    .open("error", .string("\(error)"))
+                    .open("error", error)
                 ])
                 return
             }
@@ -38,7 +38,7 @@ extension AppDelegate {
 #endif
 
         log(.debug, push, "Registering for push", fields: [
-            .hashed("deviceToken", .string(deviceToken.map { String(format: "%02x", $0) }.joined()))
+            .hashed("deviceToken", deviceToken.map { String(format: "%02x", $0) }.joined())
         ])
 
         var request = URLRequest(url: url)
@@ -52,13 +52,13 @@ extension AppDelegate {
 
                 guard let statusCode = (response as? HTTPURLResponse)?.statusCode, 200..<399 ~= statusCode else {
                     log(.error, push, "Push registration was rejected", fields: [
-                        .open("statusCode", .integer((response as? HTTPURLResponse)?.statusCode ?? -1))
+                        .open("statusCode", (response as? HTTPURLResponse)?.statusCode ?? -1)
                     ])
                     return
                 }
             } catch {
                 log(.error, push, "Push registration could not reach the server", fields: [
-                    .open("error", .string("\(error)"))
+                    .open("error", error)
                 ])
             }
         }
@@ -67,7 +67,7 @@ extension AppDelegate {
     func handleFailedRegistration(application: UIApplication, error: Error) {
         @Dependency(\.log) var log
         log(.error, push, "The system refused push registration", fields: [
-            .open("error", .string("\(error)"))
+            .open("error", error)
         ])
     }
 }


### PR DESCRIPTION
## Problem

Building a log field meant naming the `LogValue` case by hand, even for a plain string:

    .open("pushURL", .string(ConferenceConfig.pushURL))
    .open("statusCode", .integer(statusCode))

`LogValue` is `ExpressibleByStringLiteral`, so a literal reads fine and the tests, which only ever pass literals, looked clean. The wart only appears with a variable, which is what every real call site has.

## Solution

`LogValueRepresentable` describes how a value renders in a log, with conformances for `String`, `Int`, `Double`, `Bool` and `LogValue` itself. `LogField.open`, `hashed` and `secret` become generic over it, so the case name goes away:

    .open("pushURL", ConferenceConfig.pushURL)
    .open("statusCode", statusCode)

Sensitivity stays at the call site, which is what `LogValueConvertible`'s docs require: a `String` has no inherent sensitivity. `LogValueConvertible` now refines the new protocol, so it adds only `sensitivity`.

Five call sites follow. The three carrying errors move to the existing `LogDescribable` overload, so a `DecodingError` now reads as `keyNotFound attendee.email` rather than a reflected dump.

## How to test

- `swift test` in each package: LogKit 88, AuthenticationFeature 52, AuthenticationUI 54, SecureStorageKit 16.
- The six new tests in `LogFieldValueTests` hold every value in a variable, not a literal, so they fail if a conformance is wrong. Verified by breaking `String` and `Int` and watching 10 issues appear.
- Build the app: no new warnings.
