### PR TITLE
feat(AuthenticationFeature): tell the user when the server is unreachable

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/AuthenticationError.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/AuthenticationError.swift
@@ -1,4 +1,0 @@
-public enum AuthenticationError: Error, Equatable {
-    case invalidCredentials
-    case unknown
-}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignInError.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignInError.swift
@@ -1,0 +1,4 @@
+public enum SignInError: Error, Equatable {
+    case invalidCredentials
+    case unknown
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignInError.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignInError.swift
@@ -1,4 +1,16 @@
+/// Why signing in did not succeed, in the terms a caller can act on.
+///
+/// Deliberately coarse: a case exists only where the UI would say something different. Anything a
+/// user cannot act on stays ``unknown``, and the detail goes to the log instead.
 public enum SignInError: Error, Equatable {
+    /// The email address and ticket reference did not match a ticket.
     case invalidCredentials
+
+    /// The request never reached the server.
+    ///
+    /// Named for what we know: this cannot tell a device with no connection from a server that is
+    /// down, so it must not claim the user is offline.
+    case couldNotReachServer
+
     case unknown
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension AuthGateway: DependencyKey {
     /// Order is load-bearing: logging must sit inside the narrowing, or it would see only
-    /// `AuthenticationError` and the reason would already be gone.
+    /// `SignInError` and the reason would already be gone.
     package static var liveValue: AuthGateway {
         live.loggingRequestFailures().narrowingFailures()
     }
@@ -46,9 +46,9 @@ extension AuthGateway {
             do {
                 return try await authenticate(credential)
             } catch let failure as LoginRequestFailure {
-                throw AuthenticationError(failure)
+                throw SignInError(failure)
             } catch let failure as LoginResponseFailure {
-                throw AuthenticationError(failure)
+                throw SignInError(failure)
             }
         }
     }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
@@ -3,7 +3,7 @@ import LogKit
 
 extension LoginMapper {
     /// Wraps the mapper rather than the gateway, which has already narrowed the failure to
-    /// `AuthenticationError` and lost the reason.
+    /// `SignInError` and lost the reason.
     func loggingFailures() -> LoginMapper {
         LoginMapper { data, response throws(LoginResponseFailure) in
             do throws(LoginResponseFailure) {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestFailure.swift
@@ -7,7 +7,7 @@ enum LoginRequestFailure: Error {
     case transportFailed(any Error)
 }
 
-extension AuthenticationError {
+extension SignInError {
     init(_ failure: LoginRequestFailure) {
         switch failure {
         case .couldNotEncodeRequest:

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestFailure.swift
@@ -13,7 +13,7 @@ extension SignInError {
         case .couldNotEncodeRequest:
             self = .unknown
         case .transportFailed:
-            self = .unknown
+            self = .couldNotReachServer
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginResponseFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginResponseFailure.swift
@@ -1,6 +1,6 @@
 /// Why a login response could not be turned into a session.
 ///
-/// Internal on purpose: `AuthenticationError` is what callers see, and it carries no diagnostic
+/// Internal on purpose: `SignInError` is what callers see, and it carries no diagnostic
 /// payload. This is what middleware between the two gets to read. It knows nothing about logging;
 /// `LoggedLoginFailure` decides how it reads.
 enum LoginResponseFailure: Error {
@@ -8,7 +8,7 @@ enum LoginResponseFailure: Error {
     case unexpectedStatus(Int)
 }
 
-extension AuthenticationError {
+extension SignInError {
     init(_ failure: LoginResponseFailure) {
         switch failure {
         case .invalidCredentials:

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLiveTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLiveTests.swift
@@ -24,6 +24,16 @@ import Testing
         }
     }
 
+    @Test func whenRequestCannotReachServer_shouldThrowCouldNotReachServer() async throws {
+        await #expect(throws: SignInError.couldNotReachServer) {
+            try await withDependencies {
+                $0.httpClient = .failing(with: StubFailure.couldNotBuildResponse)
+            } operation: {
+                try await AuthGateway.liveValue.authenticate(credential())
+            }
+        }
+    }
+
     @Test func whenServerReturnsOtherStatus_shouldThrowUnknown() async throws {
         await #expect(throws: SignInError.unknown) {
             try await withDependencies {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLiveTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLiveTests.swift
@@ -15,7 +15,7 @@ import Testing
     }
 
     @Test func whenServerReturnsUnauthorized_shouldThrowInvalidCredentials() async throws {
-        await #expect(throws: AuthenticationError.invalidCredentials) {
+        await #expect(throws: SignInError.invalidCredentials) {
             try await withDependencies {
                 $0.httpClient = .responding(with: Data(), statusCode: 401)
             } operation: {
@@ -25,7 +25,7 @@ import Testing
     }
 
     @Test func whenServerReturnsOtherStatus_shouldThrowUnknown() async throws {
-        await #expect(throws: AuthenticationError.unknown) {
+        await #expect(throws: SignInError.unknown) {
             try await withDependencies {
                 $0.httpClient = .responding(with: Data(), statusCode: 500)
             } operation: {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLoggingTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import LogKit
 import Testing
 
-/// The public `AuthenticationError` is deliberately bare, so these assert the reason survives to the
+/// The public `SignInError` is deliberately bare, so these assert the reason survives to the
 /// log even though the caller never sees it.
 @Suite struct AuthGatewayLoggingTests {
     @Test func whenCredentialsAreRejected_shouldSayTheyWereRejected() async throws {

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView+ViewModel.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView+ViewModel.swift
@@ -22,6 +22,31 @@ extension SignInView {
 
         package init() {}
 
+        /// Which alert a failure warrants, if any.
+        ///
+        /// Names the alert rather than carrying its words: the words are literals in the view, so
+        /// there is no title that could be absent. A rejected ticket reference deliberately has no
+        /// alert, because it is shown next to the field the user needs to correct.
+        package enum Alert: Equatable {
+            case cannotConnect
+            case unexpected
+        }
+
+        package var alert: Alert? {
+            switch phase {
+            case .failed(.couldNotReachServer):
+                .cannotConnect
+            case .failed(.unknown):
+                .unexpected
+            case .failed(.invalidCredentials):
+                nil
+            case .editing:
+                nil
+            case .submitting:
+                nil
+            }
+        }
+
         package var credential: Credential? {
             try? Credential(
                 email: EmailAddress(email),

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView+ViewModel.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView+ViewModel.swift
@@ -9,7 +9,7 @@ extension SignInView {
         package enum Phase: Equatable {
             case editing
             case submitting
-            case failed(AuthenticationError)
+            case failed(SignInError)
         }
 
         @ObservationIgnored
@@ -42,7 +42,7 @@ extension SignInView {
                 try await signIn(credential)
                 phase = .editing
                 onSignedIn()
-            } catch let error as AuthenticationError {
+            } catch let error as SignInError {
                 phase = .failed(error)
             } catch {
                 phase = .failed(.unknown)

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView.swift
@@ -57,16 +57,21 @@ public struct SignInView: View {
             }
         }
         .disabled(viewModel.isSubmitting)
-        .alert("Something went wrong", isPresented: presentingUnknownError) {
+        .alert("Can't connect", isPresented: presenting(.cannotConnect)) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Check your connection and try again.")
+        }
+        .alert("Something went wrong", isPresented: presenting(.unexpected)) {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Please try again.")
         }
     }
 
-    private var presentingUnknownError: Binding<Bool> {
+    private func presenting(_ alert: ViewModel.Alert) -> Binding<Bool> {
         Binding(
-            get: { viewModel.phase == .failed(.unknown) },
+            get: { viewModel.alert == alert },
             set: { isPresented in
                 if !isPresented {
                     viewModel.dismissError()

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/SignInView/SignInViewModelTests.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/SignInView/SignInViewModelTests.swift
@@ -60,6 +60,20 @@ import Testing
         }
     }
 
+    @Test func whenServerCannotBeReached_shouldReportCouldNotReachServer() async {
+        await withDependencies {
+            $0.signIn = SignIn { _ in throw SignInError.couldNotReachServer }
+        } operation: {
+            let sut = SignInView.ViewModel()
+            sut.email = "attendee@example.com"
+            sut.ticketReference = "ABCD-12"
+
+            await sut.submit()
+
+            #expect(sut.phase == .failed(.couldNotReachServer))
+        }
+    }
+
     @Test func whenSignInFailsWithUnexpectedError_shouldReportUnknown() async {
         await withDependencies {
             $0.signIn = SignIn { _ in throw UnexpectedError.boom }
@@ -71,6 +85,49 @@ import Testing
             await sut.submit()
 
             #expect(sut.phase == .failed(.unknown))
+        }
+    }
+
+    @Test func whenServerCannotBeReached_shouldAlertAboutTheConnection() async {
+        await withDependencies {
+            $0.signIn = SignIn { _ in throw SignInError.couldNotReachServer }
+        } operation: {
+            let sut = SignInView.ViewModel()
+            sut.email = "attendee@example.com"
+            sut.ticketReference = "ABCD-12"
+
+            await sut.submit()
+
+            #expect(sut.alert == .cannotConnect)
+        }
+    }
+
+    @Test func whenSignInFailsUnexpectedly_shouldAlertGenerically() async {
+        await withDependencies {
+            $0.signIn = SignIn { _ in throw SignInError.unknown }
+        } operation: {
+            let sut = SignInView.ViewModel()
+            sut.email = "attendee@example.com"
+            sut.ticketReference = "ABCD-12"
+
+            await sut.submit()
+
+            #expect(sut.alert == .unexpected)
+        }
+    }
+
+    /// Shown beside the field the user must correct, so an alert would be in the way.
+    @Test func whenCredentialsAreRejected_shouldNotAlert() async {
+        await withDependencies {
+            $0.signIn = SignIn { _ in throw SignInError.invalidCredentials }
+        } operation: {
+            let sut = SignInView.ViewModel()
+            sut.email = "attendee@example.com"
+            sut.ticketReference = "ABCD-12"
+
+            await sut.submit()
+
+            #expect(sut.alert == nil)
         }
     }
 

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/SignInView/SignInViewModelTests.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/SignInView/SignInViewModelTests.swift
@@ -48,7 +48,7 @@ import Testing
 
     @Test func whenSignInFailsWithInvalidCredentials_shouldReportInvalidCredentials() async {
         await withDependencies {
-            $0.signIn = SignIn { _ in throw AuthenticationError.invalidCredentials }
+            $0.signIn = SignIn { _ in throw SignInError.invalidCredentials }
         } operation: {
             let sut = SignInView.ViewModel()
             sut.email = "attendee@example.com"
@@ -76,7 +76,7 @@ import Testing
 
     @Test func whenErrorDismissed_shouldReturnToEditing() async {
         await withDependencies {
-            $0.signIn = SignIn { _ in throw AuthenticationError.unknown }
+            $0.signIn = SignIn { _ in throw SignInError.unknown }
         } operation: {
             let sut = SignInView.ViewModel()
             sut.email = "attendee@example.com"


### PR DESCRIPTION
## Problem

`AuthenticationError` had two cases, `invalidCredentials` and `unknown`. Everything that was not a rejected ticket became `unknown`, so **a user with no signal saw "Something went wrong. Please try again.", identical to a server returning 500.** The most common real failure had the least useful message, and it is the one the user can actually fix.

The internals already knew the difference after #125; the public error threw it away.

## Solution

Three changes.

**`AuthenticationError` becomes `SignInError`.** Nothing but the sign-in path produces or consumes it: `SignOut` and `AuthStatus` do not. It matches `AttendeeFetchError`, which is named for its operation rather than its module. The rename is its own commit, with no behaviour change.

The name also survives refresh tokens arriving later. A shared error across sign-in and refresh would make illegal states representable, since `invalidCredentials` is meaningless during a refresh and an expired-refresh case is meaningless during sign-in. `AuthGateway` deliberately keeps its name: a gateway is named for the system it fronts, not one operation, so it can gain `refresh` alongside `authenticate`.

**A `couldNotReachServer` case.** Named for what we know: this cannot tell a device with no connection from a server that is down, so it does not claim the user is offline. The other internal causes stay `unknown` on purpose, because an encode failure is a programmer error and an unexpected status leads to the same advice.

**The UI says something useful**, and the alert decision moves to the view model so it can be tested.

## How to test

- `swift test` per package: LogKit 124, AuthenticationFeature 60, AuthenticationUI 58, SecureStorageKit 16.
- Build the app and check for `warning:`, not just success.

## Follow-up, in the backlog

`SignInError` still sits in `Domain/` while being named for an operation whose use case lives in `Application/`. `AttendeeFetchError` has the same mismatch. Both should move; deliberately not folded in here.
