### PR TITLE
feat(SwiftLeeds): name log categories once

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/LogCategories.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/LogCategories.swift
@@ -1,0 +1,7 @@
+import LogKit
+
+/// This feature's log categories. Naming them once means a typo cannot silently create a second
+/// category and split a filter in two.
+extension LogCategory {
+    static let profile: Self = "profile"
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
@@ -13,7 +13,7 @@ extension AttendeeMapper {
                 // Resolved per call, so a test overriding \.log is honoured. Resolving it while
                 // building liveValue would capture whichever log existed first.
                 @Dependency(\.log) var log
-                log(.error, "profile", "The attendee response was rejected",
+                log.error("The attendee response was rejected", in: .profile,
                     .open("reason", error))
                 throw error
             }

--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		AE9367902A93467500F2DB3F /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE93678E2A93455400F2DB3F /* ScheduleView.swift */; };
 		AEB06BD128CF8D2100E51967 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB06BD028CF8D2100E51967 /* WebView.swift */; };
 		AECB295727417F9D00CDC983 /* SwiftLeedsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB295627417F9D00CDC983 /* SwiftLeedsApp.swift */; };
+		AECB2A0127417F9D00CDC902 /* LogCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB2A0027417F9D00CDC901 /* LogCategories.swift */; };
 		AECB295927417F9D00CDC983 /* MyConferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB295827417F9D00CDC983 /* MyConferenceView.swift */; };
 		AECB296827417F9E00CDC983 /* SwiftLeedsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB296727417F9E00CDC983 /* SwiftLeedsTests.swift */; };
 		AECB297227417F9E00CDC983 /* SwiftLeedsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB297127417F9E00CDC983 /* SwiftLeedsUITests.swift */; };
@@ -270,6 +271,7 @@
 		AEB06BD028CF8D2100E51967 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		AECB295327417F9D00CDC983 /* SwiftLeeds.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftLeeds.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AECB295627417F9D00CDC983 /* SwiftLeedsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLeedsApp.swift; sourceTree = "<group>"; };
+		AECB2A0027417F9D00CDC901 /* LogCategories.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogCategories.swift; sourceTree = "<group>"; };
 		AECB295827417F9D00CDC983 /* MyConferenceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyConferenceView.swift; sourceTree = "<group>"; };
 		AECB296327417F9E00CDC983 /* SwiftLeedsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftLeedsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AECB296727417F9E00CDC983 /* SwiftLeedsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLeedsTests.swift; sourceTree = "<group>"; };
@@ -548,6 +550,7 @@
 			children = (
 				AECB29832741ABFD00CDC983 /* Info.plist */,
 				AECB295627417F9D00CDC983 /* SwiftLeedsApp.swift */,
+				AECB2A0027417F9D00CDC901 /* LogCategories.swift */,
 				740162D92A7053A000C2D1B3 /* AppState.swift */,
 				67624B7470D6BA62D4912236 /* ConferenceConfig.swift */,
 			);
@@ -970,6 +973,7 @@
 				E3569AEF2E5A1D0200BC9556 /* ShimmerView.swift in Sources */,
 				0B4B1A4D2A486EA800ED7EA9 /* SponsorsViewModel.swift in Sources */,
 				AECB295727417F9D00CDC983 /* SwiftLeedsApp.swift in Sources */,
+				AECB2A0127417F9D00CDC902 /* LogCategories.swift in Sources */,
 				0B59B5662E70E5D400820C3C /* TeamMember.swift in Sources */,
 				0B4B1A4B2A4858F600ED7EA9 /* SponsorsView.swift in Sources */,
 				AE8C1B2B28C4B39A00AF7318 /* TokenDetails.swift in Sources */,

