### PR TITLE
fix(AuthenticationFeature): parse the session token instead of trusting it

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SessionToken.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SessionToken.swift
@@ -1,10 +1,18 @@
 import Foundation
 
 package struct SessionToken: Equatable, Hashable, Sendable {
+    package enum ParsingError: Error, Equatable {
+        case empty
+    }
+
     private let storage: String
 
-    package init(_ value: String) {
-        storage = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    /// Creates a session token, trimming surrounding whitespace.
+    /// - Throws: ``ParsingError/empty`` if `value` is blank once trimmed.
+    package init(_ value: String) throws(ParsingError) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw .empty }
+        storage = trimmed
     }
 
     fileprivate var stringValue: String { storage }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignInError.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SignInError.swift
@@ -1,15 +1,13 @@
-/// Why signing in did not succeed, in the terms a caller can act on.
+/// Why signing in did not succeed.
 ///
-/// Deliberately coarse: a case exists only where the UI would say something different. Anything a
-/// user cannot act on stays ``unknown``, and the detail goes to the log instead.
+/// Deliberately coarse: a case exists only where a caller would behave differently.
 public enum SignInError: Error, Equatable {
     /// The email address and ticket reference did not match a ticket.
     case invalidCredentials
 
     /// The request never reached the server.
     ///
-    /// Named for what we know: this cannot tell a device with no connection from a server that is
-    /// down, so it must not claim the user is offline.
+    /// Does not distinguish a device with no connection from a server that is down.
     case couldNotReachServer
 
     case unknown

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -2,16 +2,13 @@ import Dependencies
 import Foundation
 
 extension AuthGateway: DependencyKey {
-    /// Order is load-bearing: logging must sit inside the narrowing, or it would see only
-    /// `SignInError` and the reason would already be gone.
     package static var liveValue: AuthGateway {
         live.loggingRequestFailures().narrowingFailures()
     }
 }
 
 extension AuthGateway {
-    /// Throws `LoginRequestFailure` for anything that stops a response arriving, and lets the
-    /// mapper's own `LoginResponseFailure` pass through.
+    /// Throws ``LoginRequestFailure`` or ``LoginResponseFailure``.
     static var live: AuthGateway {
         AuthGateway { credential in
             @Dependency(\.httpClient) var httpClient

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Logging.swift
@@ -2,8 +2,6 @@ import Dependencies
 import LogKit
 
 extension AuthGateway {
-    /// Records only this seam's own failures. A response failure has already been logged by the
-    /// mapper's decorator, so it passes through untouched rather than being logged twice.
     func loggingRequestFailures() -> AuthGateway {
         AuthGateway { credential in
             do {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/CachedSession.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/CachedSession.swift
@@ -9,7 +9,9 @@ extension CachedSession {
         self.init(token: String(session.token))
     }
 
-    var session: Session {
-        Session(token: SessionToken(token))
+    /// The stored session, or `nil` if what was stored is no longer valid.
+    var session: Session? {
+        guard let token = try? SessionToken(token) else { return nil }
+        return Session(token: token)
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginFailure.swift
@@ -1,11 +1,6 @@
 import LogKit
 
 /// How a login failure reads in a log.
-///
-/// A mapped projection, in the same spirit as `CachedSession` for storage: the failure types stay
-/// free of LogKit, and every decision about how they are recorded lives here. Each failure gets its
-/// own message, because a message is what a destination groups and filters by; one shared message
-/// with the cause in a field cannot be filtered at all.
 struct LoggedLoginFailure {
     let level: LogLevel
     let message: LogMessage
@@ -30,6 +25,9 @@ struct LoggedLoginFailure {
         case let .unexpectedStatus(code):
             level = .error
             message = "Sign-in got an unexpected status \(code, name: "statusCode", privacy: .open)"
+        case let .invalidToken(reason):
+            level = .error
+            message = "The server's sign-in token was rejected: \(reason, name: "reason", privacy: .open)"
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
@@ -2,8 +2,6 @@ import Dependencies
 import LogKit
 
 extension LoginMapper {
-    /// Wraps the mapper rather than the gateway, which has already narrowed the failure to
-    /// `SignInError` and lost the reason.
     func loggingFailures() -> LoginMapper {
         LoginMapper { data, response throws(LoginResponseFailure) in
             do throws(LoginResponseFailure) {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
@@ -13,7 +13,11 @@ extension LoginMapper {
     static let live = LoginMapper { data, response throws(LoginResponseFailure) in
         switch response.statusCode {
         case 200:
-            return SessionToken(String(decoding: data, as: UTF8.self))
+            do throws(SessionToken.ParsingError) {
+                return try SessionToken(String(decoding: data, as: UTF8.self))
+            } catch {
+                throw .invalidToken(error)
+            }
         case 401:
             throw .invalidCredentials
         default:

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginRequestFailure.swift
@@ -1,7 +1,4 @@
 /// Why a login request never got a response.
-///
-/// Separate from ``LoginResponseFailure`` so each seam owns its own failures: the gateway's
-/// decorator logs only these, and passes response failures through already logged.
 enum LoginRequestFailure: Error {
     case couldNotEncodeRequest(any Error)
     case transportFailed(any Error)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginResponseFailure.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginResponseFailure.swift
@@ -1,11 +1,8 @@
 /// Why a login response could not be turned into a session.
-///
-/// Internal on purpose: `SignInError` is what callers see, and it carries no diagnostic
-/// payload. This is what middleware between the two gets to read. It knows nothing about logging;
-/// `LoggedLoginFailure` decides how it reads.
 enum LoginResponseFailure: Error {
     case invalidCredentials
     case unexpectedStatus(Int)
+    case invalidToken(SessionToken.ParsingError)
 }
 
 extension SignInError {
@@ -14,6 +11,8 @@ extension SignInError {
         case .invalidCredentials:
             self = .invalidCredentials
         case .unexpectedStatus:
+            self = .unknown
+        case .invalidToken:
             self = .unknown
         }
     }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Live.swift
@@ -17,7 +17,7 @@ extension SessionStore: DependencyKey {
             current: {
                 @Dependency(\.secureStorage) var secureStorage
                 return try await secureStorage.data(key)
-                    .map { try JSONDecoder().decode(CachedSession.self, from: $0).session }
+                    .flatMap { try JSONDecoder().decode(CachedSession.self, from: $0).session }
             }
         )
     }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLiveTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLiveTests.swift
@@ -11,13 +11,24 @@ import Testing
             try await AuthGateway.liveValue.authenticate(credential())
         }
 
-        #expect(token == SessionToken("jwt-abc-123"))
+        #expect(try token == SessionToken("jwt-abc-123"))
     }
 
     @Test func whenServerReturnsUnauthorized_shouldThrowInvalidCredentials() async throws {
         await #expect(throws: SignInError.invalidCredentials) {
             try await withDependencies {
                 $0.httpClient = .responding(with: Data(), statusCode: 401)
+            } operation: {
+                try await AuthGateway.liveValue.authenticate(credential())
+            }
+        }
+    }
+
+    /// A 200 carrying nothing is a server contract violation, not a session.
+    @Test func whenServerReturnsEmptyBody_shouldThrowUnknown() async throws {
+        await #expect(throws: SignInError.unknown) {
+            try await withDependencies {
+                $0.httpClient = .responding(with: Data(), statusCode: 200)
             } operation: {
                 try await AuthGateway.liveValue.authenticate(credential())
             }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthStatusTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthStatusTests.swift
@@ -3,8 +3,8 @@ import Dependencies
 import Testing
 
 @Suite struct AuthStatusTests {
-    @Test func whenSessionExists_shouldReportSignedIn() async {
-        let session = Session(token: SessionToken("jwt-abc-123"))
+    @Test func whenSessionExists_shouldReportSignedIn() async throws {
+        let session = try Session(token: SessionToken("jwt-abc-123"))
         let store = InMemorySessionStore(stored: session)
 
         let state = await withDependencies {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientAuthenticatedTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientAuthenticatedTests.swift
@@ -12,7 +12,7 @@ import Testing
 
     @Test func whenSessionExists_shouldAttachBearer() async throws {
         let spy = HTTPClientSpy(respondingWith: Data(), statusCode: 200)
-        let store = InMemorySessionStore(stored: Session(token: SessionToken("jwt-abc-123")))
+        let store = InMemorySessionStore(stored: Session(token: try SessionToken("jwt-abc-123")))
 
         _ = try await withDependencies {
             $0.sessionStore = store.sessionStore

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreTests.swift
@@ -1,11 +1,26 @@
 import AuthenticationFeature
 import Dependencies
+import Foundation
 import SecureStorageKit
 import Testing
 
 @Suite struct SessionStoreTests {
+    /// Storage is an outer ring like any other: a stored token that no longer parses is not a
+    /// session, and must not be handed inward as one.
+    @Test func whenStoredTokenIsBlank_shouldReportNoSession() async throws {
+        let spy = SecureStorageSpy()
+
+        try await withDependencies {
+            $0.secureStorage = spy.secureStorage
+        } operation: {
+            try await spy.secureStorage.set(Data(#"{"token":"  "}"#.utf8), SecureStorageKey("auth.session"))
+
+            #expect(try await SessionStore.liveValue.current() == nil)
+        }
+    }
+
     @Test func whenSessionEstablished_shouldReadBackSameSession() async throws {
-        let session = Session(token: SessionToken("jwt-abc-123"))
+        let session = Session(token: try SessionToken("jwt-abc-123"))
 
         try await withDependencies {
             $0.secureStorage = SecureStorageSpy().secureStorage

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionTokenTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionTokenTests.swift
@@ -2,13 +2,24 @@ import AuthenticationFeature
 import Testing
 
 @Suite struct SessionTokenTests {
-    @Test func whenDescribed_shouldRedactValue() {
-        let token = SessionToken("jwt-abc-123")
+    @Test func whenDescribed_shouldRedactValue() throws {
+        let token = try SessionToken("jwt-abc-123")
+
         #expect(!String(describing: token).contains("jwt-abc-123"))
     }
 
-    @Test func whenCreatedWithSurroundingWhitespace_shouldTrim() {
-        let sut = SessionToken("  jwt-abc-123\n")
+    @Test func whenCreatedWithSurroundingWhitespace_shouldTrim() throws {
+        let sut = try SessionToken("  jwt-abc-123\n")
+
         #expect(String(sut) == "jwt-abc-123")
+    }
+
+    /// A 200 with an empty body would otherwise become a token that is stored in the keychain and
+    /// sent as an Authorization header, surfacing much later as 401s that read as session expiry.
+    @Test(arguments: ["", " ", "\n", "   \t  "])
+    func whenCreatedFromBlankString_shouldThrowEmpty(value: String) {
+        #expect(throws: SessionToken.ParsingError.empty) {
+            try SessionToken(value)
+        }
     }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInTests.swift
@@ -7,7 +7,7 @@ import Testing
         let store = InMemorySessionStore()
 
         try await withDependencies {
-            $0.authGateway = .returning(SessionToken("jwt-abc-123"))
+            $0.authGateway = .returning(try SessionToken("jwt-abc-123"))
             $0.sessionStore = store.sessionStore
         } operation: {
             let sut = SignIn.liveValue

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite struct SignOutTests {
     @Test func whenSignedOut_shouldClearStoredSession() async throws {
-        let store = InMemorySessionStore(stored: Session(token: SessionToken("jwt-abc-123")))
+        let store = InMemorySessionStore(stored: Session(token: try SessionToken("jwt-abc-123")))
 
         try await withDependencies {
             $0.sessionStore = store.sessionStore


### PR DESCRIPTION
## Problem

* A sign-in response with an empty body produced a valid-looking empty session token.
* That token was saved to the keychain and sent on every later request, so the user hit 401s that looked like their session had expired. The cause was several screens away from the symptom.
* Tokens read back out of the keychain were trusted the same way.

## Solution

* `SessionToken` rejects a blank value. Non-empty only for now, so the token format stays free to change.
* An empty token in a sign-in response is logged and reaches the caller as `SignInError.unknown`.
* A stored token that no longer parses means no session, so the user is signed out cleanly instead of sending empty auth headers.
* Both changes are one commit: once the initialiser throws, the keychain path stops compiling.
* A second commit trims doc comments across nine files, 35 lines to 15.

## How to test

```
git fetch && git checkout fix/parse-session-token
for p in LogKit AuthenticationFeature AuthenticationUI SecureStorageKit; do (cd Packages/$p && swift test); done
```

* 261 tests pass.
* Sign in normally to confirm the happy path is unchanged.
