### PR TITLE
feat(LogKit): name the level at the call site

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
@@ -13,9 +13,8 @@ extension AttendeeMapper {
                 // Resolved per call, so a test overriding \.log is honoured. Resolving it while
                 // building liveValue would capture whichever log existed first.
                 @Dependency(\.log) var log
-                log(.error, "profile", "The attendee response was rejected", fields: [
-                    .open("reason", error)
-                ])
+                log(.error, "profile", "The attendee response was rejected",
+                    .open("reason", error))
                 throw error
             }
         }

--- a/Packages/LogKit/Sources/LogKit/Log+Combine.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Combine.swift
@@ -1,22 +1,17 @@
 extension Log {
-    /// A log that writes nowhere and accepts nothing.
+    /// A log that writes nowhere.
     ///
     /// Use it to include a destination conditionally without branching, or to
     /// silence logging entirely. Combining with it changes nothing.
-    public static let none = Log(accepts: { _, _ in false }, write: { _ in })
+    public static let none = Log { _ in }
 
     /// Writes each event to every given log, in order.
     public static func combine(_ logs: [Log]) -> Log {
-        Log(
-            accepts: { level, category in
-                logs.contains { $0.accepts(level, category) }
-            },
-            write: { event in
-                for log in logs {
-                    log.write(event)
-                }
+        Log { event in
+            for log in logs {
+                log.write(event)
             }
-        )
+        }
     }
 
     /// Writes each event to both logs.

--- a/Packages/LogKit/Sources/LogKit/Log+Levels.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Levels.swift
@@ -1,0 +1,76 @@
+// One method per level rather than a shared helper: the source literals must
+// expand at the call site, so every public entry point has to declare them
+// itself. See `callAsFunction`.
+extension Log {
+    /// Records a debug event.
+    public func debug(
+        _ message: LogMessage,
+        in category: LogCategory,
+        _ fields: LogField...,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        self(.debug, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+    }
+
+    /// Records an informational event.
+    public func info(
+        _ message: LogMessage,
+        in category: LogCategory,
+        _ fields: LogField...,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        self(.info, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+    }
+
+    /// Records an event worth noticing but not acting on.
+    public func notice(
+        _ message: LogMessage,
+        in category: LogCategory,
+        _ fields: LogField...,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        self(.notice, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+    }
+
+    /// Records an event that may lead to a failure.
+    public func warning(
+        _ message: LogMessage,
+        in category: LogCategory,
+        _ fields: LogField...,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        self(.warning, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+    }
+
+    /// Records a failure.
+    public func error(
+        _ message: LogMessage,
+        in category: LogCategory,
+        _ fields: LogField...,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        self(.error, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+    }
+
+    /// Records a failure that leaves the app unable to continue as intended.
+    public func critical(
+        _ message: LogMessage,
+        in category: LogCategory,
+        _ fields: LogField...,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        self(.critical, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+    }
+}

--- a/Packages/LogKit/Sources/LogKit/Log+Levels.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Levels.swift
@@ -11,7 +11,7 @@ extension Log {
         function: String = #function,
         line: Int = #line
     ) {
-        self(.debug, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+        record(.debug, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records an informational event.
@@ -23,7 +23,7 @@ extension Log {
         function: String = #function,
         line: Int = #line
     ) {
-        self(.info, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+        record(.info, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records an event worth noticing but not acting on.
@@ -35,7 +35,7 @@ extension Log {
         function: String = #function,
         line: Int = #line
     ) {
-        self(.notice, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+        record(.notice, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records an event that may lead to a failure.
@@ -47,7 +47,7 @@ extension Log {
         function: String = #function,
         line: Int = #line
     ) {
-        self(.warning, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+        record(.warning, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records a failure.
@@ -59,7 +59,7 @@ extension Log {
         function: String = #function,
         line: Int = #line
     ) {
-        self(.error, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+        record(.error, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records a failure that leaves the app unable to continue as intended.
@@ -71,6 +71,6 @@ extension Log {
         function: String = #function,
         line: Int = #line
     ) {
-        self(.critical, category, message, fields: LogFields(fields), file: file, function: function, line: line)
+        record(.critical, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
     }
 }

--- a/Packages/LogKit/Sources/LogKit/Log+Transform.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Transform.swift
@@ -2,62 +2,40 @@ extension Log {
     /// Rewrites each event on its way in. A log consumes events rather than producing them,
     /// so the transform runs before this log sees anything.
     ///
-    /// The transform may change level or category, so the result accepts everything and lets
-    /// `write` decide. Use ``mappingFields(_:)`` when only fields change.
+    /// Use ``mappingFields(_:)`` when only fields change.
     public func pullback(_ transform: @escaping @Sendable (LogEvent) -> LogEvent) -> Log {
         Log { event in write(transform(event)) }
     }
 
-    /// Rewrites only the fields, keeping the level and category, so the cheap
-    /// pre-check still applies.
+    /// Rewrites only the fields, keeping the level and category.
     public func mappingFields(_ transform: @escaping @Sendable (LogFields) -> LogFields) -> Log {
-        Log(accepts: accepts) { event in
-            write(
-                LogEvent(
-                    level: event.level,
-                    category: event.category,
-                    message: event.message,
-                    fields: transform(event.fields),
-                    source: event.source
-                )
+        pullback { event in
+            LogEvent(
+                level: event.level,
+                category: event.category,
+                message: event.message,
+                fields: transform(event.fields),
+                source: event.source
             )
         }
     }
 
     /// Passes on only the events satisfying the predicate.
-    ///
-    /// The predicate needs a whole event, so it cannot inform the pre-check.
     public func filtered(by isIncluded: @escaping @Sendable (LogEvent) -> Bool) -> Log {
-        Log(accepts: accepts) { event in
+        Log { event in
             guard isIncluded(event) else { return }
             write(event)
         }
     }
 
-    /// Drops anything less severe than `level`, before the event is built.
+    /// Drops anything less severe than `level`.
     public func atLeast(_ level: LogLevel) -> Log {
-        Log(
-            accepts: { eventLevel, category in
-                eventLevel >= level && accepts(eventLevel, category)
-            },
-            write: { event in
-                guard event.level >= level else { return }
-                write(event)
-            }
-        )
+        filtered { $0.level >= level }
     }
 
-    /// Passes on only the given categories, before the event is built.
+    /// Passes on only the given categories.
     public func only(_ categories: Set<LogCategory>) -> Log {
-        Log(
-            accepts: { level, category in
-                categories.contains(category) && accepts(level, category)
-            },
-            write: { event in
-                guard categories.contains(event.category) else { return }
-                write(event)
-            }
-        )
+        filtered { categories.contains($0.category) }
     }
 
     /// Removes secret fields before this log sees them.
@@ -76,17 +54,8 @@ extension Log {
 
     /// Writes only while consent is given.
     ///
-    /// Checked per event, so withdrawing consent takes effect immediately, and
-    /// checked in the pre-check too, so a withheld consent costs nothing.
+    /// Checked per event, so withdrawing consent takes effect immediately.
     public func consented(by isGranted: @escaping @Sendable () -> Bool) -> Log {
-        Log(
-            accepts: { level, category in
-                isGranted() && accepts(level, category)
-            },
-            write: { event in
-                guard isGranted() else { return }
-                write(event)
-            }
-        )
+        filtered { _ in isGranted() }
     }
 }

--- a/Packages/LogKit/Sources/LogKit/Log+Write.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Write.swift
@@ -1,19 +1,37 @@
 extension Log {
     /// Records an event.
     ///
-    /// `fields` is only evaluated once something would write the event, so a log filtered out
-    /// by level or category costs a single comparison.
-    ///
     /// The source literals must stay in this signature. Moved into a helper's defaults they
     /// would expand there instead of at the call site.
     public func callAsFunction(
         _ level: LogLevel,
         _ category: LogCategory,
         _ message: LogMessage,
-        fields: @autoclosure @Sendable () -> LogFields = LogFields(),
+        _ fields: LogField...,
         file: String = #fileID,
         function: String = #function,
         line: Int = #line
+    ) {
+        record(
+            level,
+            category,
+            message,
+            LogFields(fields),
+            SourceLocation(file: file, function: function, line: line)
+        )
+    }
+
+    /// The shared body behind every entry point.
+    ///
+    /// Takes the source location as a value rather than defaulting it, so the literals stay at
+    /// the call site. Fields arrive already collected because Swift cannot forward one variadic
+    /// parameter into another.
+    func record(
+        _ level: LogLevel,
+        _ category: LogCategory,
+        _ message: LogMessage,
+        _ fields: LogFields,
+        _ source: SourceLocation
     ) {
         guard accepts(level, category) else { return }
 
@@ -22,8 +40,8 @@ extension Log {
                 level: level,
                 category: category,
                 message: message,
-                fields: fields(),
-                source: SourceLocation(file: file, function: function, line: line)
+                fields: fields,
+                source: source
             )
         )
     }

--- a/Packages/LogKit/Sources/LogKit/Log+Write.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Write.swift
@@ -33,8 +33,6 @@ extension Log {
         _ fields: LogFields,
         _ source: SourceLocation
     ) {
-        guard accepts(level, category) else { return }
-
         write(
             LogEvent(
                 level: level,

--- a/Packages/LogKit/Sources/LogKit/Log.swift
+++ b/Packages/LogKit/Sources/LogKit/Log.swift
@@ -3,24 +3,9 @@
 /// A destination is a `Log`, and so is any composition of destinations, so
 /// callers only ever hold one type.
 public struct Log: Sendable {
-    /// Whether an event with this level and category would reach anything.
-    ///
-    /// Consulted before an event is built, so a log nobody keeps costs only
-    /// this comparison. Answering `true` is always safe: `write` filters again.
-    public var accepts: @Sendable (LogLevel, LogCategory) -> Bool
-
     public var write: @Sendable (LogEvent) -> Void
 
-    public init(
-        accepts: @escaping @Sendable (LogLevel, LogCategory) -> Bool,
-        write: @escaping @Sendable (LogEvent) -> Void
-    ) {
-        self.accepts = accepts
-        self.write = write
-    }
-
-    /// A destination that accepts everything.
     public init(write: @escaping @Sendable (LogEvent) -> Void) {
-        self.init(accepts: { _, _ in true }, write: write)
+        self.write = write
     }
 }

--- a/Packages/LogKit/Tests/LogKitTests/LogDependencyTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogDependencyTests.swift
@@ -3,10 +3,12 @@ import LogKit
 import Testing
 
 @Suite struct LogDependencyTests {
-    @Test func whenNotConfigured_shouldWriteNothing() {
+    /// The default is `Log.none`, so a test that forgets to override gets silence rather than
+    /// real output. That it writes nowhere is covered by `LogCombineTests`.
+    @Test func whenNotConfigured_shouldNotTrap() {
         @Dependency(\.log) var log
 
-        #expect(log.accepts(.critical, "any") == false)
+        log(.critical, "any", "goes nowhere")
     }
 
     @Test func whenConfigured_shouldUseTheGivenDestination() {

--- a/Packages/LogKit/Tests/LogKitTests/LogLevelMethodTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogLevelMethodTests.swift
@@ -1,0 +1,52 @@
+import LogKit
+import Testing
+
+@Suite struct LogLevelMethodTests {
+    @Test func whenLoggingAtEachLevel_shouldRecordThatLevel() {
+        let recorder = LogRecorder()
+        let sut = recorder.log
+
+        sut.debug("d", in: "push")
+        sut.info("i", in: "push")
+        sut.notice("n", in: "push")
+        sut.warning("w", in: "push")
+        sut.error("e", in: "push")
+        sut.critical("c", in: "push")
+
+        #expect(recorder.events.map(\.level) == [.debug, .info, .notice, .warning, .error, .critical])
+    }
+
+    @Test func whenLogging_shouldCarryCategoryAndMessage() {
+        let recorder = LogRecorder()
+
+        recorder.log.error("The push URL is not a valid URL", in: "push")
+
+        #expect(recorder.events.first?.category == "push")
+        #expect(recorder.events.first?.message == "The push URL is not a valid URL")
+    }
+
+    @Test func whenGivenSeveralFields_shouldKeepThemInWrittenOrder() {
+        let recorder = LogRecorder()
+
+        recorder.log.error("ordered", in: "push", .open("first", 1), .hashed("second", "x"), .secret("third", true))
+
+        #expect(recorder.events.first?.fields.map(\.name) == ["first", "second", "third"])
+    }
+
+    /// The literals must expand where the developer wrote the call, not inside the level method.
+    @Test func whenLogging_shouldCaptureTheCallSiteNotTheHelper() {
+        let recorder = LogRecorder()
+
+        recorder.log.error("located", in: "push")
+
+        #expect(recorder.events.first?.source.file.hasSuffix("LogLevelMethodTests.swift") == true)
+    }
+
+    @Test func whenLevelIsBelowMinimum_shouldNotWrite() {
+        let recorder = LogRecorder()
+
+        recorder.log.atLeast(.error).debug("ignored", in: "push")
+
+        #expect(recorder.events.isEmpty)
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogWriteTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogWriteTests.swift
@@ -1,54 +1,62 @@
-import Foundation
 import LogKit
 import Testing
 
 @Suite struct LogWriteTests {
-    @Test func whenLevelIsBelowMinimum_shouldNotBuildFields() {
+    @Test func whenLevelIsBelowMinimum_shouldNotWrite() {
         let recorder = LogRecorder()
-        let counter = CallCounter()
         let sut = recorder.log.atLeast(.error)
 
-        sut(.debug, "push", "ignored", fields: counter.record())
+        sut(.debug, "push", "ignored")
 
-        #expect(counter.count == 0)
         #expect(recorder.events.isEmpty)
     }
 
-    @Test func whenCategoryIsNotListed_shouldNotBuildFields() {
+    @Test func whenCategoryIsNotListed_shouldNotWrite() {
         let recorder = LogRecorder()
-        let counter = CallCounter()
         let sut = recorder.log.only(["push"])
 
-        sut(.error, "theme", "ignored", fields: counter.record())
+        sut(.error, "theme", "ignored")
 
-        #expect(counter.count == 0)
+        #expect(recorder.events.isEmpty)
     }
 
-    @Test func whenConsentIsWithheld_shouldNotBuildFields() {
+    @Test func whenConsentIsWithheld_shouldNotWrite() {
         let recorder = LogRecorder()
-        let counter = CallCounter()
         let sut = recorder.log.consented { false }
 
-        sut(.error, "push", "ignored", fields: counter.record())
+        sut(.error, "push", "ignored")
 
-        #expect(counter.count == 0)
+        #expect(recorder.events.isEmpty)
     }
 
-    @Test func whenEventIsAccepted_shouldBuildFieldsExactlyOnce() {
-        let counter = CallCounter()
-        let sut = Log.combine([LogRecorder().log, LogRecorder().log, LogRecorder().log])
+    @Test func whenWritingToNone_shouldNotWrite() {
+        let recorder = LogRecorder()
 
-        sut(.error, "push", "kept", fields: counter.record())
+        Log.none(.critical, "push", "nowhere")
 
-        #expect(counter.count == 1)
+        #expect(recorder.events.isEmpty)
     }
 
-    @Test func whenWritingToNone_shouldNotBuildFields() {
-        let counter = CallCounter()
+    /// The filtering tests above pass through destinations that filter again inside `write`, so
+    /// they cannot see the `accepts` pre-check. This isolates it: `write` here records everything.
+    @Test func whenAcceptsRefuses_shouldNotReachWrite() {
+        let recorder = LogRecorder()
+        let sut = Log(accepts: { _, _ in false }, write: recorder.log.write)
 
-        Log.none(.critical, "push", "nowhere", fields: counter.record())
+        sut(.error, "push", "ignored")
 
-        #expect(counter.count == 0)
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func whenCombined_shouldWriteToEveryDestinationOnce() {
+        let first = LogRecorder()
+        let second = LogRecorder()
+        let sut = Log.combine([first.log, second.log])
+
+        sut(.error, "push", "kept")
+
+        #expect(first.events.count == 1)
+        #expect(second.events.count == 1)
     }
 
     @Test func whenOneOfManyDestinationsAccepts_shouldStillWrite() {
@@ -62,29 +70,19 @@ import Testing
         #expect(loud.events.map(\.message) == ["partial"])
     }
 
+    @Test func whenGivenSeveralFields_shouldKeepThemInWrittenOrder() {
+        let recorder = LogRecorder()
+
+        recorder.log(.error, "push", "ordered", .open("first", 1), .hashed("second", "x"), .secret("third", true))
+
+        #expect(recorder.events.first?.fields.map(\.name) == ["first", "second", "third"])
+    }
+
     @Test func whenRecordingEvent_shouldCaptureCallSite() {
         let recorder = LogRecorder()
 
         recorder.log(.info, "push", "located")
 
         #expect(recorder.events.first?.source.file.hasSuffix("LogWriteTests.swift") == true)
-    }
-}
-
-private final class CallCounter: @unchecked Sendable {
-    private let lock = NSLock()
-    private var storage = 0
-
-    var count: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return storage
-    }
-
-    func record() -> LogFields {
-        lock.lock()
-        defer { lock.unlock() }
-        storage += 1
-        return [.open("built", true)]
     }
 }

--- a/Packages/LogKit/Tests/LogKitTests/LogWriteTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogWriteTests.swift
@@ -29,25 +29,6 @@ import Testing
         #expect(recorder.events.isEmpty)
     }
 
-    @Test func whenWritingToNone_shouldNotWrite() {
-        let recorder = LogRecorder()
-
-        Log.none(.critical, "push", "nowhere")
-
-        #expect(recorder.events.isEmpty)
-    }
-
-    /// The filtering tests above pass through destinations that filter again inside `write`, so
-    /// they cannot see the `accepts` pre-check. This isolates it: `write` here records everything.
-    @Test func whenAcceptsRefuses_shouldNotReachWrite() {
-        let recorder = LogRecorder()
-        let sut = Log(accepts: { _, _ in false }, write: recorder.log.write)
-
-        sut(.error, "push", "ignored")
-
-        #expect(recorder.events.isEmpty)
-    }
-
     @Test func whenCombined_shouldWriteToEveryDestinationOnce() {
         let first = LogRecorder()
         let second = LogRecorder()

--- a/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
+++ b/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
@@ -4,18 +4,14 @@ import Testing
 
 @testable import LogKitUnified
 
+/// Unified logging cannot be read back from a test process, so these exercise every path for a
+/// trap or a precondition failure rather than asserting on output. What the destination *renders*
+/// is covered by `LogValueRenderingTests`.
 @Suite struct LogUnifiedTests {
     private let subsystem: LogSubsystem = "uk.co.swiftleeds.tests"
     private let salt = LogSalt(Data("fixed-for-tests".utf8))
 
-    @Test func whenBuilt_shouldAcceptEveryLevelAndCategory() {
-        let sut = Log.unified(subsystem: subsystem, salt: salt)
-
-        #expect(sut.accepts(.debug, "push"))
-        #expect(sut.accepts(.critical, "theme"))
-    }
-
-    @Test func whenWritingEveryLevelAndSensitivity_shouldReachUnifiedLogging() {
+    @Test func whenWritingEveryLevelAndSensitivity_shouldNotTrap() {
         let sut = Log.unified(subsystem: subsystem, salt: salt)
 
         for level in LogLevel.allCases {
@@ -29,16 +25,12 @@ import Testing
                 .secret("token", "abc123")
             )
         }
-
-        #expect(sut.accepts(.info, "push"))
     }
 
-    @Test func whenSameCategoryIsUsedTwice_shouldReuseItsLogger() {
+    @Test func whenSameCategoryIsUsedTwice_shouldNotTrap() {
         let sut = Log.unified(subsystem: subsystem, salt: salt)
 
         sut(.info, "push", "first")
         sut(.info, "push", "second")
-
-        #expect(sut.accepts(.info, "push"))
     }
 }

--- a/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
+++ b/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
@@ -23,12 +23,10 @@ import Testing
                 level,
                 "push",
                 "exercised every sensitivity",
-                fields: [
-                    .open("category", "registration"),
-                    .hashed("email", "ada@example.com"),
-                    .hashed("reference", "ABCD-1"),
-                    .secret("token", "abc123"),
-                ]
+                .open("category", "registration"),
+                .hashed("email", "ada@example.com"),
+                .hashed("reference", "ABCD-1"),
+                .secret("token", "abc123")
             )
         }
 

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -56,9 +56,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         @Dependency(\.log) var log
         guard let url = URL(string: ConferenceConfig.pushURL) else {
-            log(.error, "push", "The push URL is not a valid URL", fields: [
-                .open("pushURL", ConferenceConfig.pushURL)
-            ])
+            log(.error, "push", "The push URL is not a valid URL",
+                .open("pushURL", ConferenceConfig.pushURL))
             return
         }
         sendPushRegistrationDatails(to: url, deviceToken: deviceToken)

--- a/SwiftLeeds/Push/AppDelegate+Push.swift
+++ b/SwiftLeeds/Push/AppDelegate+Push.swift
@@ -15,9 +15,8 @@ extension AppDelegate {
                 return
             }
             if let error {
-                log(.error, push, "Could not request notification permission", fields: [
-                    .open("error", error)
-                ])
+                log(.error, push, "Could not request notification permission",
+                    .open("error", error))
                 return
             }
 
@@ -37,9 +36,8 @@ extension AppDelegate {
         details.debug = true
 #endif
 
-        log(.debug, push, "Registering for push", fields: [
-            .hashed("deviceToken", deviceToken.map { String(format: "%02x", $0) }.joined())
-        ])
+        log(.debug, push, "Registering for push",
+            .hashed("deviceToken", deviceToken.map { String(format: "%02x", $0) }.joined()))
 
         var request = URLRequest(url: url)
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -51,24 +49,21 @@ extension AppDelegate {
                 let (_, response) = try await URLSession.shared.data(for: request)
 
                 guard let statusCode = (response as? HTTPURLResponse)?.statusCode, 200..<399 ~= statusCode else {
-                    log(.error, push, "Push registration was rejected", fields: [
-                        .open("statusCode", (response as? HTTPURLResponse)?.statusCode ?? -1)
-                    ])
+                    log(.error, push, "Push registration was rejected",
+                        .open("statusCode", (response as? HTTPURLResponse)?.statusCode ?? -1))
                     return
                 }
             } catch {
-                log(.error, push, "Push registration could not reach the server", fields: [
-                    .open("error", error)
-                ])
+                log(.error, push, "Push registration could not reach the server",
+                    .open("error", error))
             }
         }
     }
 
     func handleFailedRegistration(application: UIApplication, error: Error) {
         @Dependency(\.log) var log
-        log(.error, push, "The system refused push registration", fields: [
-            .open("error", error)
-        ])
+        log(.error, push, "The system refused push registration",
+            .open("error", error))
     }
 }
 


### PR DESCRIPTION
## Problem

Three things, all visible in one call site:

    log(.error, "push", "The push URL is not a valid URL", fields: [
        .open("pushURL", ConferenceConfig.pushURL)
    ])

`.error` and `"push"` are unlabelled, so the call reads as a list rather than a sentence. Typing `log.` offered `callAsFunction`, `accepts` and `write`, none of which answer the first question a developer has. And `fields` had to be a labelled array because it was an `@autoclosure`.

That delay existed to skip building fields for an event nobody wants. **It never fired.** No filtering is applied anywhere in the app, so `accepts` always said yes. We paid its call-site cost on every log line to save nothing.

## Solution

    log.error("The push URL is not a valid URL", in: .push,
        .open("pushURL", ConferenceConfig.pushURL))

Three commits:

1. **Level methods.** `debug` through `critical`, so the six levels appear in autocomplete. `callAsFunction` stays for a computed level.
2. **Fields as a list.** Drops the `@autoclosure`, and with it the five tests asserting the laziness.
3. **Remove `accepts`.** Its only job was that delay. It also stated each filter rule twice, once in `accepts` and once in `write`, where only the `write` copy protected anything. `atLeast`, `only` and `consented` are now one line each on `filtered`, and `mappingFields` is built on `pullback`. Net 110 lines deleted.

## Tests removed, and why

Three assertions relied on `accepts` and were weak:

- Two in `LogUnifiedTests` ended with `#expect(sut.accepts(.info, "push"))`, which asserts a constant `true`. Unified logging cannot be read back from a test process, so these are honestly renamed `shouldNotTrap`, with a suite comment saying so. What the destination renders is covered by `LogValueRenderingTests`.
- One in `LogDependencyTests` used `accepts` as a stand-in for "writes nothing". `Log.none` is covered by five tests in `LogCombineTests`.

## How to test

- `swift test` per package: LogKit 92, AuthenticationFeature 52, AuthenticationUI 54, SecureStorageKit 16.
- Probes run and reverted: swapping two levels fails the level test; removing the `#fileID` forwarding fails the call-site test, which is what stops these methods being refactored into a shared helper; making `filtered` pass everything fails 10 assertions; reversing field order fails 10.
- App build clean, checked for `warning:` and not just success.