--- a/SwiftLeeds/App/LogCategories.swift
+++ b/SwiftLeeds/App/LogCategories.swift
@@ -1,0 +1,7 @@
+import LogKit
+
+/// The app's log categories. Naming them once means a typo cannot silently create a second
+/// category and split a filter in two.
+extension LogCategory {
+    static let push: Self = "push"
+}

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -56,7 +56,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         @Dependency(\.log) var log
         guard let url = URL(string: ConferenceConfig.pushURL) else {
-            log(.error, "push", "The push URL is not a valid URL",
+            log.error("The push URL is not a valid URL", in: .push,
                 .open("pushURL", ConferenceConfig.pushURL))
             return
         }

--- a/SwiftLeeds/Push/AppDelegate+Push.swift
+++ b/SwiftLeeds/Push/AppDelegate+Push.swift
@@ -3,19 +3,17 @@ import LogKit
 import UIKit
 import UserNotifications
 
-private let push: LogCategory = "push"
-
 extension AppDelegate {
     func requestPushAuthorization(application: UIApplication) {
         @Dependency(\.log) var log
         let notificatioNCenter = UNUserNotificationCenter.current()
         notificatioNCenter.requestAuthorization(options: [.badge, .sound, .alert]) { [weak self] isGranted, error in
             guard isGranted else {
-                log(.notice, push, "Notification permission was declined")
+                log.notice("Notification permission was declined", in: .push)
                 return
             }
             if let error {
-                log(.error, push, "Could not request notification permission",
+                log.error("Could not request notification permission", in: .push,
                     .open("error", error))
                 return
             }
@@ -36,7 +34,7 @@ extension AppDelegate {
         details.debug = true
 #endif
 
-        log(.debug, push, "Registering for push",
+        log.debug("Registering for push", in: .push,
             .hashed("deviceToken", deviceToken.map { String(format: "%02x", $0) }.joined()))
 
         var request = URLRequest(url: url)
@@ -49,12 +47,12 @@ extension AppDelegate {
                 let (_, response) = try await URLSession.shared.data(for: request)
 
                 guard let statusCode = (response as? HTTPURLResponse)?.statusCode, 200..<399 ~= statusCode else {
-                    log(.error, push, "Push registration was rejected",
+                    log.error("Push registration was rejected", in: .push,
                         .open("statusCode", (response as? HTTPURLResponse)?.statusCode ?? -1))
                     return
                 }
             } catch {
-                log(.error, push, "Push registration could not reach the server",
+                log.error("Push registration could not reach the server", in: .push,
                     .open("error", error))
             }
         }
@@ -62,7 +60,7 @@ extension AppDelegate {
 
     func handleFailedRegistration(application: UIApplication, error: Error) {
         @Dependency(\.log) var log
-        log(.error, push, "The system refused push registration",
+        log.error("The system refused push registration", in: .push,
             .open("error", error))
     }
 }


### PR DESCRIPTION
## Problem

Categories were written as bare strings at every call site:

    log(.error, "push", "The push URL is not a valid URL", ...)
    log(.error, "profile", "The attendee response was rejected", ...)

The risk is not churn, it is that **a typo compiles**. `"prfile"` is a perfectly valid `LogCategory`, so it silently creates a second category and splits every filter that looks for the first. Nothing catches it at any layer.

`AppDelegate+Push.swift` had already noticed the problem and solved it locally with a `private let push: LogCategory = "push"`, which the rest of the app could not see.

Separately: **the level methods added in #121 were not used anywhere.** Every production call site still went through `callAsFunction`, so the API shipped unadopted. That is fixed here, because it changes the same lines.

## Solution

Each module names its own categories, internal to itself. LogKit owns the type; consumers own the vocabulary.

    extension LogCategory {
        static let push: Self = "push"
    }

Call sites become:

    log.error("The push URL is not a valid URL", in: .push,
        .open("pushURL", ConferenceConfig.pushURL))

Two commits: add the statics, then convert all eight call sites and delete the file-local constant.

The Xcode project gains `SwiftLeeds/App/LogCategories.swift`. The project has no file-system-synchronized groups, so a new app source file needs an explicit `project.pbxproj` entry; verified by building the app target and confirming the file compiles into it.

## How to test

- `swift test` per package: LogKit 92, AuthenticationFeature 52, AuthenticationUI 54, SecureStorageKit 16.
- Build the app and confirm no new warnings. Both app targets build.
- The compiler is the test for the rename itself: a category that no longer exists fails to build, which is the whole point of the change.
