### PR TITLE
fix(AuthenticationFeature): make login failures diagnosable

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -19,7 +19,11 @@ extension AuthGateway: DependencyKey {
             } catch {
                 throw AuthenticationError.unknown
             }
-            return try LoginMapper.map(data, response)
+            do throws(LoginResponseFailure) {
+                return try LoginMapper.map(data, response)
+            } catch {
+                throw AuthenticationError(error)
+            }
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -2,7 +2,17 @@ import Dependencies
 import Foundation
 
 extension AuthGateway: DependencyKey {
+    /// Order is load-bearing: logging must sit inside the narrowing, or it would see only
+    /// `AuthenticationError` and the reason would already be gone.
     package static var liveValue: AuthGateway {
+        live.loggingRequestFailures().narrowingFailures()
+    }
+}
+
+extension AuthGateway {
+    /// Throws `LoginRequestFailure` for anything that stops a response arriving, and lets the
+    /// mapper's own `LoginResponseFailure` pass through.
+    static var live: AuthGateway {
         AuthGateway { credential in
             @Dependency(\.httpClient) var httpClient
             @Dependency(\.apiConfiguration) var apiConfiguration
@@ -12,18 +22,33 @@ extension AuthGateway: DependencyKey {
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
+            do {
+                request.httpBody = try JSONEncoder().encode(LoginRequestDTO(credential))
+            } catch {
+                throw LoginRequestFailure.couldNotEncodeRequest(error)
+            }
+
             let data: Data
             let response: HTTPURLResponse
             do {
-                request.httpBody = try JSONEncoder().encode(LoginRequestDTO(credential))
                 (data, response) = try await httpClient.send(request)
             } catch {
-                throw AuthenticationError.unknown
+                throw LoginRequestFailure.transportFailed(error)
             }
-            do throws(LoginResponseFailure) {
-                return try loginMapper.map(data, response)
-            } catch {
-                throw AuthenticationError(error)
+
+            return try loginMapper.map(data, response)
+        }
+    }
+
+    /// Converts both seams' detailed failures to the bare error callers see.
+    func narrowingFailures() -> AuthGateway {
+        AuthGateway { credential in
+            do {
+                return try await authenticate(credential)
+            } catch let failure as LoginRequestFailure {
+                throw AuthenticationError(failure)
+            } catch let failure as LoginResponseFailure {
+                throw AuthenticationError(failure)
             }
         }
     }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -6,6 +6,7 @@ extension AuthGateway: DependencyKey {
         AuthGateway { credential in
             @Dependency(\.httpClient) var httpClient
             @Dependency(\.apiConfiguration) var apiConfiguration
+            @Dependency(\.loginMapper) var loginMapper
 
             var request = URLRequest(url: Endpoint.login.url(baseURL: apiConfiguration.baseURL))
             request.httpMethod = "POST"
@@ -20,7 +21,7 @@ extension AuthGateway: DependencyKey {
                 throw AuthenticationError.unknown
             }
             do throws(LoginResponseFailure) {
-                return try LoginMapper.map(data, response)
+                return try loginMapper.map(data, response)
             } catch {
                 throw AuthenticationError(error)
             }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Logging.swift
@@ -1,0 +1,21 @@
+import Dependencies
+import LogKit
+
+extension AuthGateway {
+    /// Records only this seam's own failures. A response failure has already been logged by the
+    /// mapper's decorator, so it passes through untouched rather than being logged twice.
+    func loggingRequestFailures() -> AuthGateway {
+        AuthGateway { credential in
+            do {
+                return try await authenticate(credential)
+            } catch let failure as LoginRequestFailure {
+                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+                // building liveValue would capture whichever log existed first.
+                @Dependency(\.log) var log
+                let entry = LoggedLoginFailure(failure)
+                log(entry.level, .auth, entry.message)
+                throw failure
+            }
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginFailure.swift
@@ -1,0 +1,35 @@
+import LogKit
+
+/// How a login failure reads in a log.
+///
+/// A mapped projection, in the same spirit as `CachedSession` for storage: the failure types stay
+/// free of LogKit, and every decision about how they are recorded lives here. Each failure gets its
+/// own message, because a message is what a destination groups and filters by; one shared message
+/// with the cause in a field cannot be filtered at all.
+struct LoggedLoginFailure {
+    let level: LogLevel
+    let message: LogMessage
+
+    init(_ failure: LoginRequestFailure) {
+        switch failure {
+        case let .couldNotEncodeRequest(cause):
+            level = .error
+            message = "The sign-in request could not be encoded: \(cause, name: "reason", privacy: .open)"
+        case let .transportFailed(cause):
+            level = .error
+            message = "The sign-in request could not reach the server: \(cause, name: "reason", privacy: .open)"
+        }
+    }
+
+    init(_ failure: LoginResponseFailure) {
+        switch failure {
+        case .invalidCredentials:
+            // Expected: someone mistyped a ticket reference. Not a fault in the app.
+            level = .notice
+            message = "The sign-in credentials were rejected"
+        case let .unexpectedStatus(code):
+            level = .error
+            message = "Sign-in got an unexpected status \(code, name: "statusCode", privacy: .open)"
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
@@ -1,5 +1,4 @@
 import Dependencies
-import Foundation
 import LogKit
 
 extension LoginMapper {
@@ -13,21 +12,10 @@ extension LoginMapper {
                 // Resolved per call, so a test overriding \.log is honoured. Resolving it while
                 // building liveValue would capture whichever log existed first.
                 @Dependency(\.log) var log
-                log(error.level, .auth, "Sign-in was refused: \(error, name: "reason", privacy: .open)")
+                let entry = LoggedLoginFailure(error)
+                log(entry.level, .auth, entry.message)
                 throw error
             }
-        }
-    }
-}
-
-extension LoginResponseFailure {
-    /// A rejected credential is an expected outcome, not a fault in the app; anything else is.
-    var level: LogLevel {
-        switch self {
-        case .invalidCredentials:
-            .notice
-        case .unexpectedStatus:
-            .error
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
@@ -1,0 +1,33 @@
+import Dependencies
+import Foundation
+import LogKit
+
+extension LoginMapper {
+    /// Wraps the mapper rather than the gateway, which has already narrowed the failure to
+    /// `AuthenticationError` and lost the reason.
+    func loggingFailures() -> LoginMapper {
+        LoginMapper { data, response throws(LoginResponseFailure) in
+            do throws(LoginResponseFailure) {
+                return try map(data, response)
+            } catch {
+                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+                // building liveValue would capture whichever log existed first.
+                @Dependency(\.log) var log
+                log(error.level, .auth, "Sign-in was refused: \(error, name: "reason", privacy: .open)")
+                throw error
+            }
+        }
+    }
+}
+
+extension LoginResponseFailure {
+    /// A rejected credential is an expected outcome, not a fault in the app; anything else is.
+    var level: LogLevel {
+        switch self {
+        case .invalidCredentials:
+            .notice
+        case .unexpectedStatus:
+            .error
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
@@ -1,14 +1,17 @@
 import Foundation
 
 enum LoginMapper {
-    static func map(_ data: Data, _ response: HTTPURLResponse) throws(AuthenticationError) -> SessionToken {
+    static func map(
+        _ data: Data,
+        _ response: HTTPURLResponse
+    ) throws(LoginResponseFailure) -> SessionToken {
         switch response.statusCode {
         case 200:
             return SessionToken(String(decoding: data, as: UTF8.self))
         case 401:
             throw .invalidCredentials
         default:
-            throw .unknown
+            throw .unexpectedStatus(response.statusCode)
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
@@ -23,7 +23,7 @@ extension LoginMapper {
 }
 
 private enum LoginMapperKey: DependencyKey {
-    static var liveValue: LoginMapper { .live }
+    static var liveValue: LoginMapper { .live.loggingFailures() }
     static var testValue: LoginMapper { liveValue }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
@@ -1,10 +1,16 @@
+import Dependencies
 import Foundation
 
-enum LoginMapper {
-    static func map(
-        _ data: Data,
-        _ response: HTTPURLResponse
-    ) throws(LoginResponseFailure) -> SessionToken {
+struct LoginMapper: Sendable {
+    var map: @Sendable (Data, HTTPURLResponse) throws(LoginResponseFailure) -> SessionToken
+
+    init(map: @escaping @Sendable (Data, HTTPURLResponse) throws(LoginResponseFailure) -> SessionToken) {
+        self.map = map
+    }
+}
+
+extension LoginMapper {
+    static let live = LoginMapper { data, response throws(LoginResponseFailure) in
         switch response.statusCode {
         case 200:
             return SessionToken(String(decoding: data, as: UTF8.self))
@@ -13,5 +19,17 @@ enum LoginMapper {
         default:
             throw .unexpectedStatus(response.statusCode)
         }
+    }
+}
+
+private enum LoginMapperKey: DependencyKey {
+    static var liveValue: LoginMapper { .live }
+    static var testValue: LoginMapper { liveValue }
+}
+
+extension DependencyValues {
+    var loginMapper: LoginMapper {
+        get { self[LoginMapperKey.self] }
+        set { self[LoginMapperKey.self] = newValue }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestFailure.swift
@@ -1,0 +1,19 @@
+/// Why a login request never got a response.
+///
+/// Separate from ``LoginResponseFailure`` so each seam owns its own failures: the gateway's
+/// decorator logs only these, and passes response failures through already logged.
+enum LoginRequestFailure: Error {
+    case couldNotEncodeRequest(any Error)
+    case transportFailed(any Error)
+}
+
+extension AuthenticationError {
+    init(_ failure: LoginRequestFailure) {
+        switch failure {
+        case .couldNotEncodeRequest:
+            self = .unknown
+        case .transportFailed:
+            self = .unknown
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginResponseFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginResponseFailure.swift
@@ -1,21 +1,11 @@
-import LogKit
-
+/// Why a login response could not be turned into a session.
+///
 /// Internal on purpose: `AuthenticationError` is what callers see, and it carries no diagnostic
-/// payload. This is what middleware between the two gets to read.
+/// payload. This is what middleware between the two gets to read. It knows nothing about logging;
+/// `LoggedLoginFailure` decides how it reads.
 enum LoginResponseFailure: Error {
     case invalidCredentials
     case unexpectedStatus(Int)
-}
-
-extension LoginResponseFailure: LogDescribable {
-    var logDescription: String {
-        switch self {
-        case .invalidCredentials:
-            "invalidCredentials"
-        case let .unexpectedStatus(code):
-            "unexpectedStatus(\(code))"
-        }
-    }
 }
 
 extension AuthenticationError {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginResponseFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginResponseFailure.swift
@@ -1,0 +1,30 @@
+import LogKit
+
+/// Internal on purpose: `AuthenticationError` is what callers see, and it carries no diagnostic
+/// payload. This is what middleware between the two gets to read.
+enum LoginResponseFailure: Error {
+    case invalidCredentials
+    case unexpectedStatus(Int)
+}
+
+extension LoginResponseFailure: LogDescribable {
+    var logDescription: String {
+        switch self {
+        case .invalidCredentials:
+            "invalidCredentials"
+        case let .unexpectedStatus(code):
+            "unexpectedStatus(\(code))"
+        }
+    }
+}
+
+extension AuthenticationError {
+    init(_ failure: LoginResponseFailure) {
+        switch failure {
+        case .invalidCredentials:
+            self = .invalidCredentials
+        case .unexpectedStatus:
+            self = .unknown
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/LogCategories.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/LogCategories.swift
@@ -3,5 +3,6 @@ import LogKit
 /// This feature's log categories. Naming them once means a typo cannot silently create a second
 /// category and split a filter in two.
 extension LogCategory {
+    static let auth: Self = "auth"
     static let profile: Self = "profile"
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLoggingTests.swift
@@ -1,0 +1,70 @@
+import AuthenticationFeature
+import Dependencies
+import Foundation
+import Testing
+
+/// The public `AuthenticationError` is deliberately bare, so these assert the reason survives to the
+/// log even though the caller never sees it.
+@Suite struct AuthGatewayLoggingTests {
+    @Test func whenServerReturnsUnexpectedStatus_shouldLogTheStatus() async throws {
+        let recorder = LogRecorder()
+
+        try? await withDependencies {
+            $0.httpClient = .responding(with: Data(), statusCode: 503)
+            $0.log = recorder.log
+        } operation: {
+            _ = try await AuthGateway.liveValue.authenticate(credential())
+        }
+
+        let reason = try #require(recorder.events.first?.fields.first { String($0.name) == "reason" })
+        #expect(reason.value == .string("unexpectedStatus(503)"))
+    }
+
+    @Test func whenCredentialsAreRejected_shouldLogThatReason() async throws {
+        let recorder = LogRecorder()
+
+        try? await withDependencies {
+            $0.httpClient = .responding(with: Data(), statusCode: 401)
+            $0.log = recorder.log
+        } operation: {
+            _ = try await AuthGateway.liveValue.authenticate(credential())
+        }
+
+        let reason = try #require(recorder.events.first?.fields.first { String($0.name) == "reason" })
+        #expect(reason.value == .string("invalidCredentials"))
+    }
+
+    @Test func whenServerReturnsToken_shouldLogNothing() async throws {
+        let recorder = LogRecorder()
+
+        _ = try await withDependencies {
+            $0.httpClient = .responding(with: Data("jwt-abc-123".utf8), statusCode: 200)
+            $0.log = recorder.log
+        } operation: {
+            try await AuthGateway.liveValue.authenticate(credential())
+        }
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    /// A rejected credential is an expected outcome, not a fault in the app.
+    @Test func whenCredentialsAreRejected_shouldLogAtNoticeRatherThanError() async throws {
+        let recorder = LogRecorder()
+
+        try? await withDependencies {
+            $0.httpClient = .responding(with: Data(), statusCode: 401)
+            $0.log = recorder.log
+        } operation: {
+            _ = try await AuthGateway.liveValue.authenticate(credential())
+        }
+
+        #expect(recorder.events.map(\.level) == [.notice])
+    }
+}
+
+private func credential() throws -> Credential {
+    try Credential(
+        email: EmailAddress("attendee@example.com"),
+        ticketReference: TicketReference("ABCD-12")
+    )
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLoggingTests.swift
@@ -1,12 +1,53 @@
 import AuthenticationFeature
 import Dependencies
 import Foundation
+import LogKit
 import Testing
 
 /// The public `AuthenticationError` is deliberately bare, so these assert the reason survives to the
 /// log even though the caller never sees it.
 @Suite struct AuthGatewayLoggingTests {
+    @Test func whenCredentialsAreRejected_shouldSayTheyWereRejected() async throws {
+        let event = try #require(await attempt(statusCode: 401))
+
+        #expect(event.message == "The sign-in credentials were rejected")
+    }
+
+    /// A mistyped ticket reference is an expected outcome, not a fault in the app.
+    @Test func whenCredentialsAreRejected_shouldLogAtNoticeRatherThanError() async throws {
+        let event = try #require(await attempt(statusCode: 401))
+
+        #expect(event.level == .notice)
+    }
+
     @Test func whenServerReturnsUnexpectedStatus_shouldLogTheStatus() async throws {
+        let event = try #require(await attempt(statusCode: 503))
+
+        #expect(event.level == .error)
+        #expect(event.fields.first { String($0.name) == "statusCode" }?.value == .integer(503))
+    }
+
+    @Test func whenTransportFails_shouldLogTheCause() async throws {
+        let event = try #require(await attempt(failingWith: StubFailure.couldNotBuildResponse))
+
+        #expect(event.level == .error)
+        let reason = try #require(event.fields.first { String($0.name) == "reason" })
+        #expect(reason.value == .string("couldNotBuildResponse"))
+    }
+
+    /// The point of a projection per failure: a destination groups by message, so two causes sharing
+    /// one message could never be told apart when filtering.
+    @Test func whenCausesDiffer_shouldLogDifferentMessages() async throws {
+        let rejected = try #require(await attempt(statusCode: 401))
+        let unexpected = try #require(await attempt(statusCode: 503))
+        let transport = try #require(await attempt(failingWith: StubFailure.couldNotBuildResponse))
+
+        #expect(rejected.message != unexpected.message)
+        #expect(unexpected.message != transport.message)
+        #expect(transport.message != rejected.message)
+    }
+
+    @Test func whenTransportFailsAndResponseIsFine_shouldLogOnlyOnce() async throws {
         let recorder = LogRecorder()
 
         try? await withDependencies {
@@ -16,22 +57,7 @@ import Testing
             _ = try await AuthGateway.liveValue.authenticate(credential())
         }
 
-        let reason = try #require(recorder.events.first?.fields.first { String($0.name) == "reason" })
-        #expect(reason.value == .string("unexpectedStatus(503)"))
-    }
-
-    @Test func whenCredentialsAreRejected_shouldLogThatReason() async throws {
-        let recorder = LogRecorder()
-
-        try? await withDependencies {
-            $0.httpClient = .responding(with: Data(), statusCode: 401)
-            $0.log = recorder.log
-        } operation: {
-            _ = try await AuthGateway.liveValue.authenticate(credential())
-        }
-
-        let reason = try #require(recorder.events.first?.fields.first { String($0.name) == "reason" })
-        #expect(reason.value == .string("invalidCredentials"))
+        #expect(recorder.events.count == 1)
     }
 
     @Test func whenServerReturnsToken_shouldLogNothing() async throws {
@@ -46,20 +72,32 @@ import Testing
 
         #expect(recorder.events.isEmpty)
     }
+}
 
-    /// A rejected credential is an expected outcome, not a fault in the app.
-    @Test func whenCredentialsAreRejected_shouldLogAtNoticeRatherThanError() async throws {
-        let recorder = LogRecorder()
+private func attempt(statusCode: Int) async -> LogEvent? {
+    let recorder = LogRecorder()
 
-        try? await withDependencies {
-            $0.httpClient = .responding(with: Data(), statusCode: 401)
-            $0.log = recorder.log
-        } operation: {
-            _ = try await AuthGateway.liveValue.authenticate(credential())
-        }
-
-        #expect(recorder.events.map(\.level) == [.notice])
+    try? await withDependencies {
+        $0.httpClient = .responding(with: Data(), statusCode: statusCode)
+        $0.log = recorder.log
+    } operation: {
+        _ = try await AuthGateway.liveValue.authenticate(credential())
     }
+
+    return recorder.events.first
+}
+
+private func attempt(failingWith error: some Error & Sendable) async -> LogEvent? {
+    let recorder = LogRecorder()
+
+    try? await withDependencies {
+        $0.httpClient = .failing(with: error)
+        $0.log = recorder.log
+    } operation: {
+        _ = try await AuthGateway.liveValue.authenticate(credential())
+    }
+
+    return recorder.events.first
 }
 
 private func credential() throws -> Credential {


### PR DESCRIPTION
## Problem

Four distinct things could go wrong signing in, and all four surfaced as `AuthenticationError.unknown` with nothing logged:

- the request body failed to encode,
- the request never reached the server,
- the server returned a status we do not handle,
- the credentials were rejected.

`AuthGateway+Live` caught the first two in a single `catch`, and `LoginMapper` threw the **public** `AuthenticationError` directly, so there was no seam to decorate and no detail left to log.

## Solution

Each seam owns its own failure type, both plain enums with **no LogKit import**:

- `LoginRequestFailure`: `couldNotEncodeRequest`, `transportFailed`
- `LoginResponseFailure`: `invalidCredentials`, `unexpectedStatus`

`LoggedLoginFailure` is a mapped projection, in the same spirit as `CachedSession` for storage. It holds the only switch and decides how each failure reads. Errors stay free of logging concerns exactly as domain types do; logging lives only in files named `+Logging` or under `Logging/`, which is greppable rather than a convention to trust.

Two decorators, one per seam, each catching only its own type, so a response failure passes through the gateway already logged rather than being logged twice.

Composition order is load-bearing and commented:

```swift
    live.loggingRequestFailures().narrowingFailures()
```

Logging sits inside the narrowing. Reverse them and the decorator sees only `AuthenticationError`, with the reason already gone.

`LoginMapper` also stops being a static `enum`. A static function is not a value and cannot be decorated, so logging could only have gone inside the mapping.

## Result

Five causes, five distinct searchable messages, where there was one `.unknown`:

    [error]  The sign-in request could not be encoded: …
    [error]  The sign-in request could not reach the server: couldNotBuildResponse
    [notice] The sign-in credentials were rejected
    [error]  Sign-in got an unexpected status 503

Each failure gets its own message because a destination groups and filters by message; one shared message with the cause in a field cannot be filtered at all. A rejected credential logs at `notice`, since someone mistyping a ticket reference is an expected outcome rather than a fault in the app.

`AuthenticationError` is unchanged and still carries no diagnostic payload.

## How to test

- `swift test` per package: LogKit 124, AuthenticationFeature 59, AuthenticationUI 54, SecureStorageKit 16.
- Probes run and reverted: giving two causes the same message fails; adding double-logging at the gateway fails the single-event test; reversing the decorator order fails four tests.
- Build the app and check for `warning:`, not just success.

## Follow-up, already in the backlog

`AttendeeRepository+Live` swallows its transport failure in exactly the same way, and `AttendeeResponseFailure.couldNotRead` absorbs four causes. The attendee path should converge on this shape next.
