### PR TITLE
feat(LogKit): interpolate values into a message

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
@@ -13,8 +13,7 @@ extension AttendeeMapper {
                 // Resolved per call, so a test overriding \.log is honoured. Resolving it while
                 // building liveValue would capture whichever log existed first.
                 @Dependency(\.log) var log
-                log.error("The attendee response was rejected", in: .profile,
-                    .open("reason", error))
+                log.error("The attendee response was rejected: \(error, name: "reason", privacy: .open)", in: .profile)
                 throw error
             }
         }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryLiveTests.swift
@@ -98,7 +98,7 @@ import Testing
             _ = try await sut.fetch()
         }
 
-        let reason = try #require(recorder.events.first?.fields.first { $0.name == "reason" })
+        let reason = try #require(recorder.events.first?.fields.first { String($0.name) == "reason" })
         guard case let .string(text) = reason.value else {
             Issue.record("expected the reason to be a string, got \(reason.value)")
             return

--- a/Packages/LogKit/Sources/LogKit/FieldName.swift
+++ b/Packages/LogKit/Sources/LogKit/FieldName.swift
@@ -1,20 +1,43 @@
-/// The name of a single logged field.
-public struct FieldName: Hashable, Sendable, ExpressibleByStringLiteral {
-    private let storage: String
+/// Which gap in an interpolated message a value came from.
+///
+/// Constructible only inside this package, so a caller cannot mint one and shadow a gap.
+public struct GapIndex: Hashable, Sendable {
+    package let value: Int
 
-    public init(_ value: String) {
-        self.storage = value
+    package init(_ value: Int) {
+        self.value = value
     }
+}
+
+/// The name of a single logged field, and where that name came from.
+///
+/// The two cases are kept apart deliberately. A gap's identity is assigned by LogKit and a caller
+/// cannot construct one, so nothing a caller writes, including a field injected by middleware, can
+/// shadow a gap and put the wrong value into a message.
+public enum FieldName: Hashable, Sendable, ExpressibleByStringLiteral {
+    /// A name a developer wrote.
+    case authored(String)
+
+    /// A gap in an interpolated message. `label` names it for a destination that records fields
+    /// separately; it is display only and plays no part in identity.
+    case positional(GapIndex, label: String?)
 
     public init(stringLiteral value: String) {
-        self.init(value)
+        self = .authored(value)
     }
-
-    fileprivate var stringValue: String { storage }
 }
 
 extension String {
+    /// The name as a destination should show it.
+    ///
+    /// A gap with no label falls back to its position, which is why a label is worth giving to
+    /// anything a structured destination will key on.
     public init(_ name: FieldName) {
-        self = name.stringValue
+        switch name {
+        case let .authored(value):
+            self = value
+        case let .positional(index, label):
+            self = label ?? String(index.value)
+        }
     }
 }

--- a/Packages/LogKit/Sources/LogKit/Log+Levels.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Levels.swift
@@ -6,71 +6,65 @@ extension Log {
     public func debug(
         _ message: LogMessage,
         in category: LogCategory,
-        _ fields: LogField...,
         file: String = #fileID,
         function: String = #function,
         line: Int = #line
     ) {
-        record(.debug, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
+        record(.debug, category, message, SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records an informational event.
     public func info(
         _ message: LogMessage,
         in category: LogCategory,
-        _ fields: LogField...,
         file: String = #fileID,
         function: String = #function,
         line: Int = #line
     ) {
-        record(.info, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
+        record(.info, category, message, SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records an event worth noticing but not acting on.
     public func notice(
         _ message: LogMessage,
         in category: LogCategory,
-        _ fields: LogField...,
         file: String = #fileID,
         function: String = #function,
         line: Int = #line
     ) {
-        record(.notice, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
+        record(.notice, category, message, SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records an event that may lead to a failure.
     public func warning(
         _ message: LogMessage,
         in category: LogCategory,
-        _ fields: LogField...,
         file: String = #fileID,
         function: String = #function,
         line: Int = #line
     ) {
-        record(.warning, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
+        record(.warning, category, message, SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records a failure.
     public func error(
         _ message: LogMessage,
         in category: LogCategory,
-        _ fields: LogField...,
         file: String = #fileID,
         function: String = #function,
         line: Int = #line
     ) {
-        record(.error, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
+        record(.error, category, message, SourceLocation(file: file, function: function, line: line))
     }
 
     /// Records a failure that leaves the app unable to continue as intended.
     public func critical(
         _ message: LogMessage,
         in category: LogCategory,
-        _ fields: LogField...,
         file: String = #fileID,
         function: String = #function,
         line: Int = #line
     ) {
-        record(.critical, category, message, LogFields(fields), SourceLocation(file: file, function: function, line: line))
+        record(.critical, category, message, SourceLocation(file: file, function: function, line: line))
     }
 }

--- a/Packages/LogKit/Sources/LogKit/Log+Write.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Write.swift
@@ -37,7 +37,7 @@ extension Log {
             LogEvent(
                 level: level,
                 category: category,
-                message: message,
+                message: message.template,
                 fields: fields,
                 source: source
             )

--- a/Packages/LogKit/Sources/LogKit/Log+Write.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Write.swift
@@ -7,7 +7,6 @@ extension Log {
         _ level: LogLevel,
         _ category: LogCategory,
         _ message: LogMessage,
-        _ fields: LogField...,
         file: String = #fileID,
         function: String = #function,
         line: Int = #line
@@ -16,7 +15,6 @@ extension Log {
             level,
             category,
             message,
-            LogFields(fields),
             SourceLocation(file: file, function: function, line: line)
         )
     }
@@ -24,13 +22,11 @@ extension Log {
     /// The shared body behind every entry point.
     ///
     /// Takes the source location as a value rather than defaulting it, so the literals stay at
-    /// the call site. Fields arrive already collected because Swift cannot forward one variadic
-    /// parameter into another.
+    /// the call site.
     func record(
         _ level: LogLevel,
         _ category: LogCategory,
         _ message: LogMessage,
-        _ fields: LogFields,
         _ source: SourceLocation
     ) {
         write(
@@ -38,7 +34,7 @@ extension Log {
                 level: level,
                 category: category,
                 message: message.template,
-                fields: message.values.appending(contentsOf: fields),
+                fields: message.values,
                 source: source
             )
         )

--- a/Packages/LogKit/Sources/LogKit/Log+Write.swift
+++ b/Packages/LogKit/Sources/LogKit/Log+Write.swift
@@ -38,7 +38,7 @@ extension Log {
                 level: level,
                 category: category,
                 message: message.template,
-                fields: fields,
+                fields: message.values.appending(contentsOf: fields),
                 source: source
             )
         )

--- a/Packages/LogKit/Sources/LogKit/LogEvent.swift
+++ b/Packages/LogKit/Sources/LogKit/LogEvent.swift
@@ -2,14 +2,14 @@
 public struct LogEvent: Hashable, Sendable {
     public let level: LogLevel
     public let category: LogCategory
-    public let message: LogMessage
+    public let message: MessageTemplate
     public let fields: LogFields
     public let source: SourceLocation
 
     public init(
         level: LogLevel,
         category: LogCategory,
-        message: LogMessage,
+        message: MessageTemplate,
         fields: LogFields = LogFields(),
         source: SourceLocation = .here()
     ) {

--- a/Packages/LogKit/Sources/LogKit/LogField.swift
+++ b/Packages/LogKit/Sources/LogKit/LogField.swift
@@ -13,6 +13,11 @@ public struct LogField: Hashable, Sendable {
         self.sensitivity = sensitivity
     }
 
+    /// Builds a field whose sensitivity is only known at runtime, as an interpolation's is.
+    package init(_ name: FieldName, _ value: some LogValueRepresentable, _ sensitivity: Sensitivity) {
+        self.init(name: name, value: value.logValue, sensitivity: sensitivity)
+    }
+
     /// A value safe to store or transmit anywhere.
     public static func open(_ name: FieldName, _ value: some LogValueRepresentable) -> LogField {
         LogField(name: name, value: value.logValue, sensitivity: .open)

--- a/Packages/LogKit/Sources/LogKit/LogMessage.swift
+++ b/Packages/LogKit/Sources/LogKit/LogMessage.swift
@@ -1,46 +1,70 @@
-/// The fixed part of a logged event.
+/// A message as it was written at the call site.
 ///
-/// Backed by `StaticString` so it can never carry interpolated data. That keeps
-/// messages searchable, and lets a destination treat them as safe to show in full.
-public struct LogMessage: Hashable, Sendable, ExpressibleByStringLiteral {
-    public typealias StringLiteralType = StaticString
+/// Built only from a string literal or an interpolation, so its literal text always comes from
+/// source. There is deliberately no initialiser taking a runtime `String`: that is the single door
+/// keeping data out of the message itself. Interpolated values do not stay here, they become
+/// fields, where classification reaches them.
+public struct LogMessage: Sendable, ExpressibleByStringInterpolation {
+    package let template: MessageTemplate
+    package let values: LogFields
 
-    private let storage: StaticString
-
-    public init(_ value: StaticString) {
-        self.storage = value
+    public init(stringLiteral value: String) {
+        template = MessageTemplate(leadingText: value)
+        values = LogFields()
     }
 
-    public init(stringLiteral value: StaticString) {
-        self.init(value)
+    public init(stringInterpolation: Interpolation) {
+        template = MessageTemplate(
+            leadingText: stringInterpolation.leadingText,
+            gaps: stringInterpolation.gaps
+        )
+        values = LogFields(stringInterpolation.values)
     }
-
-    public static func == (lhs: LogMessage, rhs: LogMessage) -> Bool {
-        lhs.storage.description == rhs.storage.description
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(storage.description)
-    }
-
-    fileprivate var staticValue: StaticString { storage }
 }
 
 extension LogMessage {
-    /// The template an event stores for this message.
-    package var template: MessageTemplate {
-        MessageTemplate(leadingText: storage.description)
-    }
-}
+    /// Collects the literal text and the interpolated values as the compiler walks the message.
+    public struct Interpolation: StringInterpolationProtocol {
+        public typealias StringLiteralType = String
 
-extension StaticString {
-    public init(_ message: LogMessage) {
-        self = message.staticValue
-    }
-}
+        package var leadingText = ""
+        package var gaps: [MessageTemplate.Gap] = []
+        package var values: [LogField] = []
 
-extension String {
-    public init(_ message: LogMessage) {
-        self = message.staticValue.description
+        public init(literalCapacity: Int, interpolationCount: Int) {
+            gaps.reserveCapacity(interpolationCount)
+            values.reserveCapacity(interpolationCount)
+        }
+
+        public mutating func appendLiteral(_ literal: String) {
+            guard let last = gaps.indices.last else {
+                leadingText += literal
+                return
+            }
+
+            gaps[last] = MessageTemplate.Gap(
+                placeholder: gaps[last].placeholder,
+                trailingText: gaps[last].trailingText + literal
+            )
+        }
+
+        /// Records an interpolated value.
+        ///
+        /// - Parameters:
+        ///   - value: The value to log.
+        ///   - name: What a destination recording fields separately should call it. Display only:
+        ///     the gap's identity is its position, so two values sharing a name stay distinct.
+        ///   - privacy: How freely the value may travel. Deliberately has no default, so a value
+        ///     cannot be published by forgetting to classify it.
+        public mutating func appendInterpolation(
+            _ value: some LogValueRepresentable,
+            name: String? = nil,
+            privacy: Sensitivity
+        ) {
+            let placeholder = FieldName.positional(GapIndex(gaps.count), label: name)
+
+            gaps.append(MessageTemplate.Gap(placeholder: placeholder, trailingText: ""))
+            values.append(LogField(placeholder, value, privacy))
+        }
     }
 }

--- a/Packages/LogKit/Sources/LogKit/LogMessage.swift
+++ b/Packages/LogKit/Sources/LogKit/LogMessage.swift
@@ -61,6 +61,25 @@ extension LogMessage {
             name: String? = nil,
             privacy: Sensitivity
         ) {
+            append(value, name: name, privacy: privacy)
+        }
+
+        /// Records an interpolated error, described by ``LogDescribable`` where it conforms.
+        ///
+        /// A separate overload because `any Error` cannot conform to `LogValueRepresentable`.
+        public mutating func appendInterpolation(
+            _ error: any Error,
+            name: String? = nil,
+            privacy: Sensitivity
+        ) {
+            append(String(logDescribing: error), name: name, privacy: privacy)
+        }
+
+        private mutating func append(
+            _ value: some LogValueRepresentable,
+            name: String?,
+            privacy: Sensitivity
+        ) {
             let placeholder = FieldName.positional(GapIndex(gaps.count), label: name)
 
             gaps.append(MessageTemplate.Gap(placeholder: placeholder, trailingText: ""))

--- a/Packages/LogKit/Sources/LogKit/LogMessage.swift
+++ b/Packages/LogKit/Sources/LogKit/LogMessage.swift
@@ -26,6 +26,13 @@ public struct LogMessage: Hashable, Sendable, ExpressibleByStringLiteral {
     fileprivate var staticValue: StaticString { storage }
 }
 
+extension LogMessage {
+    /// The template an event stores for this message.
+    package var template: MessageTemplate {
+        MessageTemplate(leadingText: storage.description)
+    }
+}
+
 extension StaticString {
     public init(_ message: LogMessage) {
         self = message.staticValue

--- a/Packages/LogKit/Sources/LogKit/MessageTemplate.swift
+++ b/Packages/LogKit/Sources/LogKit/MessageTemplate.swift
@@ -32,19 +32,23 @@ extension MessageTemplate {
     /// Stands in for a value the destination was not trusted to see.
     package static let redactionMarker = "<redacted>"
 
-    /// Fills each gap with the matching field's value, in the order they were written.
-    ///
-    /// A gap whose field is absent renders as ``redactionMarker``. That is the normal outcome for a
-    /// secret: classification removes it before the destination is handed the event.
+    /// Fills each gap from its own field, in the order they were written.
     package func rendered(with fields: LogFields) -> String {
-        let valuesByName = Dictionary(
-            fields.map { ($0.name, $0.value.rendered) },
-            uniquingKeysWith: { first, _ in first }
-        )
-
-        return gaps.reduce(into: leadingText) { text, gap in
-            text += valuesByName[gap.placeholder] ?? Self.redactionMarker
+        gaps.reduce(into: leadingText) { text, gap in
+            text += Self.text(for: gap.placeholder, in: fields)
             text += gap.trailingText
         }
+    }
+
+    /// A secret never reaches the sentence, whether or not its field survived classification.
+    ///
+    /// A destination trusted to hold secrets still receives the value, through whatever channel it
+    /// redacts. The sentence is not that channel: `Log.unified` writes it as public.
+    private static func text(for placeholder: FieldName, in fields: LogFields) -> String {
+        guard let field = fields.first(where: { $0.name == placeholder }) else {
+            return redactionMarker
+        }
+
+        return field.sensitivity == .secret ? redactionMarker : field.value.rendered
     }
 }

--- a/Packages/LogKit/Sources/LogKit/MessageTemplate.swift
+++ b/Packages/LogKit/Sources/LogKit/MessageTemplate.swift
@@ -1,0 +1,50 @@
+/// The literal skeleton of a message: text, then each gap and the text following it.
+///
+/// Deliberately holds no values. An event's interpolated values live in its fields, where
+/// classification reaches them; if they were stored here a destination could read a secret straight
+/// off the message.
+public struct MessageTemplate: Hashable, Sendable, ExpressibleByStringLiteral {
+    /// A gap in the message and the literal text that follows it.
+    package struct Gap: Hashable, Sendable {
+        package let placeholder: FieldName
+        package let trailingText: String
+
+        package init(placeholder: FieldName, trailingText: String) {
+            self.placeholder = placeholder
+            self.trailingText = trailingText
+        }
+    }
+
+    package let leadingText: String
+    package let gaps: [Gap]
+
+    package init(leadingText: String, gaps: [Gap] = []) {
+        self.leadingText = leadingText
+        self.gaps = gaps
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(leadingText: value)
+    }
+}
+
+extension MessageTemplate {
+    /// Stands in for a value the destination was not trusted to see.
+    package static let redactionMarker = "<redacted>"
+
+    /// Fills each gap with the matching field's value, in the order they were written.
+    ///
+    /// A gap whose field is absent renders as ``redactionMarker``. That is the normal outcome for a
+    /// secret: classification removes it before the destination is handed the event.
+    package func rendered(with fields: LogFields) -> String {
+        let valuesByName = Dictionary(
+            fields.map { ($0.name, $0.value.rendered) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        return gaps.reduce(into: leadingText) { text, gap in
+            text += valuesByName[gap.placeholder] ?? Self.redactionMarker
+            text += gap.trailingText
+        }
+    }
+}

--- a/Packages/LogKit/Sources/LogKitUnified/Log+Unified.swift
+++ b/Packages/LogKit/Sources/LogKitUnified/Log+Unified.swift
@@ -18,6 +18,7 @@ extension Log {
 
             // OSLogType has no warning, so notice and warning would both read as `default`.
             let level = "[\(event.level.name)]"
+            let message = event.message.rendered(with: event.fields)
             let fields = event.fields.renderedWithoutSecrets
             let secrets = event.fields.renderedSecrets
 
@@ -25,7 +26,7 @@ extension Log {
                 level: event.level.osLogType,
                 """
                 \(level, privacy: .public) \
-                \(String(event.message), privacy: .public) \
+                \(message, privacy: .public) \
                 \(fields, privacy: .public) \
                 \(secrets, privacy: .sensitive)
                 """

--- a/Packages/LogKit/Tests/LogKitTests/FieldNameTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/FieldNameTests.swift
@@ -1,0 +1,43 @@
+import LogKit
+import Testing
+
+@Suite struct FieldNameTests {
+    @Test func whenWrittenAsStringLiteral_shouldBeAuthored() {
+        let sut: FieldName = "pushURL"
+
+        #expect(sut == .authored("pushURL"))
+    }
+
+    /// The property the whole sum type exists for: a caller writing the text a gap happens to use
+    /// cannot produce that gap's name, so an injected field can never shadow one.
+    @Test func whenAuthoredNameMatchesGapPosition_shouldNotBeEqual() {
+        let injected: FieldName = "0"
+
+        #expect(injected != .positional(GapIndex(0), label: nil))
+    }
+
+    @Test func whenAuthoredNameMatchesGapLabel_shouldNotBeEqual() {
+        let injected: FieldName = "email"
+
+        #expect(injected != .positional(GapIndex(0), label: "email"))
+    }
+
+    @Test func whenTwoGapsShareLabel_shouldNotBeEqual() {
+        let first = FieldName.positional(GapIndex(0), label: "user")
+        let second = FieldName.positional(GapIndex(1), label: "user")
+
+        #expect(first != second)
+    }
+
+    @Test func whenGapHasLabel_shouldShowLabel() {
+        #expect(String(FieldName.positional(GapIndex(3), label: "email")) == "email")
+    }
+
+    @Test func whenGapHasNoLabel_shouldShowPosition() {
+        #expect(String(FieldName.positional(GapIndex(3), label: nil)) == "3")
+    }
+
+    @Test func whenAuthored_shouldShowTheName() {
+        #expect(String(FieldName.authored("statusCode")) == "statusCode")
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/InterpolatedEventTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/InterpolatedEventTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import LogKit
+import Testing
+
+/// The whole path an interpolated message takes: written at a call site, enriched by middleware,
+/// classified by the destination, then rendered. Each step is covered on its own elsewhere; this
+/// covers them composed, which is where the secret-in-the-sentence defect lived.
+@Suite struct InterpolatedEventTests {
+    private let salt = LogSalt(Data("fixed-for-tests".utf8))
+
+    private func recorded(
+        secrets: SecretPolicy,
+        _ write: (Log) -> Void
+    ) -> LogEvent? {
+        let recorder = LogRecorder()
+        let sut = Log
+            .destination(salt: salt, secrets: secrets, write: recorder.log.write)
+            .enriching(with: { [.open("sessionID", "abc123")] })
+
+        write(sut)
+        return recorder.events.first
+    }
+
+    @Test func whenSecretIsInterpolated_shouldNotReachTheSentence() throws {
+        let event = try #require(
+            recorded(secrets: .passThrough) { sut in
+                sut.error("Token \("supersecret", privacy: .secret) rejected", in: "auth")
+            }
+        )
+
+        let sentence = event.message.rendered(with: event.fields)
+
+        #expect(sentence == "Token <redacted> rejected")
+        #expect(!sentence.contains("supersecret"))
+    }
+
+    @Test func whenSecretIsInterpolatedAndRemoved_shouldNotReachTheSentence() throws {
+        let event = try #require(
+            recorded(secrets: .remove) { sut in
+                sut.error("Token \("supersecret", privacy: .secret) rejected", in: "auth")
+            }
+        )
+
+        #expect(event.message.rendered(with: event.fields) == "Token <redacted> rejected")
+    }
+
+    @Test func whenHashedIsInterpolated_shouldRenderTokenNotValue() throws {
+        let event = try #require(
+            recorded(secrets: .remove) { sut in
+                sut.error("Signed in as \("ada@example.com", privacy: .hashed)", in: "auth")
+            }
+        )
+
+        let sentence = event.message.rendered(with: event.fields)
+
+        #expect(!sentence.contains("ada@example.com"))
+        #expect(sentence.hasPrefix("Signed in as "))
+    }
+
+    @Test func whenOpenIsInterpolated_shouldRenderTheValue() throws {
+        let event = try #require(
+            recorded(secrets: .remove) { sut in
+                sut.error("Rejected with \(500, privacy: .open)", in: "auth")
+            }
+        )
+
+        #expect(event.message.rendered(with: event.fields) == "Rejected with 500")
+    }
+
+    /// Middleware appends an authored field. It must not be able to fill a gap, however it is named.
+    @Test func whenMiddlewareInjectsField_shouldNotFillAnyGap() throws {
+        let recorder = LogRecorder()
+        let sut = Log
+            .destination(salt: salt, write: recorder.log.write)
+            .enriching(with: { [.open("0", "impostor")] })
+
+        sut.error("Value was \("real", privacy: .open)", in: "auth")
+
+        let event = try #require(recorder.events.first)
+        #expect(event.message.rendered(with: event.fields) == "Value was real")
+    }
+
+    @Test func whenEnriched_shouldKeepInterpolatedFieldsAndInjectedOnes() throws {
+        let event = try #require(
+            recorded(secrets: .remove) { sut in
+                sut.error("Rejected with \(500, name: "statusCode", privacy: .open)", in: "auth")
+            }
+        )
+
+        #expect(event.fields.map { String($0.name) } == ["statusCode", "sessionID"])
+    }
+}

--- a/Packages/LogKit/Tests/LogKitTests/LogDestinationTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogDestinationTests.swift
@@ -2,10 +2,17 @@ import Foundation
 import LogKit
 import Testing
 
-/// These assert what a destination is *unable* to see. The recorder here writes down whatever it
-/// is handed, so anything it observes is something a real destination could have leaked.
+/// These assert what a destination is *unable* to see. The recorder here writes down whatever it is
+/// handed, so anything it observes is something a real destination could have leaked.
+///
+/// Events are written directly rather than through a level method, so these cover classification
+/// alone. The path from a call site is covered by `InterpolatedEventTests`.
 @Suite struct LogDestinationTests {
     private let salt = LogSalt(Data("fixed-for-tests".utf8))
+
+    private func event(_ fields: LogField...) -> LogEvent {
+        LogEvent(level: .error, category: "push", message: "m", fields: LogFields(fields))
+    }
 
     // MARK: - Secrets
 
@@ -13,16 +20,16 @@ import Testing
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
-        sut(.error, "push", "m", .open("scheme", "ticket"), .secret("token", "abc123"))
+        sut.write(event(.open("scheme", "ticket"), .secret("token", "abc123")))
 
-        #expect(recorder.events.first?.fields.map(\.name) == ["scheme"])
+        #expect(recorder.events.first?.fields.map { String($0.name) } == ["scheme"])
     }
 
     @Test func whenBuiltWithDefaults_shouldNotReceiveASecretValueAnywhere() {
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
-        sut(.error, "push", "m", .secret("token", "abc123"))
+        sut.write(event(.secret("token", "abc123")))
 
         let values = recorder.events.flatMap { $0.fields.map(\.value.rendered) }
         #expect(!values.contains("abc123"))
@@ -32,7 +39,7 @@ import Testing
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, secrets: .passThrough, write: recorder.log.write)
 
-        sut(.error, "push", "m", .secret("token", "abc123"))
+        sut.write(event(.secret("token", "abc123")))
 
         #expect(recorder.events.first?.fields.map(\.value) == [.string("abc123")])
     }
@@ -43,7 +50,7 @@ import Testing
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
-        sut(.error, "push", "m", .hashed("email", "ada@example.com"))
+        sut.write(event(.hashed("email", "ada@example.com")))
 
         let value = recorder.events.first?.fields.map(\.value).first?.rendered
         #expect(value?.contains("ada") == false)
@@ -54,7 +61,7 @@ import Testing
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
-        sut(.error, "push", "m", .hashed("email", "ada@example.com"))
+        sut.write(event(.hashed("email", "ada@example.com")))
 
         let value = recorder.events.first?.fields.map(\.value).first?.rendered
         #expect(value?.count == 16)
@@ -68,7 +75,7 @@ import Testing
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
         for index in 0..<64 {
-            sut(.error, "push", "m", .hashed("value", "value-\(index)"))
+            sut.write(event(.hashed("value", "value-\(index)")))
         }
 
         let lengths = Set(recorder.events.compactMap { $0.fields.map(\.value.rendered).first?.count })
@@ -79,8 +86,8 @@ import Testing
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
-        sut(.error, "push", "m", .hashed("email", "ada@example.com"))
-        sut(.error, "push", "m", .hashed("email", "ada@example.com"))
+        sut.write(event(.hashed("email", "ada@example.com")))
+        sut.write(event(.hashed("email", "ada@example.com")))
 
         let tokens = recorder.events.compactMap { $0.fields.map(\.value).first }
         #expect(tokens.count == 2)
@@ -91,7 +98,7 @@ import Testing
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
-        sut(.error, "push", "m", .hashed("email", "ada@example.com"), .hashed("reference", "ABCD-1"))
+        sut.write(event(.hashed("email", "ada@example.com"), .hashed("reference", "ABCD-1")))
 
         let tokens = recorder.events.first?.fields.map(\.value) ?? []
         #expect(tokens.count == 2)
@@ -102,8 +109,10 @@ import Testing
         let first = LogRecorder()
         let second = LogRecorder()
 
-        Log.destination(salt: salt, write: first.log.write)(.error, "push", "m", .hashed("email", "ada@example.com"))
-        Log.destination(salt: LogSalt(Data("other".utf8)), write: second.log.write)(.error, "push", "m", .hashed("email", "ada@example.com"))
+        Log.destination(salt: salt, write: first.log.write)
+            .write(event(.hashed("email", "ada@example.com")))
+        Log.destination(salt: LogSalt(Data("other".utf8)), write: second.log.write)
+            .write(event(.hashed("email", "ada@example.com")))
 
         #expect(first.events.first?.fields.map(\.value).first != second.events.first?.fields.map(\.value).first)
     }
@@ -114,7 +123,7 @@ import Testing
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, secrets: .passThrough, write: recorder.log.write)
 
-        sut(.error, "push", "m", .open("a", 1), .hashed("b", "x"), .secret("c", "y"))
+        sut.write(event(.open("a", 1), .hashed("b", "x"), .secret("c", "y")))
 
         #expect(recorder.events.first?.fields.map(\.sensitivity) == [.open, .hashed, .secret])
     }
@@ -123,16 +132,16 @@ import Testing
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
-        sut(.error, "push", "m", .open("second", 2), .hashed("first", "x"), .open("third", 3))
+        sut.write(event(.open("second", 2), .hashed("first", "x"), .open("third", 3)))
 
-        #expect(recorder.events.first?.fields.map(\.name) == ["second", "first", "third"])
+        #expect(recorder.events.first?.fields.map { String($0.name) } == ["second", "first", "third"])
     }
 
     @Test func whenClassified_shouldLeaveOpenValuesAlone() {
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
-        sut(.error, "push", "m", .open("scheme", "ticket"))
+        sut.write(event(.open("scheme", "ticket")))
 
         #expect(recorder.events.first?.fields.map(\.value).first == .string("ticket"))
     }
@@ -141,7 +150,7 @@ import Testing
         let recorder = LogRecorder()
         let sut = Log.destination(salt: salt, write: recorder.log.write)
 
-        sut(.warning, "push", "unchanged")
+        sut.write(LogEvent(level: .warning, category: "push", message: "unchanged"))
 
         #expect(recorder.events.first?.level == .warning)
         #expect(recorder.events.first?.category == "push")

--- a/Packages/LogKit/Tests/LogKitTests/LogLevelMethodTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogLevelMethodTests.swift
@@ -28,9 +28,12 @@ import Testing
     @Test func whenGivenSeveralFields_shouldKeepThemInWrittenOrder() {
         let recorder = LogRecorder()
 
-        recorder.log.error("ordered", in: "push", .open("first", 1), .hashed("second", "x"), .secret("third", true))
+        recorder.log.error(
+            "\(1, name: "first", privacy: .open) \("x", name: "second", privacy: .hashed) \(true, name: "third", privacy: .secret)",
+            in: "push"
+        )
 
-        #expect(recorder.events.first?.fields.map(\.name) == ["first", "second", "third"])
+        #expect(recorder.events.first?.fields.map { String($0.name) } == ["first", "second", "third"])
     }
 
     /// The literals must expand where the developer wrote the call, not inside the level method.

--- a/Packages/LogKit/Tests/LogKitTests/LogMessageTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogMessageTests.swift
@@ -2,21 +2,65 @@ import LogKit
 import Testing
 
 @Suite struct LogMessageTests {
-    @Test func whenBuiltFromSameLiteral_shouldBeEqual() {
-        let sut: LogMessage = "push registration failed"
+    @Test func whenWrittenAsLiteral_shouldHaveNoGapsOrValues() {
+        let sut: LogMessage = "Registering for push"
 
-        #expect(sut == LogMessage("push registration failed"))
+        #expect(sut.template.leadingText == "Registering for push")
+        #expect(sut.template.gaps.isEmpty)
+        #expect(sut.values.isEmpty)
     }
 
-    @Test func whenBuiltFromDifferentLiteral_shouldNotBeEqual() {
-        let sut: LogMessage = "push registration failed"
+    @Test func whenInterpolated_shouldSplitLiteralAroundTheGap() {
+        let sut: LogMessage = "Signed in as \("ada", privacy: .open) today"
 
-        #expect(sut != LogMessage("sign in failed"))
+        #expect(sut.template.leadingText == "Signed in as ")
+        #expect(sut.template.gaps.map(\.trailingText) == [" today"])
     }
 
-    @Test func whenConvertedToString_shouldReturnLiteral() {
-        let sut: LogMessage = "theme unavailable"
+    @Test func whenInterpolated_shouldMakeTheValueAField() {
+        let sut: LogMessage = "Signed in as \("ada", privacy: .open)"
 
-        #expect(String(sut) == "theme unavailable")
+        #expect(sut.values.map(\.value) == [.string("ada")])
+        #expect(sut.values.map(\.sensitivity) == [.open])
+    }
+
+    @Test func whenInterpolatedWithoutName_shouldNameTheFieldByPosition() {
+        let sut: LogMessage = "\(1, privacy: .open) then \(2, privacy: .open)"
+
+        #expect(sut.values.map(\.name) == [.positional(GapIndex(0), label: nil),
+                                           .positional(GapIndex(1), label: nil)])
+    }
+
+    @Test func whenInterpolatedWithName_shouldLabelTheField() {
+        let sut: LogMessage = "Rejected \(401, name: "statusCode", privacy: .open)"
+
+        #expect(sut.values.map(\.name) == [.positional(GapIndex(0), label: "statusCode")])
+    }
+
+    @Test func whenTwoInterpolationsShareName_shouldStayDistinct() {
+        let sut: LogMessage = "\("a", name: "user", privacy: .open) and \("b", name: "user", privacy: .secret)"
+
+        #expect(sut.values.map(\.name) == [.positional(GapIndex(0), label: "user"),
+                                           .positional(GapIndex(1), label: "user")])
+        #expect(sut.values.map(\.sensitivity) == [.open, .secret])
+    }
+
+    @Test func whenInterpolationsAreAdjacent_shouldKeepEmptyTextBetween() {
+        let sut: LogMessage = "\(1, privacy: .open)\(2, privacy: .open)"
+
+        #expect(sut.template.leadingText.isEmpty)
+        #expect(sut.template.gaps.map(\.trailingText) == ["", ""])
+    }
+
+    @Test func whenMessageEndsWithLiteral_shouldTrailTheLastGap() {
+        let sut: LogMessage = "Token \("abc", privacy: .secret) rejected"
+
+        #expect(sut.template.gaps.map(\.trailingText) == [" rejected"])
+    }
+
+    @Test func whenSensitivitiesDiffer_shouldCarryEachOne() {
+        let sut: LogMessage = "\(1, privacy: .open) \(2, privacy: .hashed) \(3, privacy: .secret)"
+
+        #expect(sut.values.map(\.sensitivity) == [.open, .hashed, .secret])
     }
 }

--- a/Packages/LogKit/Tests/LogKitTests/LogRecorder.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogRecorder.swift
@@ -24,7 +24,7 @@ final class LogRecorder: @unchecked Sendable {
 
 extension LogEvent {
     static func stub(
-        _ message: LogMessage = "event",
+        _ message: MessageTemplate = "event",
         level: LogLevel = .info,
         category: LogCategory = "test"
     ) -> LogEvent {

--- a/Packages/LogKit/Tests/LogKitTests/LogWriteTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/LogWriteTests.swift
@@ -54,9 +54,13 @@ import Testing
     @Test func whenGivenSeveralFields_shouldKeepThemInWrittenOrder() {
         let recorder = LogRecorder()
 
-        recorder.log(.error, "push", "ordered", .open("first", 1), .hashed("second", "x"), .secret("third", true))
+        recorder.log(
+            .error,
+            "push",
+            "\(1, name: "first", privacy: .open) \("x", name: "second", privacy: .hashed) \(true, name: "third", privacy: .secret)"
+        )
 
-        #expect(recorder.events.first?.fields.map(\.name) == ["first", "second", "third"])
+        #expect(recorder.events.first?.fields.map { String($0.name) } == ["first", "second", "third"])
     }
 
     @Test func whenRecordingEvent_shouldCaptureCallSite() {

--- a/Packages/LogKit/Tests/LogKitTests/MessageTemplateTests.swift
+++ b/Packages/LogKit/Tests/LogKitTests/MessageTemplateTests.swift
@@ -1,0 +1,68 @@
+import LogKit
+import Testing
+
+@Suite struct MessageTemplateTests {
+    private let user = FieldName.positional(GapIndex(0), label: "user")
+    private let token = FieldName.positional(GapIndex(1), label: nil)
+
+    @Test func whenNoGaps_shouldBeTheLiteralText() {
+        let sut: MessageTemplate = "Registering for push"
+
+        #expect(sut.rendered(with: []) == "Registering for push")
+    }
+
+    @Test func whenGapHasField_shouldUseItsValue() {
+        let sut = MessageTemplate(
+            leadingText: "Signed in as ",
+            gaps: [.init(placeholder: user, trailingText: " now")]
+        )
+
+        #expect(sut.rendered(with: [.open(user, "ada")]) == "Signed in as ada now")
+    }
+
+    @Test func whenGapHasNoField_shouldRenderMarker() {
+        let sut = MessageTemplate(
+            leadingText: "Signed in as ",
+            gaps: [.init(placeholder: user, trailingText: "")]
+        )
+
+        #expect(sut.rendered(with: []) == "Signed in as <redacted>")
+    }
+
+    /// The rule the worked example exposed. `Log.unified` passes secrets through so it can put them
+    /// in an interpolation the system redacts, which means a surviving secret would otherwise be
+    /// rendered into the sentence, and the sentence is written as public.
+    @Test func whenFieldIsSecret_shouldRenderMarkerEvenThoughFieldIsPresent() {
+        let sut = MessageTemplate(
+            leadingText: "Token ",
+            gaps: [.init(placeholder: token, trailingText: " rejected")]
+        )
+
+        let rendered = sut.rendered(with: [.secret(token, "supersecret")])
+
+        #expect(rendered == "Token <redacted> rejected")
+        #expect(!rendered.contains("supersecret"))
+    }
+
+    @Test func whenSeveralGaps_shouldFillEachFromItsOwnField() {
+        let sut = MessageTemplate(
+            leadingText: "User ",
+            gaps: [.init(placeholder: user, trailingText: " token "),
+                   .init(placeholder: token, trailingText: "")]
+        )
+
+        let rendered = sut.rendered(with: [.open(user, "ada"), .secret(token, "abc")])
+
+        #expect(rendered == "User ada token <redacted>")
+    }
+
+    /// An injected field cannot be mistaken for a gap, however it is named.
+    @Test func whenInjectedFieldSharesGapLabel_shouldNotFillTheGap() {
+        let sut = MessageTemplate(
+            leadingText: "Signed in as ",
+            gaps: [.init(placeholder: user, trailingText: "")]
+        )
+
+        #expect(sut.rendered(with: [.open("user", "impostor")]) == "Signed in as <redacted>")
+    }
+}

--- a/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
+++ b/Packages/LogKit/Tests/LogKitUnifiedTests/LogUnifiedTests.swift
@@ -17,11 +17,12 @@ import Testing
             sut(
                 level,
                 "push",
-                "exercised every sensitivity",
-                .open("category", "registration"),
-                .hashed("email", "ada@example.com"),
-                .hashed("reference", "ABCD-1"),
-                .secret("token", "abc123")
+                """
+                exercised \("registration", name: "category", privacy: .open) \
+                for \("ada@example.com", name: "email", privacy: .hashed) \
+                ref \("ABCD-1", name: "reference", privacy: .hashed) \
+                token \("abc123", name: "token", privacy: .secret)
+                """
             )
         }
     }

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -56,8 +56,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         @Dependency(\.log) var log
         guard let url = URL(string: ConferenceConfig.pushURL) else {
-            log.error("The push URL is not a valid URL", in: .push,
-                .open("pushURL", ConferenceConfig.pushURL))
+            log.error("The push URL is not a valid URL: \(ConferenceConfig.pushURL, name: "pushURL", privacy: .open)", in: .push)
             return
         }
         sendPushRegistrationDatails(to: url, deviceToken: deviceToken)

--- a/SwiftLeeds/Push/AppDelegate+Push.swift
+++ b/SwiftLeeds/Push/AppDelegate+Push.swift
@@ -13,8 +13,7 @@ extension AppDelegate {
                 return
             }
             if let error {
-                log.error("Could not request notification permission", in: .push,
-                    .open("error", error))
+                log.error("Could not request notification permission: \(error, privacy: .open)", in: .push)
                 return
             }
 
@@ -34,8 +33,10 @@ extension AppDelegate {
         details.debug = true
 #endif
 
-        log.debug("Registering for push", in: .push,
-            .hashed("deviceToken", deviceToken.map { String(format: "%02x", $0) }.joined()))
+        log.debug(
+            "Registering for push with token \(deviceToken.map { String(format: "%02x", $0) }.joined(), name: "deviceToken", privacy: .hashed)",
+            in: .push
+        )
 
         var request = URLRequest(url: url)
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -46,22 +47,24 @@ extension AppDelegate {
             do {
                 let (_, response) = try await URLSession.shared.data(for: request)
 
-                guard let statusCode = (response as? HTTPURLResponse)?.statusCode, 200..<399 ~= statusCode else {
-                    log.error("Push registration was rejected", in: .push,
-                        .open("statusCode", (response as? HTTPURLResponse)?.statusCode ?? -1))
+                let statusCode = (response as? HTTPURLResponse)?.statusCode
+
+                guard let statusCode, 200..<399 ~= statusCode else {
+                    log.error(
+                        "Push registration was rejected with status \(statusCode.map(String.init) ?? "none", name: "statusCode", privacy: .open)",
+                        in: .push
+                    )
                     return
                 }
             } catch {
-                log.error("Push registration could not reach the server", in: .push,
-                    .open("error", error))
+                log.error("Push registration could not reach the server: \(error, privacy: .open)", in: .push)
             }
         }
     }
 
     func handleFailedRegistration(application: UIApplication, error: Error) {
         @Dependency(\.log) var log
-        log.error("The system refused push registration", in: .push,
-            .open("error", error))
+        log.error("The system refused push registration: \(error, privacy: .open)", in: .push)
     }
 }
 


### PR DESCRIPTION
## Problem

A value and the sentence describing it had to be written apart:

    log.error("The push URL is not a valid URL", in: .push, .open("pushURL", url))

Two mechanisms also existed for attaching a value: a fields list, and nothing else. OSLog has one, and reads better for it.

## Solution

    log.error("The push URL is not a valid URL: \(url, name: "pushURL", privacy: .open)", in: .push)

Interpolated values become ordinary fields, so classification reaches them exactly as before. The message stores only its literal skeleton.

**This is not sugar.** `OSLogMessage` cannot be forwarded through a wrapper, so a LogKit interpolation renders to the destination's own fixed literal as it always did. What it buys is a readable sentence while keeping named fields, `hashed` correlation tokens and destination independence, none of which OSLog's privacy vocabulary has.

## Two invariants moved into types

**`MessageTemplate` is leading text, then each gap with the text following it.** Having one more literal than gaps is now structural. It was previously a doc comment propped up by index arithmetic and `?? ""` fallbacks.

**`FieldName` says where a name came from:** `.authored` for what a developer wrote, `.positional(GapIndex, label:)` for a gap. `GapIndex` is `package`, so a caller cannot mint one. This closes a real hole: with plain string names, `enriching(with: [.open("0", x)])` would hijack gap 0 and print the wrong value.

A `name:` on an interpolation is a **display label only**. Identity is always positional, which is what makes this safe:

    log.error("User 1: \(a, name: "user", privacy: .open). User 2: \(b, name: "user", privacy: .secret)")

Both gaps stay distinct, so the second renders `<redacted>` and the first does not. Had the caller's name been the identity, the surviving open field would have filled both gaps and published a value marked secret.

## The security rule, found by tracing a worked example

**A secret never enters the sentence**, whether or not the destination is trusted to hold it. `Log.unified` passes secrets through so it can put them in an interpolation the system redacts; without this rule a surviving secret would have been rendered into the sentence, which is written as `public`. That defect existed in the first draft and only appeared when tracing middleware, classification and rendering composed together.

`InterpolatedEventTests` covers that composed path, since no unit test did.

## How to test

- `swift test` per package: LogKit 124, AuthenticationFeature 52, AuthenticationUI 54, SecureStorageKit 16.
- Probes run and reverted: letting a secret into the sentence fails 5 assertions; matching gap identity by display text instead of by case fails the impostor test; collapsing `FieldName` identity onto its text fails 3.
- Build the app, checking for `warning:` and not just success.

## Also in here

`AppDelegate+Push` cast `response` twice and used `-1` to mean "no status". It now binds once and logs `"none"`.
