### PR TITLE
feat(AuthenticationFeature): log the cause and outcome of authentication failures

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension AuthGateway: DependencyKey {
     package static var liveValue: AuthGateway {
-        live.loggingRequestFailures().narrowingFailures()
+        live.logging().narrowingFailures()
     }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Logging.swift
@@ -2,7 +2,7 @@ import Dependencies
 import LogKit
 
 extension AuthGateway {
-    package func loggingRequestFailures() -> AuthGateway {
+    package func logging() -> AuthGateway {
         AuthGateway { credential in
             do {
                 return try await authenticate(credential)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Live.swift
@@ -1,7 +1,7 @@
 extension HTTPClient {
     public static func live(onSessionExpiry: @escaping @Sendable () async -> Void) -> HTTPClient {
         urlSession()
-            .loggingFailures()
+            .logging()
             .interceptingSessionExpiry(onExpiry: onSessionExpiry)
             .authenticated()
     }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Logging.swift
@@ -3,7 +3,7 @@ import Foundation
 import LogKit
 
 extension HTTPClient {
-    package func loggingFailures() -> HTTPClient {
+    package func logging() -> HTTPClient {
         HTTPClient { request in
             do {
                 return try await send(request)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedSessionStoreOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedSessionStoreOutcome.swift
@@ -1,0 +1,48 @@
+import LogKit
+
+/// How each thing the session store did reads in a log.
+struct LoggedSessionStoreOutcome {
+    let level: LogLevel
+    let message: LogMessage
+
+    static let stored = LoggedSessionStoreOutcome(
+        level: .info,
+        message: "The session was stored"
+    )
+
+    static let cleared = LoggedSessionStoreOutcome(
+        level: .info,
+        message: "The session was cleared"
+    )
+
+    /// A read runs on every authenticated request, so it records at the level the platform drops
+    /// unless someone is watching. Finding nothing gets its own message, because that is the line
+    /// that explains why a user is signed out.
+    static func read(foundSession: Bool) -> LoggedSessionStoreOutcome {
+        LoggedSessionStoreOutcome(
+            level: .debug,
+            message: foundSession ? "The stored session was read" : "No session is stored"
+        )
+    }
+
+    static func notStored(_ error: any Error) -> LoggedSessionStoreOutcome {
+        LoggedSessionStoreOutcome(
+            level: .error,
+            message: "The session could not be stored: \(error, name: "reason", privacy: .open)"
+        )
+    }
+
+    static func notCleared(_ error: any Error) -> LoggedSessionStoreOutcome {
+        LoggedSessionStoreOutcome(
+            level: .error,
+            message: "The session could not be cleared: \(error, name: "reason", privacy: .open)"
+        )
+    }
+
+    static func notRead(_ error: any Error) -> LoggedSessionStoreOutcome {
+        LoggedSessionStoreOutcome(
+            level: .error,
+            message: "The stored session could not be read: \(error, name: "reason", privacy: .open)"
+        )
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedSignInOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedSignInOutcome.swift
@@ -1,0 +1,23 @@
+import LogKit
+
+/// How the outcome of a sign-in reads in a log.
+struct LoggedSignInOutcome {
+    let level: LogLevel
+    let message: LogMessage
+
+    init(_ error: SignInError) {
+        switch error {
+        case .invalidCredentials:
+            // Expected: someone mistyped a ticket reference. Not a fault in the app.
+            level = .notice
+            message = "Signing in did not finish: the credentials were rejected"
+        case .couldNotReachServer:
+            // Expected: the device is offline. The user can retry.
+            level = .notice
+            message = "Signing in did not finish: the server could not be reached"
+        case .unknown:
+            level = .error
+            message = "Signing in did not finish: the reason is not known"
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedSignInOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedSignInOutcome.swift
@@ -5,19 +5,39 @@ struct LoggedSignInOutcome {
     let level: LogLevel
     let message: LogMessage
 
-    init(_ error: SignInError) {
+    /// Carries no field. The credential identifies a person, and nothing here needs it.
+    static let success = LoggedSignInOutcome(
+        level: .notice,
+        message: "Signing in finished"
+    )
+
+    /// The gateway throws only ``SignInError``, so in the live app this is the session store. The
+    /// message names no step: `narrowingFailures()` has no catch-all, so a third error type would
+    /// reach here without the store ever running.
+    static let unexplainedFailure = LoggedSignInOutcome(
+        level: .error,
+        message: "Signing in did not finish, and no sign-in outcome explains it"
+    )
+
+    static func failure(_ error: SignInError) -> LoggedSignInOutcome {
         switch error {
         case .invalidCredentials:
             // Expected: someone mistyped a ticket reference. Not a fault in the app.
-            level = .notice
-            message = "Signing in did not finish: the credentials were rejected"
+            LoggedSignInOutcome(
+                level: .notice,
+                message: "Signing in did not finish: the credentials were rejected"
+            )
         case .couldNotReachServer:
             // Expected: the device is offline. The user can retry.
-            level = .notice
-            message = "Signing in did not finish: the server could not be reached"
+            LoggedSignInOutcome(
+                level: .notice,
+                message: "Signing in did not finish: the server could not be reached"
+            )
         case .unknown:
-            level = .error
-            message = "Signing in did not finish: the reason is not known"
+            LoggedSignInOutcome(
+                level: .error,
+                message: "Signing in did not finish: the reason is not known"
+            )
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedSignOutOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedSignOutOutcome.swift
@@ -1,0 +1,17 @@
+import LogKit
+
+/// How the outcome of a sign-out reads in a log.
+struct LoggedSignOutOutcome {
+    let level: LogLevel
+    let message: LogMessage
+
+    static let success = LoggedSignOutOutcome(
+        level: .notice,
+        message: "Signing out finished"
+    )
+
+    static let failure = LoggedSignOutOutcome(
+        level: .error,
+        message: "Signing out did not finish, so the session is still on this device"
+    )
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+Logging.swift
@@ -2,7 +2,7 @@ import Dependencies
 import LogKit
 
 extension LoginMapper {
-    package func loggingFailures() -> LoginMapper {
+    package func logging() -> LoginMapper {
         LoginMapper { data, response throws(ResponseError) in
             do throws(ResponseError) {
                 return try map(data, response)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
@@ -27,7 +27,7 @@ extension LoginMapper {
 }
 
 private enum LoginMapperKey: DependencyKey {
-    static var liveValue: LoginMapper { .live.loggingFailures() }
+    static var liveValue: LoginMapper { .live.logging() }
     static var testValue: LoginMapper { liveValue }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Live.swift
@@ -4,6 +4,12 @@ import SecureStorageKit
 
 extension SessionStore: DependencyKey {
     package static var liveValue: SessionStore {
+        live.loggingFailures()
+    }
+}
+
+extension SessionStore {
+    package static var live: SessionStore {
         let key = SecureStorageKey("auth.session")
         return SessionStore(
             establish: { session in

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Live.swift
@@ -4,7 +4,7 @@ import SecureStorageKit
 
 extension SessionStore: DependencyKey {
     package static var liveValue: SessionStore {
-        live.loggingFailures()
+        live.logging()
     }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Logging.swift
@@ -1,0 +1,50 @@
+import Dependencies
+import LogKit
+
+extension SessionStore {
+    /// Records why the store refused, then rethrows.
+    ///
+    /// A session that will not clear stays on the device after the user believes they signed out.
+    package func loggingFailures() -> SessionStore {
+        SessionStore(
+            establish: { session in
+                do {
+                    try await establish(session)
+                } catch {
+                    // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+                    // building liveValue would capture whichever log existed first.
+                    @Dependency(\.log) var log
+                    log.error(
+                        "The session could not be stored: \(error, name: "reason", privacy: .open)",
+                        in: .auth
+                    )
+                    throw error
+                }
+            },
+            clear: {
+                do {
+                    try await clear()
+                } catch {
+                    @Dependency(\.log) var log
+                    log.error(
+                        "The session could not be cleared: \(error, name: "reason", privacy: .open)",
+                        in: .auth
+                    )
+                    throw error
+                }
+            },
+            current: {
+                do {
+                    return try await current()
+                } catch {
+                    @Dependency(\.log) var log
+                    log.error(
+                        "The stored session could not be read: \(error, name: "reason", privacy: .open)",
+                        in: .auth
+                    )
+                    throw error
+                }
+            }
+        )
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Logging.swift
@@ -5,7 +5,7 @@ extension SessionStore {
     /// Records why the store refused, then rethrows.
     ///
     /// A session that will not clear stays on the device after the user believes they signed out.
-    package func loggingFailures() -> SessionStore {
+    package func logging() -> SessionStore {
         SessionStore(
             establish: { session in
                 do {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SessionStore+Logging.swift
@@ -2,46 +2,48 @@ import Dependencies
 import LogKit
 
 extension SessionStore {
-    /// Records why the store refused, then rethrows.
+    /// Records what the store did, then returns or rethrows.
     ///
-    /// A session that will not clear stays on the device after the user believes they signed out.
+    /// Every caller discards the error with `try?`, so a refusal reaches no one else. A session that
+    /// will not clear stays on the device after the user believes they signed out.
     package func logging() -> SessionStore {
         SessionStore(
             establish: { session in
+                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+                // building liveValue would capture whichever log existed first.
+                @Dependency(\.log) var log
                 do {
                     try await establish(session)
+                    let entry = LoggedSessionStoreOutcome.stored
+                    log(entry.level, .auth, entry.message)
                 } catch {
-                    // Resolved per call, so a test overriding \.log is honoured. Resolving it while
-                    // building liveValue would capture whichever log existed first.
-                    @Dependency(\.log) var log
-                    log.error(
-                        "The session could not be stored: \(error, name: "reason", privacy: .open)",
-                        in: .auth
-                    )
+                    let entry = LoggedSessionStoreOutcome.notStored(error)
+                    log(entry.level, .auth, entry.message)
                     throw error
                 }
             },
             clear: {
+                @Dependency(\.log) var log
                 do {
                     try await clear()
+                    let entry = LoggedSessionStoreOutcome.cleared
+                    log(entry.level, .auth, entry.message)
                 } catch {
-                    @Dependency(\.log) var log
-                    log.error(
-                        "The session could not be cleared: \(error, name: "reason", privacy: .open)",
-                        in: .auth
-                    )
+                    let entry = LoggedSessionStoreOutcome.notCleared(error)
+                    log(entry.level, .auth, entry.message)
                     throw error
                 }
             },
             current: {
+                @Dependency(\.log) var log
                 do {
-                    return try await current()
+                    let session = try await current()
+                    let entry = LoggedSessionStoreOutcome.read(foundSession: session != nil)
+                    log(entry.level, .auth, entry.message)
+                    return session
                 } catch {
-                    @Dependency(\.log) var log
-                    log.error(
-                        "The stored session could not be read: \(error, name: "reason", privacy: .open)",
-                        in: .auth
-                    )
+                    let entry = LoggedSessionStoreOutcome.notRead(error)
+                    log(entry.level, .auth, entry.message)
                     throw error
                 }
             }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
@@ -5,8 +5,8 @@ extension SignIn {
     /// Records the outcome the user got, then rethrows.
     ///
     /// The cause already reached the log at the seam that knew it: the transport, the mapper, or
-    /// the session store.
-    public func loggingFailures() -> SignIn {
+    /// the session store. This line says what that cost the person signing in.
+    public func loggingFailedOutcomes() -> SignIn {
         SignIn { credential in
             do {
                 try await self(credential)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
@@ -6,7 +6,7 @@ extension SignIn {
     ///
     /// The cause already reached the log at the seam that knew it: the transport, the mapper, or
     /// the session store. This line says what that cost the person signing in.
-    public func loggingFailedOutcomes() -> SignIn {
+    public func logging() -> SignIn {
         SignIn { credential in
             do {
                 try await self(credential)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
@@ -18,10 +18,11 @@ extension SignIn {
                 log(entry.level, .auth, entry.message)
                 throw error
             } catch {
-                // The gateway narrows every failure it can produce to SignInError, so a failure of
-                // any other type means the server accepted the credentials.
+                // The gateway throws only SignInError, so in the live app this is the session
+                // store. The message names no step: `narrowingFailures()` has no catch-all, so a
+                // third error type would reach here without the store ever running.
                 @Dependency(\.log) var log
-                log.error("Signing in did not finish: the session was not stored", in: .auth)
+                log.error("Signing in did not finish, and no sign-in outcome explains it", in: .auth)
                 throw error
             }
         }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
@@ -4,25 +4,24 @@ import LogKit
 extension SignIn {
     /// Records the outcome the user got, then rethrows.
     ///
-    /// The cause already reached the log at the seam that knew it: the transport, the mapper, or
-    /// the session store. This line says what that cost the person signing in.
+    /// A failure's cause already reached the log at the seam that knew it: the transport, the
+    /// mapper, or the session store. This line says what that meant for the person signing in.
     public func logging() -> SignIn {
         SignIn { credential in
+            // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+            // building liveValue would capture whichever log existed first.
+            @Dependency(\.log) var log
             do {
                 try await self(credential)
+                let entry = LoggedSignInOutcome.success
+                log(entry.level, .auth, entry.message)
             } catch let error as SignInError {
-                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
-                // building liveValue would capture whichever log existed first.
-                @Dependency(\.log) var log
-                let entry = LoggedSignInOutcome(error)
+                let entry = LoggedSignInOutcome.failure(error)
                 log(entry.level, .auth, entry.message)
                 throw error
             } catch {
-                // The gateway throws only SignInError, so in the live app this is the session
-                // store. The message names no step: `narrowingFailures()` has no catch-all, so a
-                // third error type would reach here without the store ever running.
-                @Dependency(\.log) var log
-                log.error("Signing in did not finish, and no sign-in outcome explains it", in: .auth)
+                let entry = LoggedSignInOutcome.unexplainedFailure
+                log(entry.level, .auth, entry.message)
                 throw error
             }
         }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignIn+Logging.swift
@@ -1,0 +1,29 @@
+import Dependencies
+import LogKit
+
+extension SignIn {
+    /// Records the outcome the user got, then rethrows.
+    ///
+    /// The cause already reached the log at the seam that knew it: the transport, the mapper, or
+    /// the session store.
+    public func loggingFailures() -> SignIn {
+        SignIn { credential in
+            do {
+                try await self(credential)
+            } catch let error as SignInError {
+                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+                // building liveValue would capture whichever log existed first.
+                @Dependency(\.log) var log
+                let entry = LoggedSignInOutcome(error)
+                log(entry.level, .auth, entry.message)
+                throw error
+            } catch {
+                // The gateway narrows every failure it can produce to SignInError, so a failure of
+                // any other type means the server accepted the credentials.
+                @Dependency(\.log) var log
+                log.error("Signing in did not finish: the session was not stored", in: .auth)
+                throw error
+            }
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignOut+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignOut+Logging.swift
@@ -6,7 +6,7 @@ extension SignOut {
     ///
     /// The store names the mechanism that refused. This names what it cost the user: they believe
     /// they signed out, and the session is still on the device.
-    public func loggingFailedOutcomes() -> SignOut {
+    public func logging() -> SignOut {
         SignOut {
             do {
                 try await self()

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignOut+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignOut+Logging.swift
@@ -2,19 +2,22 @@ import Dependencies
 import LogKit
 
 extension SignOut {
-    /// Records that signing out did not finish, then rethrows.
+    /// Records the outcome the user got, then rethrows.
     ///
-    /// The store names the mechanism that refused. This names what it cost the user: they believe
-    /// they signed out, and the session is still on the device.
+    /// The store names the mechanism. This names what it meant: either the session is gone, or the
+    /// user believes they signed out while it is still on the device.
     public func logging() -> SignOut {
         SignOut {
+            // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+            // building liveValue would capture whichever log existed first.
+            @Dependency(\.log) var log
             do {
                 try await self()
+                let entry = LoggedSignOutOutcome.success
+                log(entry.level, .auth, entry.message)
             } catch {
-                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
-                // building liveValue would capture whichever log existed first.
-                @Dependency(\.log) var log
-                log.error("Signing out did not finish, so the session is still on this device", in: .auth)
+                let entry = LoggedSignOutOutcome.failure
+                log(entry.level, .auth, entry.message)
                 throw error
             }
         }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignOut+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignOut+Logging.swift
@@ -6,7 +6,7 @@ extension SignOut {
     ///
     /// The store names the mechanism that refused. This names what it cost the user: they believe
     /// they signed out, and the session is still on the device.
-    public func loggingFailures() -> SignOut {
+    public func loggingFailedOutcomes() -> SignOut {
         SignOut {
             do {
                 try await self()

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignOut+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/SignOut+Logging.swift
@@ -1,0 +1,22 @@
+import Dependencies
+import LogKit
+
+extension SignOut {
+    /// Records that signing out did not finish, then rethrows.
+    ///
+    /// The store names the mechanism that refused. This names what it cost the user: they believe
+    /// they signed out, and the session is still on the device.
+    public func loggingFailures() -> SignOut {
+        SignOut {
+            do {
+                try await self()
+            } catch {
+                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+                // building liveValue would capture whichever log existed first.
+                @Dependency(\.log) var log
+                log.error("Signing out did not finish, so the session is still on this device", in: .auth)
+                throw error
+            }
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Domain/AttendeeFetchError.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Domain/AttendeeFetchError.swift
@@ -1,6 +1,13 @@
 public enum AttendeeFetchError: Error, Equatable {
     case unauthorized
+
+    /// The request never reached the server.
+    ///
+    /// Does not distinguish a device with no connection from a server that is down.
+    case couldNotReachServer
+
     /// The server answered, but not with something we accept.
     case invalidResponse
+
     case unknown
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+Logging.swift
@@ -3,7 +3,7 @@ import Foundation
 import LogKit
 
 extension AttendeeMapper {
-    package func loggingFailures() -> AttendeeMapper {
+    package func logging() -> AttendeeMapper {
         AttendeeMapper { data, response throws(ResponseError) in
             do throws(ResponseError) {
                 return try map(data, response)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
@@ -33,7 +33,7 @@ extension AttendeeMapper {
 }
 
 private enum AttendeeMapperKey: DependencyKey {
-    static var liveValue: AttendeeMapper { .live.loggingFailures() }
+    static var liveValue: AttendeeMapper { .live.logging() }
     static var testValue: AttendeeMapper { liveValue }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
@@ -13,7 +13,7 @@ extension AttendeeRepository: DependencyKey {
             do {
                 (data, response) = try await httpClient.send(request)
             } catch {
-                throw AttendeeFetchError.unknown
+                throw AttendeeFetchError.couldNotReachServer
             }
             do throws(AttendeeMapper.ResponseError) {
                 return try attendeeMapper.map(data, response)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
@@ -5,7 +5,8 @@ extension FetchProfile {
     /// Records the outcome the user got, then rethrows.
     ///
     /// The cause already reached the log at the seam that knew it: the transport or the mapper.
-    public func loggingFailures() -> FetchProfile {
+    /// This line says what that cost the person waiting for their profile.
+    public func loggingFailedOutcomes() -> FetchProfile {
         FetchProfile { () async throws(AttendeeFetchError) -> Profile in
             do throws(AttendeeFetchError) {
                 return try await self()

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
@@ -1,0 +1,22 @@
+import Dependencies
+import LogKit
+
+extension FetchProfile {
+    /// Records the outcome the user got, then rethrows.
+    ///
+    /// The cause already reached the log at the seam that knew it: the transport or the mapper.
+    public func loggingFailures() -> FetchProfile {
+        FetchProfile { () async throws(AttendeeFetchError) -> Profile in
+            do throws(AttendeeFetchError) {
+                return try await self()
+            } catch {
+                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+                // building liveValue would capture whichever log existed first.
+                @Dependency(\.log) var log
+                let entry = LoggedAttendeeFetchOutcome(error)
+                log(entry.level, .profile, entry.message)
+                throw error
+            }
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
@@ -14,7 +14,7 @@ extension FetchProfile {
                 // Resolved per call, so a test overriding \.log is honoured. Resolving it while
                 // building liveValue would capture whichever log existed first.
                 @Dependency(\.log) var log
-                let entry = LoggedAttendeeFetchOutcome(error)
+                let entry = LoggedProfileFetchOutcome(error)
                 log(entry.level, .profile, entry.message)
                 throw error
             }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
@@ -6,7 +6,7 @@ extension FetchProfile {
     ///
     /// The cause already reached the log at the seam that knew it: the transport or the mapper.
     /// This line says what that cost the person waiting for their profile.
-    public func loggingFailedOutcomes() -> FetchProfile {
+    public func logging() -> FetchProfile {
         FetchProfile { () async throws(AttendeeFetchError) -> Profile in
             do throws(AttendeeFetchError) {
                 return try await self()

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/FetchProfile+Logging.swift
@@ -4,17 +4,20 @@ import LogKit
 extension FetchProfile {
     /// Records the outcome the user got, then rethrows.
     ///
-    /// The cause already reached the log at the seam that knew it: the transport or the mapper.
-    /// This line says what that cost the person waiting for their profile.
+    /// A failure's cause already reached the log at the seam that knew it: the transport or the
+    /// mapper. This line says what that meant for the person waiting for their profile.
     public func logging() -> FetchProfile {
         FetchProfile { () async throws(AttendeeFetchError) -> Profile in
+            // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+            // building liveValue would capture whichever log existed first.
+            @Dependency(\.log) var log
             do throws(AttendeeFetchError) {
-                return try await self()
+                let profile = try await self()
+                let entry = LoggedProfileFetchOutcome.success
+                log(entry.level, .profile, entry.message)
+                return profile
             } catch {
-                // Resolved per call, so a test overriding \.log is honoured. Resolving it while
-                // building liveValue would capture whichever log existed first.
-                @Dependency(\.log) var log
-                let entry = LoggedProfileFetchOutcome(error)
+                let entry = LoggedProfileFetchOutcome.failure(error)
                 log(entry.level, .profile, entry.message)
                 throw error
             }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedAttendeeFetchOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedAttendeeFetchOutcome.swift
@@ -1,0 +1,22 @@
+import LogKit
+
+/// How the outcome of a profile fetch reads in a log.
+struct LoggedAttendeeFetchOutcome {
+    let level: LogLevel
+    let message: LogMessage
+
+    init(_ error: AttendeeFetchError) {
+        switch error {
+        case .unauthorized:
+            // Expected: the session expired or was revoked. Not a fault in the app.
+            level = .notice
+            message = "Loading the profile did not finish: the session was not accepted"
+        case .invalidResponse:
+            level = .error
+            message = "Loading the profile did not finish: the server's answer was rejected"
+        case .unknown:
+            level = .error
+            message = "Loading the profile did not finish: the reason is not known"
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedProfileFetchOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedProfileFetchOutcome.swift
@@ -11,6 +11,10 @@ struct LoggedProfileFetchOutcome {
             // Expected: the session expired or was revoked. Not a fault in the app.
             level = .notice
             message = "Loading the profile did not finish: the session was not accepted"
+        case .couldNotReachServer:
+            // Expected: the device is offline. The user can retry.
+            level = .notice
+            message = "Loading the profile did not finish: the server could not be reached"
         case .invalidResponse:
             level = .error
             message = "Loading the profile did not finish: the server's answer was rejected"

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedProfileFetchOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedProfileFetchOutcome.swift
@@ -1,7 +1,7 @@
 import LogKit
 
 /// How the outcome of a profile fetch reads in a log.
-struct LoggedAttendeeFetchOutcome {
+struct LoggedProfileFetchOutcome {
     let level: LogLevel
     let message: LogMessage
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedProfileFetchOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedProfileFetchOutcome.swift
@@ -5,22 +5,37 @@ struct LoggedProfileFetchOutcome {
     let level: LogLevel
     let message: LogMessage
 
-    init(_ error: AttendeeFetchError) {
+    /// Carries no field. A profile holds a name, an email address and a ticket reference, and none
+    /// of them belong in a log line that says the load worked.
+    static let success = LoggedProfileFetchOutcome(
+        level: .info,
+        message: "The profile loaded"
+    )
+
+    static func failure(_ error: AttendeeFetchError) -> LoggedProfileFetchOutcome {
         switch error {
         case .unauthorized:
             // Expected: the session expired or was revoked. Not a fault in the app.
-            level = .notice
-            message = "Loading the profile did not finish: the session was not accepted"
+            LoggedProfileFetchOutcome(
+                level: .notice,
+                message: "Loading the profile did not finish: the session was not accepted"
+            )
         case .couldNotReachServer:
             // Expected: the device is offline. The user can retry.
-            level = .notice
-            message = "Loading the profile did not finish: the server could not be reached"
+            LoggedProfileFetchOutcome(
+                level: .notice,
+                message: "Loading the profile did not finish: the server could not be reached"
+            )
         case .invalidResponse:
-            level = .error
-            message = "Loading the profile did not finish: the server's answer was rejected"
+            LoggedProfileFetchOutcome(
+                level: .error,
+                message: "Loading the profile did not finish: the server's answer was rejected"
+            )
         case .unknown:
-            level = .error
-            message = "Loading the profile did not finish: the reason is not known"
+            LoggedProfileFetchOutcome(
+                level: .error,
+                message: "Loading the profile did not finish: the reason is not known"
+            )
         }
     }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/Attendee+Fixture.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/Attendee+Fixture.swift
@@ -1,0 +1,18 @@
+import AuthenticationFeature
+import Foundation
+import Testing
+
+extension Attendee {
+    /// Any well-formed attendee. Nothing in a test depends on these particular values.
+    static var fixture: Attendee {
+        get throws {
+            Attendee(
+                name: PersonNameComponents(givenName: "Ada", familyName: "Lovelace"),
+                emailAddress: try EmailAddress("ada@example.com"),
+                avatarURL: AvatarURL(try #require(URL(string: "https://example.com/avatar.png"))),
+                ticketReference: try TicketReference("ABCD-12"),
+                ticketSlug: try TicketSlug("ti_abc")
+            )
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/Attendee+Fixture.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/Attendee+Fixture.swift
@@ -3,7 +3,8 @@ import Foundation
 import Testing
 
 extension Attendee {
-    /// Any well-formed attendee. Nothing in a test depends on these particular values.
+    /// Any well-formed attendee. `FetchProfileTests` pins these values in its own expectation, so
+    /// changing one changes that test.
     static var fixture: Attendee {
         get throws {
             Attendee(

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeMapperLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeMapperLoggingTests.swift
@@ -74,7 +74,7 @@ import Testing
         withDependencies {
             $0.log = LogRecorder().log
         } operation: {
-            let sut = AttendeeMapper.live.loggingFailures()
+            let sut = AttendeeMapper.live.logging()
 
             #expect(throws: AttendeeMapper.ResponseError.self) {
                 try sut.map(Data(), response)
@@ -89,7 +89,7 @@ import Testing
         try withDependencies {
             $0.log = recorder.log
         } operation: {
-            let sut = AttendeeMapper.live.loggingFailures()
+            let sut = AttendeeMapper.live.logging()
             _ = try sut.map(attendeeJSON(), response)
         }
 
@@ -103,7 +103,7 @@ import Testing
         withDependencies {
             $0.log = recorder.log
         } operation: {
-            let sut = AttendeeMapper.live.loggingFailures()
+            let sut = AttendeeMapper.live.logging()
             _ = try? sut.map(data, response)
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryIntegrationTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryIntegrationTests.swift
@@ -87,8 +87,10 @@ import Testing
         #expect(recorder.events.count == 1)
     }
 
-    @Test func whenTransportFails_shouldThrowUnknown() async throws {
-        await #expect(throws: AttendeeFetchError.unknown) {
+    /// An offline device is the commonest failure here, and it is not the same as a server the app
+    /// cannot make sense of.
+    @Test func whenTransportFails_shouldThrowCouldNotReachServer() async throws {
+        await #expect(throws: AttendeeFetchError.couldNotReachServer) {
             try await withDependencies {
                 $0.httpClient = .failing(with: StubError.transport)
             } operation: {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayIntegrationTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayIntegrationTests.swift
@@ -76,7 +76,7 @@ import Testing
         let recorder = LogRecorder()
 
         try? await withDependencies {
-            $0.httpClient = .failing(with: StubFailure.couldNotBuildResponse).loggingFailures()
+            $0.httpClient = .failing(with: StubFailure.couldNotBuildResponse).logging()
             $0.log = recorder.log
         } operation: {
             let sut = AuthGateway.liveValue

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayLoggingTests.swift
@@ -30,7 +30,7 @@ import Testing
         _ = try await withDependencies {
             $0.log = recorder.log
         } operation: {
-            let sut = AuthGateway { _ in try SessionToken("jwt-abc-123") }.loggingRequestFailures()
+            let sut = AuthGateway { _ in try SessionToken("jwt-abc-123") }.logging()
             return try await sut.authenticate(Credential.fixture)
         }
 
@@ -44,7 +44,7 @@ private func logEvent(forFailure error: LoginRequestError) async -> LogEvent? {
     try? await withDependencies {
         $0.log = recorder.log
     } operation: {
-        let sut = AuthGateway { _ in throw error }.loggingRequestFailures()
+        let sut = AuthGateway { _ in throw error }.logging()
         _ = try await sut.authenticate(Credential.fixture)
     }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
@@ -1,0 +1,78 @@
+import AuthenticationFeature
+import Dependencies
+import LogKit
+import Testing
+
+/// The cause reaches the log at the mapper or the transport. These assert the outcome the user got.
+@Suite struct FetchProfileLoggingTests {
+    @Test func whenSessionIsNotAccepted_shouldLogAtNoticeRatherThanError() async throws {
+        let event = try #require(await logEvent(whenRepositoryThrows: .unauthorized))
+
+        #expect(event.level == .notice)
+    }
+
+    @Test func whenResponseIsRejected_shouldLogAtErrorLevel() async throws {
+        let event = try #require(await logEvent(whenRepositoryThrows: .invalidResponse))
+
+        #expect(event.level == .error)
+    }
+
+    @Test func whenReasonIsUnknown_shouldLogAtErrorLevel() async throws {
+        let event = try #require(await logEvent(whenRepositoryThrows: .unknown))
+
+        #expect(event.level == .error)
+    }
+
+    /// A destination groups by message, so two outcomes sharing one message could never be told
+    /// apart when filtering.
+    @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
+        let unaccepted = try #require(await logEvent(whenRepositoryThrows: .unauthorized))
+        let rejected = try #require(await logEvent(whenRepositoryThrows: .invalidResponse))
+        let unknown = try #require(await logEvent(whenRepositoryThrows: .unknown))
+
+        #expect(unaccepted.message != rejected.message)
+        #expect(rejected.message != unknown.message)
+        #expect(unknown.message != unaccepted.message)
+    }
+
+    @Test func whenFetchFails_shouldRethrowFailure() async {
+        await withDependencies {
+            $0.log = LogRecorder().log
+            $0.attendeeRepository = .failing(with: .unauthorized)
+        } operation: {
+            let sut = FetchProfile.liveValue.loggingFailures()
+
+            await #expect(throws: AttendeeFetchError.unauthorized) {
+                try await sut()
+            }
+        }
+    }
+
+    @Test func whenFetchSucceeds_shouldLogNothing() async throws {
+        let recorder = LogRecorder()
+
+        _ = try await withDependencies {
+            $0.log = recorder.log
+            $0.attendeeRepository = .returning(try Attendee.fixture)
+        } operation: {
+            let sut = FetchProfile.liveValue.loggingFailures()
+            return try await sut()
+        }
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    private func logEvent(whenRepositoryThrows error: AttendeeFetchError) async -> LogEvent? {
+        let recorder = LogRecorder()
+
+        await withDependencies {
+            $0.log = recorder.log
+            $0.attendeeRepository = .failing(with: error)
+        } operation: {
+            let sut = FetchProfile.liveValue.loggingFailures()
+            _ = try? await sut()
+        }
+
+        return recorder.events.first
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
@@ -35,6 +35,7 @@ import Testing
     /// apart when filtering.
     @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
         let messages = try await [
+            #require(try await successEvent()),
             #require(await logEvent(whenRepositoryThrows: .unauthorized)),
             #require(await logEvent(whenRepositoryThrows: .couldNotReachServer)),
             #require(await logEvent(whenRepositoryThrows: .invalidResponse)),
@@ -74,7 +75,21 @@ import Testing
         }
     }
 
-    @Test func whenFetchSucceeds_shouldLogNothing() async throws {
+    /// A profile loads each time the card appears, so the success sits below the levels the
+    /// platform writes to disk.
+    @Test func whenFetchSucceeds_shouldLogAtInfoLevel() async throws {
+        let event = try #require(try await successEvent())
+
+        #expect(event.level == .info)
+    }
+
+    @Test func whenFetchSucceeds_shouldLogNoAttendeeDetail() async throws {
+        let event = try #require(try await successEvent())
+
+        #expect(event.fields.isEmpty)
+    }
+
+    private func successEvent() async throws -> LogEvent? {
         let recorder = LogRecorder()
 
         _ = try await withDependencies {
@@ -85,7 +100,7 @@ import Testing
             return try await sut()
         }
 
-        #expect(recorder.events.isEmpty)
+        return recorder.events.first
     }
 
     private func logEvent(whenRepositoryThrows error: AttendeeFetchError) async -> LogEvent? {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
@@ -11,6 +11,14 @@ import Testing
         #expect(event.level == .notice)
     }
 
+    /// An offline device is expected and the user can retry, so it matches the sign-in side rather
+    /// than reporting a fault in the app.
+    @Test func whenServerCannotBeReached_shouldLogAtNoticeRatherThanError() async throws {
+        let event = try #require(await logEvent(whenRepositoryThrows: .couldNotReachServer))
+
+        #expect(event.level == .notice)
+    }
+
     @Test func whenResponseIsRejected_shouldLogAtErrorLevel() async throws {
         let event = try #require(await logEvent(whenRepositoryThrows: .invalidResponse))
 
@@ -26,13 +34,14 @@ import Testing
     /// A destination groups by message, so two outcomes sharing one message could never be told
     /// apart when filtering.
     @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
-        let unaccepted = try #require(await logEvent(whenRepositoryThrows: .unauthorized))
-        let rejected = try #require(await logEvent(whenRepositoryThrows: .invalidResponse))
-        let unknown = try #require(await logEvent(whenRepositoryThrows: .unknown))
+        let messages = try await [
+            #require(await logEvent(whenRepositoryThrows: .unauthorized)),
+            #require(await logEvent(whenRepositoryThrows: .couldNotReachServer)),
+            #require(await logEvent(whenRepositoryThrows: .invalidResponse)),
+            #require(await logEvent(whenRepositoryThrows: .unknown)),
+        ].map(\.message)
 
-        #expect(unaccepted.message != rejected.message)
-        #expect(rejected.message != unknown.message)
-        #expect(unknown.message != unaccepted.message)
+        #expect(Set(messages).count == messages.count)
     }
 
     /// The mapper names the cause, the use case names the outcome. Two seams, two lines, and no

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
@@ -35,6 +35,23 @@ import Testing
         #expect(unknown.message != unaccepted.message)
     }
 
+    /// The mapper names the cause, the use case names the outcome. Two seams, two lines, and no
+    /// third line from anywhere else.
+    @Test func whenResponseIsRejected_shouldLogCauseAndOutcome() async throws {
+        let recorder = LogRecorder()
+
+        try await withDependencies {
+            $0.log = recorder.log
+            $0.httpClient = .responding(with: try attendeeJSON(reference: "!!!"), statusCode: 200)
+            $0.attendeeRepository = .liveValue
+        } operation: {
+            let sut = FetchProfile.liveValue.loggingFailedOutcomes()
+            _ = try? await sut()
+        }
+
+        #expect(recorder.events.count == 2)
+    }
+
     @Test func whenFetchFails_shouldRethrowFailure() async {
         await withDependencies {
             $0.log = LogRecorder().log

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
@@ -40,7 +40,7 @@ import Testing
             $0.log = LogRecorder().log
             $0.attendeeRepository = .failing(with: .unauthorized)
         } operation: {
-            let sut = FetchProfile.liveValue.loggingFailures()
+            let sut = FetchProfile.liveValue.loggingFailedOutcomes()
 
             await #expect(throws: AttendeeFetchError.unauthorized) {
                 try await sut()
@@ -55,7 +55,7 @@ import Testing
             $0.log = recorder.log
             $0.attendeeRepository = .returning(try Attendee.fixture)
         } operation: {
-            let sut = FetchProfile.liveValue.loggingFailures()
+            let sut = FetchProfile.liveValue.loggingFailedOutcomes()
             return try await sut()
         }
 
@@ -69,7 +69,7 @@ import Testing
             $0.log = recorder.log
             $0.attendeeRepository = .failing(with: error)
         } operation: {
-            let sut = FetchProfile.liveValue.loggingFailures()
+            let sut = FetchProfile.liveValue.loggingFailedOutcomes()
             _ = try? await sut()
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
@@ -54,7 +54,7 @@ import Testing
             $0.httpClient = .responding(with: try attendeeJSON(reference: "!!!"), statusCode: 200)
             $0.attendeeRepository = .liveValue
         } operation: {
-            let sut = FetchProfile.liveValue.loggingFailedOutcomes()
+            let sut = FetchProfile.liveValue.logging()
             _ = try? await sut()
         }
 
@@ -66,7 +66,7 @@ import Testing
             $0.log = LogRecorder().log
             $0.attendeeRepository = .failing(with: .unauthorized)
         } operation: {
-            let sut = FetchProfile.liveValue.loggingFailedOutcomes()
+            let sut = FetchProfile.liveValue.logging()
 
             await #expect(throws: AttendeeFetchError.unauthorized) {
                 try await sut()
@@ -81,7 +81,7 @@ import Testing
             $0.log = recorder.log
             $0.attendeeRepository = .returning(try Attendee.fixture)
         } operation: {
-            let sut = FetchProfile.liveValue.loggingFailedOutcomes()
+            let sut = FetchProfile.liveValue.logging()
             return try await sut()
         }
 
@@ -95,7 +95,7 @@ import Testing
             $0.log = recorder.log
             $0.attendeeRepository = .failing(with: error)
         } operation: {
-            let sut = FetchProfile.liveValue.loggingFailedOutcomes()
+            let sut = FetchProfile.liveValue.logging()
             _ = try? await sut()
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @Suite struct FetchProfileTests {
     @Test func whenRepositoryReturnsAttendee_shouldReturnMappedProfile() async throws {
-        let attendee = try makeAttendee()
+        let attendee = try Attendee.fixture
 
         let profile = try await withDependencies {
             $0.attendeeRepository = .returning(attendee)
@@ -44,16 +44,6 @@ import Testing
 
         #expect(caught == .unauthorized)
     }
-}
-
-private func makeAttendee() throws -> Attendee {
-    Attendee(
-        name: PersonNameComponents(givenName: "Ada", familyName: "Lovelace"),
-        emailAddress: try EmailAddress("ada@example.com"),
-        avatarURL: AvatarURL(try #require(URL(string: "https://example.com/avatar.png"))),
-        ticketReference: try TicketReference("ABCD-12"),
-        ticketSlug: try TicketSlug("ti_abc")
-    )
 }
 
 private func expectedProfile() throws -> Profile {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientLoggingTests.swift
@@ -48,7 +48,7 @@ import Testing
         _ = try await withDependencies {
             $0.log = recorder.log
         } operation: {
-            let sut = HTTPClient.responding(with: Data(), statusCode: 500).loggingFailures()
+            let sut = HTTPClient.responding(with: Data(), statusCode: 500).logging()
             return try await sut.send(URLRequest(url: url))
         }
 
@@ -61,7 +61,7 @@ import Testing
         try? await withDependencies {
             $0.log = recorder.log
         } operation: {
-            let sut = HTTPClient.failing(with: StubFailure.couldNotBuildResponse).loggingFailures()
+            let sut = HTTPClient.failing(with: StubFailure.couldNotBuildResponse).logging()
             _ = try await sut.send(request)
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/LoginMapperLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/LoginMapperLoggingTests.swift
@@ -54,7 +54,7 @@ import Testing
         withDependencies {
             $0.log = LogRecorder().log
         } operation: {
-            let sut = LoginMapper.live.loggingFailures()
+            let sut = LoginMapper.live.logging()
 
             #expect(throws: LoginMapper.ResponseError.self) {
                 try sut.map(Data(), response)
@@ -69,7 +69,7 @@ import Testing
         try withDependencies {
             $0.log = recorder.log
         } operation: {
-            let sut = LoginMapper.live.loggingFailures()
+            let sut = LoginMapper.live.logging()
             _ = try sut.map(Data("jwt-abc-123".utf8), response)
         }
 
@@ -83,7 +83,7 @@ import Testing
         withDependencies {
             $0.log = recorder.log
         } operation: {
-            let sut = LoginMapper.live.loggingFailures()
+            let sut = LoginMapper.live.logging()
             _ = try? sut.map(data, response)
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SecureStorage+Stub.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SecureStorage+Stub.swift
@@ -1,0 +1,12 @@
+import Foundation
+import SecureStorageKit
+
+extension SecureStorage {
+    static func failing(with error: some Error & Sendable) -> SecureStorage {
+        SecureStorage(
+            data: { _ in throw error },
+            set: { _, _ in throw error },
+            remove: { _ in throw error }
+        )
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SecureStorage+Stub.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SecureStorage+Stub.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SecureStorageKit
 
 extension SecureStorage {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStore+Stub.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStore+Stub.swift
@@ -1,0 +1,11 @@
+import AuthenticationFeature
+
+extension SessionStore {
+    static func failing(with error: some Error & Sendable) -> SessionStore {
+        SessionStore(
+            establish: { _ in throw error },
+            clear: { throw error },
+            current: { throw error }
+        )
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreLoggingTests.swift
@@ -1,0 +1,95 @@
+import AuthenticationFeature
+import Dependencies
+import Foundation
+import LogKit
+import SecureStorageKit
+import Testing
+
+/// Every caller of the store discards its error with `try?`, so the log is the only place a refusal
+/// is recorded.
+@Suite struct SessionStoreLoggingTests {
+    @Test func whenSessionCannotBeStored_shouldLogReasonAtErrorLevel() async throws {
+        let session = Session(token: try SessionToken("jwt-abc-123"))
+
+        let event = try #require(await logEvent { try await $0.establish(session) })
+
+        #expect(event.level == .error)
+        let reason = try #require(event.fields.first { String($0.name) == "reason" })
+        #expect(reason.value == .string("couldNotBuildResponse"))
+    }
+
+    @Test func whenSessionCannotBeCleared_shouldLogReasonAtErrorLevel() async throws {
+        let event = try #require(await logEvent { try await $0.clear() })
+
+        #expect(event.level == .error)
+        let reason = try #require(event.fields.first { String($0.name) == "reason" })
+        #expect(reason.value == .string("couldNotBuildResponse"))
+    }
+
+    @Test func whenStoredSessionCannotBeRead_shouldLogReasonAtErrorLevel() async throws {
+        let event = try #require(await logEvent { _ = try await $0.current() })
+
+        #expect(event.level == .error)
+        let reason = try #require(event.fields.first { String($0.name) == "reason" })
+        #expect(reason.value == .string("couldNotBuildResponse"))
+    }
+
+    /// A destination groups by message, so three operations sharing one message could never be told
+    /// apart when filtering.
+    @Test func whenOperationsFail_shouldLogDifferentMessagePerOperation() async throws {
+        let session = Session(token: try SessionToken("jwt-abc-123"))
+
+        let stored = try #require(await logEvent { try await $0.establish(session) })
+        let cleared = try #require(await logEvent { try await $0.clear() })
+        let read = try #require(await logEvent { _ = try await $0.current() })
+
+        #expect(stored.message != cleared.message)
+        #expect(cleared.message != read.message)
+        #expect(read.message != stored.message)
+    }
+
+    @Test func whenStoreRefuses_shouldRethrowRefusal() async throws {
+        await withDependencies {
+            $0.log = LogRecorder().log
+            $0.secureStorage = .failing(with: StubFailure.couldNotBuildResponse)
+        } operation: {
+            let sut = SessionStore.live.loggingFailures()
+
+            await #expect(throws: StubFailure.couldNotBuildResponse) {
+                try await sut.clear()
+            }
+        }
+    }
+
+    @Test func whenStoreAccepts_shouldLogNothing() async throws {
+        let recorder = LogRecorder()
+        let session = Session(token: try SessionToken("jwt-abc-123"))
+
+        try await withDependencies {
+            $0.log = recorder.log
+            $0.secureStorage = SecureStorageSpy().secureStorage
+        } operation: {
+            let sut = SessionStore.live.loggingFailures()
+            try await sut.establish(session)
+            _ = try await sut.current()
+            try await sut.clear()
+        }
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    private func logEvent(
+        _ operation: @escaping @Sendable (SessionStore) async throws -> Void
+    ) async -> LogEvent? {
+        let recorder = LogRecorder()
+
+        try? await withDependencies {
+            $0.log = recorder.log
+            $0.secureStorage = .failing(with: StubFailure.couldNotBuildResponse)
+        } operation: {
+            try await operation(SessionStore.live.loggingFailures())
+        }
+
+        return recorder.events.first
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreLoggingTests.swift
@@ -1,6 +1,5 @@
 import AuthenticationFeature
 import Dependencies
-import Foundation
 import LogKit
 import SecureStorageKit
 import Testing
@@ -59,6 +58,21 @@ import Testing
                 try await sut.clear()
             }
         }
+    }
+
+    /// Every other test here builds the decorator itself, so this is the only one that notices if
+    /// `liveValue` stops composing it.
+    @Test func whenLiveValueStoreRefuses_shouldLogRefusal() async {
+        let recorder = LogRecorder()
+
+        await withDependencies {
+            $0.log = recorder.log
+            $0.secureStorage = .failing(with: StubFailure.couldNotBuildResponse)
+        } operation: {
+            _ = try? await SessionStore.liveValue.clear()
+        }
+
+        #expect(recorder.events.count == 1)
     }
 
     @Test func whenStoreAccepts_shouldLogNothing() async throws {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreLoggingTests.swift
@@ -52,7 +52,7 @@ import Testing
             $0.log = LogRecorder().log
             $0.secureStorage = .failing(with: StubFailure.couldNotBuildResponse)
         } operation: {
-            let sut = SessionStore.live.loggingFailures()
+            let sut = SessionStore.live.logging()
 
             await #expect(throws: StubFailure.couldNotBuildResponse) {
                 try await sut.clear()
@@ -83,7 +83,7 @@ import Testing
             $0.log = recorder.log
             $0.secureStorage = SecureStorageSpy().secureStorage
         } operation: {
-            let sut = SessionStore.live.loggingFailures()
+            let sut = SessionStore.live.logging()
             try await sut.establish(session)
             _ = try await sut.current()
             try await sut.clear()
@@ -101,7 +101,7 @@ import Testing
             $0.log = recorder.log
             $0.secureStorage = .failing(with: StubFailure.couldNotBuildResponse)
         } operation: {
-            try await operation(SessionStore.live.loggingFailures())
+            try await operation(SessionStore.live.logging())
         }
 
         return recorder.events.first

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionStoreLoggingTests.swift
@@ -33,20 +33,6 @@ import Testing
         #expect(reason.value == .string("couldNotBuildResponse"))
     }
 
-    /// A destination groups by message, so three operations sharing one message could never be told
-    /// apart when filtering.
-    @Test func whenOperationsFail_shouldLogDifferentMessagePerOperation() async throws {
-        let session = Session(token: try SessionToken("jwt-abc-123"))
-
-        let stored = try #require(await logEvent { try await $0.establish(session) })
-        let cleared = try #require(await logEvent { try await $0.clear() })
-        let read = try #require(await logEvent { _ = try await $0.current() })
-
-        #expect(stored.message != cleared.message)
-        #expect(cleared.message != read.message)
-        #expect(read.message != stored.message)
-    }
-
     @Test func whenStoreRefuses_shouldRethrowRefusal() async throws {
         await withDependencies {
             $0.log = LogRecorder().log
@@ -75,21 +61,89 @@ import Testing
         #expect(recorder.events.count == 1)
     }
 
-    @Test func whenStoreAccepts_shouldLogNothing() async throws {
-        let recorder = LogRecorder()
+    @Test func whenStoreAccepts_shouldLogOneLinePerOperation() async throws {
         let session = Session(token: try SessionToken("jwt-abc-123"))
+
+        let events = try await acceptedEvents {
+            try await $0.establish(session)
+            _ = try await $0.current()
+            try await $0.clear()
+        }
+
+        #expect(events.count == 3)
+    }
+
+    @Test func whenSessionIsStored_shouldLogAtInfoLevel() async throws {
+        let session = Session(token: try SessionToken("jwt-abc-123"))
+
+        let event = try #require(try await acceptedEvents { try await $0.establish(session) }.first)
+
+        #expect(event.level == .info)
+    }
+
+    @Test func whenSessionIsCleared_shouldLogAtInfoLevel() async throws {
+        let event = try #require(try await acceptedEvents { try await $0.clear() }.first)
+
+        #expect(event.level == .info)
+    }
+
+    /// A read happens on every authenticated request, so it is recorded at the level the platform
+    /// drops unless someone is watching.
+    @Test func whenStoredSessionIsRead_shouldLogAtDebugLevel() async throws {
+        let event = try #require(try await acceptedEvents { _ = try await $0.current() }.first)
+
+        #expect(event.level == .debug)
+    }
+
+    /// "Why was the user signed out?" is answered by a read that found nothing, so it must be
+    /// filterable on its own rather than sharing the ordinary read's message.
+    @Test func whenReadFindsNothing_shouldLogDifferentMessageThanWhenItFindsSession() async throws {
+        let session = Session(token: try SessionToken("jwt-abc-123"))
+
+        let foundNothing = try #require(try await acceptedEvents { _ = try await $0.current() }.first)
+        let foundSession = try #require(
+            try await acceptedEvents {
+                try await $0.establish(session)
+                _ = try await $0.current()
+            }.last
+        )
+
+        #expect(foundNothing.message != foundSession.message)
+        #expect(foundSession.level == .debug)
+    }
+
+    /// Six outcomes, six messages. A destination groups by message, so any pair sharing one could
+    /// never be told apart when filtering.
+    @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
+        let session = Session(token: try SessionToken("jwt-abc-123"))
+
+        let refused = try await [
+            #require(await logEvent { try await $0.establish(session) }),
+            #require(await logEvent { try await $0.clear() }),
+            #require(await logEvent { _ = try await $0.current() }),
+        ].map(\.message)
+        let accepted = try await [
+            #require(try await acceptedEvents { try await $0.establish(session) }.first),
+            #require(try await acceptedEvents { try await $0.clear() }.first),
+            #require(try await acceptedEvents { _ = try await $0.current() }.first),
+        ].map(\.message)
+
+        #expect(Set(refused + accepted).count == 6)
+    }
+
+    private func acceptedEvents(
+        _ operation: @escaping @Sendable (SessionStore) async throws -> Void
+    ) async throws -> [LogEvent] {
+        let recorder = LogRecorder()
 
         try await withDependencies {
             $0.log = recorder.log
             $0.secureStorage = SecureStorageSpy().secureStorage
         } operation: {
-            let sut = SessionStore.live.logging()
-            try await sut.establish(session)
-            _ = try await sut.current()
-            try await sut.clear()
+            try await operation(SessionStore.live.logging())
         }
 
-        #expect(recorder.events.isEmpty)
+        return recorder.events
     }
 
     private func logEvent(

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
@@ -33,7 +33,7 @@ import Testing
             $0.authGateway = .returning(try SessionToken("jwt-abc-123"))
             $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
         } operation: {
-            let sut = SignIn.liveValue.loggingFailures()
+            let sut = SignIn.liveValue.loggingFailedOutcomes()
             _ = try? await sut(Credential.fixture)
         }
 
@@ -59,7 +59,7 @@ import Testing
             $0.authGateway = .failing(with: SignInError.invalidCredentials)
             $0.sessionStore = InMemorySessionStore().sessionStore
         } operation: {
-            let sut = SignIn.liveValue.loggingFailures()
+            let sut = SignIn.liveValue.loggingFailedOutcomes()
 
             await #expect(throws: SignInError.invalidCredentials) {
                 try await sut(Credential.fixture)
@@ -75,7 +75,7 @@ import Testing
             $0.authGateway = .returning(try SessionToken("jwt-abc-123"))
             $0.sessionStore = InMemorySessionStore().sessionStore
         } operation: {
-            let sut = SignIn.liveValue.loggingFailures()
+            let sut = SignIn.liveValue.loggingFailedOutcomes()
             try await sut(Credential.fixture)
         }
 
@@ -90,7 +90,7 @@ import Testing
             $0.authGateway = .failing(with: error)
             $0.sessionStore = InMemorySessionStore().sessionStore
         } operation: {
-            let sut = SignIn.liveValue.loggingFailures()
+            let sut = SignIn.liveValue.loggingFailedOutcomes()
             _ = try? await sut(Credential.fixture)
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
@@ -1,0 +1,99 @@
+import AuthenticationFeature
+import Dependencies
+import LogKit
+import Testing
+
+/// The cause reaches the log at the seam that knew it. These assert the outcome the user got.
+@Suite struct SignInLoggingTests {
+    @Test func whenCredentialsAreRejected_shouldLogAtNoticeRatherThanError() async throws {
+        let event = try #require(await logEvent(whenGatewayThrows: .invalidCredentials))
+
+        #expect(event.level == .notice)
+    }
+
+    @Test func whenServerCannotBeReached_shouldLogAtNoticeRatherThanError() async throws {
+        let event = try #require(await logEvent(whenGatewayThrows: .couldNotReachServer))
+
+        #expect(event.level == .notice)
+    }
+
+    @Test func whenReasonIsUnknown_shouldLogAtErrorLevel() async throws {
+        let event = try #require(await logEvent(whenGatewayThrows: .unknown))
+
+        #expect(event.level == .error)
+    }
+
+    /// The gateway narrows every failure it can produce to `SignInError`, so a failure of any other
+    /// type means the server accepted the credentials and the session did not survive.
+    @Test func whenSessionCannotBeStored_shouldLogAtErrorLevel() async throws {
+        let recorder = LogRecorder()
+
+        try await withDependencies {
+            $0.log = recorder.log
+            $0.authGateway = .returning(try SessionToken("jwt-abc-123"))
+            $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
+        } operation: {
+            let sut = SignIn.liveValue.loggingFailures()
+            _ = try? await sut(Credential.fixture)
+        }
+
+        let event = try #require(recorder.events.first)
+        #expect(event.level == .error)
+    }
+
+    /// A destination groups by message, so two outcomes sharing one message could never be told
+    /// apart when filtering.
+    @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
+        let rejected = try #require(await logEvent(whenGatewayThrows: .invalidCredentials))
+        let unreachable = try #require(await logEvent(whenGatewayThrows: .couldNotReachServer))
+        let unknown = try #require(await logEvent(whenGatewayThrows: .unknown))
+
+        #expect(rejected.message != unreachable.message)
+        #expect(unreachable.message != unknown.message)
+        #expect(unknown.message != rejected.message)
+    }
+
+    @Test func whenSignInFails_shouldRethrowFailure() async throws {
+        try await withDependencies {
+            $0.log = LogRecorder().log
+            $0.authGateway = .failing(with: SignInError.invalidCredentials)
+            $0.sessionStore = InMemorySessionStore().sessionStore
+        } operation: {
+            let sut = SignIn.liveValue.loggingFailures()
+
+            await #expect(throws: SignInError.invalidCredentials) {
+                try await sut(Credential.fixture)
+            }
+        }
+    }
+
+    @Test func whenSignInSucceeds_shouldLogNothing() async throws {
+        let recorder = LogRecorder()
+
+        try await withDependencies {
+            $0.log = recorder.log
+            $0.authGateway = .returning(try SessionToken("jwt-abc-123"))
+            $0.sessionStore = InMemorySessionStore().sessionStore
+        } operation: {
+            let sut = SignIn.liveValue.loggingFailures()
+            try await sut(Credential.fixture)
+        }
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    private func logEvent(whenGatewayThrows error: SignInError) async throws -> LogEvent? {
+        let recorder = LogRecorder()
+
+        try await withDependencies {
+            $0.log = recorder.log
+            $0.authGateway = .failing(with: error)
+            $0.sessionStore = InMemorySessionStore().sessionStore
+        } operation: {
+            let sut = SignIn.liveValue.loggingFailures()
+            _ = try? await sut(Credential.fixture)
+        }
+
+        return recorder.events.first
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
@@ -23,34 +23,25 @@ import Testing
         #expect(event.level == .error)
     }
 
-    /// The gateway narrows every failure it can produce to `SignInError`, so a failure of any other
-    /// type means the server accepted the credentials and the session did not survive.
+    /// Drives the real composition, because the fallback exists for failures the gateway cannot
+    /// produce and only the live chain proves one reaches it.
     @Test func whenSessionCannotBeStored_shouldLogAtErrorLevel() async throws {
-        let recorder = LogRecorder()
+        let event = try #require(try await storeFailureEvent())
 
-        try await withDependencies {
-            $0.log = recorder.log
-            $0.authGateway = .returning(try SessionToken("jwt-abc-123"))
-            $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
-        } operation: {
-            let sut = SignIn.liveValue.loggingFailedOutcomes()
-            _ = try? await sut(Credential.fixture)
-        }
-
-        let event = try #require(recorder.events.first)
         #expect(event.level == .error)
     }
 
     /// A destination groups by message, so two outcomes sharing one message could never be told
-    /// apart when filtering.
+    /// apart when filtering. The fallback counts as an outcome and must differ too.
     @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
-        let rejected = try #require(await logEvent(whenGatewayThrows: .invalidCredentials))
-        let unreachable = try #require(await logEvent(whenGatewayThrows: .couldNotReachServer))
-        let unknown = try #require(await logEvent(whenGatewayThrows: .unknown))
+        let messages = try await [
+            #require(await logEvent(whenGatewayThrows: .invalidCredentials)),
+            #require(await logEvent(whenGatewayThrows: .couldNotReachServer)),
+            #require(await logEvent(whenGatewayThrows: .unknown)),
+            #require(try await storeFailureEvent()),
+        ].map(\.message)
 
-        #expect(rejected.message != unreachable.message)
-        #expect(unreachable.message != unknown.message)
-        #expect(unknown.message != rejected.message)
+        #expect(Set(messages).count == messages.count)
     }
 
     @Test func whenSignInFails_shouldRethrowFailure() async throws {
@@ -80,6 +71,21 @@ import Testing
         }
 
         #expect(recorder.events.isEmpty)
+    }
+
+    private func storeFailureEvent() async throws -> LogEvent? {
+        let recorder = LogRecorder()
+
+        try await withDependencies {
+            $0.log = recorder.log
+            $0.authGateway = .returning(try SessionToken("jwt-abc-123"))
+            $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
+        } operation: {
+            let sut = SignIn.liveValue.loggingFailedOutcomes()
+            _ = try? await sut(Credential.fixture)
+        }
+
+        return recorder.events.first
     }
 
     private func logEvent(whenGatewayThrows error: SignInError) async throws -> LogEvent? {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
@@ -35,6 +35,7 @@ import Testing
     /// apart when filtering. The fallback counts as an outcome and must differ too.
     @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
         let messages = try await [
+            #require(try await successEvent()),
             #require(await logEvent(whenGatewayThrows: .invalidCredentials)),
             #require(await logEvent(whenGatewayThrows: .couldNotReachServer)),
             #require(await logEvent(whenGatewayThrows: .unknown)),
@@ -58,7 +59,21 @@ import Testing
         }
     }
 
-    @Test func whenSignInSucceeds_shouldLogNothing() async throws {
+    /// Signing in is rare and it starts a session, so the success is worth a line the platform
+    /// keeps. It is what anchors a later question about when the session began.
+    @Test func whenSignInSucceeds_shouldLogAtNoticeLevel() async throws {
+        let event = try #require(try await successEvent())
+
+        #expect(event.level == .notice)
+    }
+
+    @Test func whenSignInSucceeds_shouldLogNoCredential() async throws {
+        let event = try #require(try await successEvent())
+
+        #expect(event.fields.isEmpty)
+    }
+
+    private func successEvent() async throws -> LogEvent? {
         let recorder = LogRecorder()
 
         try await withDependencies {
@@ -70,7 +85,7 @@ import Testing
             try await sut(Credential.fixture)
         }
 
-        #expect(recorder.events.isEmpty)
+        return recorder.events.first
     }
 
     private func storeFailureEvent() async throws -> LogEvent? {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignInLoggingTests.swift
@@ -50,7 +50,7 @@ import Testing
             $0.authGateway = .failing(with: SignInError.invalidCredentials)
             $0.sessionStore = InMemorySessionStore().sessionStore
         } operation: {
-            let sut = SignIn.liveValue.loggingFailedOutcomes()
+            let sut = SignIn.liveValue.logging()
 
             await #expect(throws: SignInError.invalidCredentials) {
                 try await sut(Credential.fixture)
@@ -66,7 +66,7 @@ import Testing
             $0.authGateway = .returning(try SessionToken("jwt-abc-123"))
             $0.sessionStore = InMemorySessionStore().sessionStore
         } operation: {
-            let sut = SignIn.liveValue.loggingFailedOutcomes()
+            let sut = SignIn.liveValue.logging()
             try await sut(Credential.fixture)
         }
 
@@ -81,7 +81,7 @@ import Testing
             $0.authGateway = .returning(try SessionToken("jwt-abc-123"))
             $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
         } operation: {
-            let sut = SignIn.liveValue.loggingFailedOutcomes()
+            let sut = SignIn.liveValue.logging()
             _ = try? await sut(Credential.fixture)
         }
 
@@ -96,7 +96,7 @@ import Testing
             $0.authGateway = .failing(with: error)
             $0.sessionStore = InMemorySessionStore().sessionStore
         } operation: {
-            let sut = SignIn.liveValue.loggingFailedOutcomes()
+            let sut = SignIn.liveValue.logging()
             _ = try? await sut(Credential.fixture)
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutLoggingTests.swift
@@ -12,7 +12,7 @@ import Testing
             $0.log = recorder.log
             $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
         } operation: {
-            let sut = SignOut.liveValue.loggingFailures()
+            let sut = SignOut.liveValue.loggingFailedOutcomes()
             _ = try? await sut()
         }
 
@@ -25,7 +25,7 @@ import Testing
             $0.log = LogRecorder().log
             $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
         } operation: {
-            let sut = SignOut.liveValue.loggingFailures()
+            let sut = SignOut.liveValue.loggingFailedOutcomes()
 
             await #expect(throws: StubFailure.couldNotBuildResponse) {
                 try await sut()
@@ -41,7 +41,7 @@ import Testing
             $0.log = recorder.log
             $0.sessionStore = store.sessionStore
         } operation: {
-            let sut = SignOut.liveValue.loggingFailures()
+            let sut = SignOut.liveValue.loggingFailedOutcomes()
             try await sut()
         }
 
@@ -58,7 +58,7 @@ import Testing
             $0.secureStorage = .failing(with: StubFailure.couldNotBuildResponse)
             $0.sessionStore = SessionStore.live.loggingFailures()
         } operation: {
-            let sut = SignOut.liveValue.loggingFailures()
+            let sut = SignOut.liveValue.loggingFailedOutcomes()
             _ = try? await sut()
         }
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutLoggingTests.swift
@@ -1,0 +1,67 @@
+import AuthenticationFeature
+import Dependencies
+import Testing
+
+/// Both call sites move the UI to signed out and discard the error with `try?`, so this line is the
+/// only record that the user is not actually signed out.
+@Suite struct SignOutLoggingTests {
+    @Test func whenSignOutFails_shouldLogAtErrorLevel() async throws {
+        let recorder = LogRecorder()
+
+        await withDependencies {
+            $0.log = recorder.log
+            $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
+        } operation: {
+            let sut = SignOut.liveValue.loggingFailures()
+            _ = try? await sut()
+        }
+
+        let event = try #require(recorder.events.first)
+        #expect(event.level == .error)
+    }
+
+    @Test func whenSignOutFails_shouldRethrowFailure() async {
+        await withDependencies {
+            $0.log = LogRecorder().log
+            $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
+        } operation: {
+            let sut = SignOut.liveValue.loggingFailures()
+
+            await #expect(throws: StubFailure.couldNotBuildResponse) {
+                try await sut()
+            }
+        }
+    }
+
+    @Test func whenSignOutSucceeds_shouldLogNothing() async throws {
+        let recorder = LogRecorder()
+        let store = InMemorySessionStore()
+
+        try await withDependencies {
+            $0.log = recorder.log
+            $0.sessionStore = store.sessionStore
+        } operation: {
+            let sut = SignOut.liveValue.loggingFailures()
+            try await sut()
+        }
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    /// The store names the mechanism, the use case names the outcome. Two seams, two lines, and no
+    /// third line from anywhere else.
+    @Test func whenStoreRefuses_shouldLogCauseAndOutcome() async {
+        let recorder = LogRecorder()
+
+        await withDependencies {
+            $0.log = recorder.log
+            $0.secureStorage = .failing(with: StubFailure.couldNotBuildResponse)
+            $0.sessionStore = SessionStore.live.loggingFailures()
+        } operation: {
+            let sut = SignOut.liveValue.loggingFailures()
+            _ = try? await sut()
+        }
+
+        #expect(recorder.events.count == 2)
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutLoggingTests.swift
@@ -1,5 +1,6 @@
 import AuthenticationFeature
 import Dependencies
+import LogKit
 import Testing
 
 /// Both call sites move the UI to signed out and discard the error with `try?`, so this line is the
@@ -33,19 +34,62 @@ import Testing
         }
     }
 
-    @Test func whenSignOutSucceeds_shouldLogNothing() async throws {
-        let recorder = LogRecorder()
-        let store = InMemorySessionStore()
+    /// Signing out is rare and it ends a session, so it is worth a line the platform keeps.
+    @Test func whenSignOutSucceeds_shouldLogAtNoticeLevel() async throws {
+        let event = try #require(await successEvent())
 
-        try await withDependencies {
+        #expect(event.level == .notice)
+    }
+
+    @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
+        let succeeded = try #require(await successEvent())
+        let failed = try #require(await failureEvent())
+
+        #expect(succeeded.message != failed.message)
+    }
+
+    /// The store names what it did, the use case names what the user got, on both paths.
+    @Test func whenStoreAccepts_shouldLogCauseAndOutcome() async {
+        let recorder = LogRecorder()
+
+        await withDependencies {
             $0.log = recorder.log
-            $0.sessionStore = store.sessionStore
+            $0.secureStorage = SecureStorageSpy().secureStorage
+            $0.sessionStore = SessionStore.live.logging()
+        } operation: {
+            let sut = SignOut.liveValue.logging()
+            _ = try? await sut()
+        }
+
+        #expect(recorder.events.count == 2)
+    }
+
+    private func successEvent() async -> LogEvent? {
+        let recorder = LogRecorder()
+
+        try? await withDependencies {
+            $0.log = recorder.log
+            $0.sessionStore = InMemorySessionStore().sessionStore
         } operation: {
             let sut = SignOut.liveValue.logging()
             try await sut()
         }
 
-        #expect(recorder.events.isEmpty)
+        return recorder.events.first
+    }
+
+    private func failureEvent() async -> LogEvent? {
+        let recorder = LogRecorder()
+
+        await withDependencies {
+            $0.log = recorder.log
+            $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
+        } operation: {
+            let sut = SignOut.liveValue.logging()
+            _ = try? await sut()
+        }
+
+        return recorder.events.first
     }
 
     /// The store names the mechanism, the use case names the outcome. Two seams, two lines, and no

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SignOutLoggingTests.swift
@@ -12,7 +12,7 @@ import Testing
             $0.log = recorder.log
             $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
         } operation: {
-            let sut = SignOut.liveValue.loggingFailedOutcomes()
+            let sut = SignOut.liveValue.logging()
             _ = try? await sut()
         }
 
@@ -25,7 +25,7 @@ import Testing
             $0.log = LogRecorder().log
             $0.sessionStore = .failing(with: StubFailure.couldNotBuildResponse)
         } operation: {
-            let sut = SignOut.liveValue.loggingFailedOutcomes()
+            let sut = SignOut.liveValue.logging()
 
             await #expect(throws: StubFailure.couldNotBuildResponse) {
                 try await sut()
@@ -41,7 +41,7 @@ import Testing
             $0.log = recorder.log
             $0.sessionStore = store.sessionStore
         } operation: {
-            let sut = SignOut.liveValue.loggingFailedOutcomes()
+            let sut = SignOut.liveValue.logging()
             try await sut()
         }
 
@@ -56,9 +56,9 @@ import Testing
         await withDependencies {
             $0.log = recorder.log
             $0.secureStorage = .failing(with: StubFailure.couldNotBuildResponse)
-            $0.sessionStore = SessionStore.live.loggingFailures()
+            $0.sessionStore = SessionStore.live.logging()
         } operation: {
-            let sut = SignOut.liveValue.loggingFailedOutcomes()
+            let sut = SignOut.liveValue.logging()
             _ = try? await sut()
         }
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCard+ViewModel.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCard+ViewModel.swift
@@ -26,7 +26,11 @@ extension ProfileCard {
                 switch error {
                 case .unauthorized:
                     onSignOut(.signInRequired)
-                case .invalidResponse, .unknown:
+                case .couldNotReachServer:
+                    state = .failed
+                case .invalidResponse:
+                    state = .failed
+                case .unknown:
                     state = .failed
                 }
             }

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/ProfileCard/ProfileCardViewModelTests.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/ProfileCard/ProfileCardViewModelTests.swift
@@ -51,6 +51,25 @@ import Testing
         #expect(captured == nil)
     }
 
+    /// Losing signal must not cost the user their session.
+    @Test func whenServerCannotBeReached_shouldReportFailureWithoutSigningOut() async {
+        var captured: SignOutReason?
+
+        await withDependencies {
+            $0.fetchProfile = FetchProfile { () async throws(AttendeeFetchError) -> Profile in
+                throw .couldNotReachServer
+            }
+        } operation: {
+            let sut = ProfileCard.ViewModel(onSignOut: { captured = $0 })
+
+            await sut.load()
+
+            #expect(sut.state == .failed)
+        }
+
+        #expect(captured == nil)
+    }
+
     @Test func whenCredentialsAreRejected_shouldRequireSignIn() async {
         var captured: SignOutReason?
 

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -29,9 +29,9 @@ struct SwiftLeedsApp: App {
                 @Dependency(\.signOut) var signOut
                 try? await signOut()
             })
-            $0.signIn = SignIn.liveValue.loggingFailedOutcomes()
-            $0.signOut = SignOut.liveValue.loggingFailedOutcomes()
-            $0.fetchProfile = FetchProfile.liveValue.loggingFailedOutcomes()
+            $0.signIn = SignIn.liveValue.logging()
+            $0.signOut = SignOut.liveValue.logging()
+            $0.fetchProfile = FetchProfile.liveValue.logging()
         }
     }
 

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -29,9 +29,9 @@ struct SwiftLeedsApp: App {
                 @Dependency(\.signOut) var signOut
                 try? await signOut()
             })
-            $0.signIn = SignIn.liveValue.loggingFailures()
-            $0.signOut = SignOut.liveValue.loggingFailures()
-            $0.fetchProfile = FetchProfile.liveValue.loggingFailures()
+            $0.signIn = SignIn.liveValue.loggingFailedOutcomes()
+            $0.signOut = SignOut.liveValue.loggingFailedOutcomes()
+            $0.fetchProfile = FetchProfile.liveValue.loggingFailedOutcomes()
         }
     }
 

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -29,6 +29,9 @@ struct SwiftLeedsApp: App {
                 @Dependency(\.signOut) var signOut
                 try? await signOut()
             })
+            $0.signIn = SignIn.liveValue.loggingFailures()
+            $0.signOut = SignOut.liveValue.loggingFailures()
+            $0.fetchProfile = FetchProfile.liveValue.loggingFailures()
         }
     }
 


### PR DESCRIPTION
## Problem

* Several outcomes reached no log at all: storing, clearing and reading the session, and every success anywhere in the authentication chain.
* Every caller discards a store error with `try?`, so a keychain refusal left no trace.
* The worst case is a failed sign-out. The UI moves to signed out, the token stays on the device, and nobody hears about it. Two call sites do this: the session-expiry handler and the sign-out button.
* Nothing recorded that a session began, so a later "why was I signed out?" had no anchor to work back from.
* `AttendeeRepository` folded every transport failure into `unknown`, so an offline device looked the same as a server the app cannot parse.

## Solution

Every seam records what it did, in one uniform shape.

* **One name.** All eight logging decorators are now `logging()`. The method name states the concern; the projection type states what gets recorded.
* **Both outcomes.** Each projection names its success and its failures through symmetric factories, so a type called `LoggedSignInOutcome` covers the whole outcome rather than half of it.
* **Two seams still say different things.** The store names what it did; the use case names what that meant for the user. A failure produces exactly two lines, and so does a success.
* `AttendeeFetchError` gains `couldNotReachServer`, mirroring `SignInError` from #126. The card still shows the same failed state.

The level carries the volume decision, because the platform already filters on it. Under Apple's defaults debug is dropped unless someone is streaming, and info stays in a memory buffer rather than on disk.

| Event | How often | Level |
|---|---|---|
| Signing in or out finished | rare | notice |
| Session stored or cleared | rare | info |
| Session read | every authenticated request | debug |
| Profile loaded | per screen | info |
| Anything refused | rare | error, or notice when expected |

A read that finds nothing gets its own message rather than a flag, because that is the line explaining why a user is signed out:

```swift
static func read(foundSession: Bool) -> LoggedSessionStoreOutcome {
    LoggedSessionStoreOutcome(
        level: .debug,
        message: foundSession ? "The stored session was read" : "No session is stored"
    )
}
```

Success lines carry no fields. Two tests pin that, because a credential and a profile both identify a person:

```swift
@Test func whenSignInSucceeds_shouldLogNoCredential() async throws {
    let event = try #require(try await successEvent())

    #expect(event.fields.isEmpty)
}
```

## How to test

```bash
git fetch && git checkout feat/log-use-case-failures
swift test --package-path Packages/AuthenticationFeature
swift test --package-path Packages/AuthenticationUI
```

Three guards are worth probing by hand, because each catches a wiring mistake rather than a behaviour one:

* Delete `.logging()` from `SessionStore.liveValue`. Exactly one test fails.
* Point any projection's `success` factory at its `failure` one. Six tests fail, a level test and a message test for each seam.
* Delete the `log(...)` call in `FetchProfile+Logging`. The two-line count test drops to one.

## Notes

* **Four tests that asserted silence on success now assert the success line.** That is the point of the change, not an accident.
* **The sign-in fallback claims no step.** `narrowingFailures()` has no catch-all, so an error of a third type could reach it without the session store ever running. `unexplainedFailure` says only that no sign-in outcome explains the failure.
* **A locked device is noisy.** `KeychainError.deviceLocked` is transient, but a refusal still logs at error, and one background fetch on a locked device can write several lines. Fixing it needs a transient marker on the `SecureStorage` interface, which is a separate unit of work.
* **Nothing guards the app-root composition.** Deleting the three `logging()` calls in `SwiftLeedsApp` leaves every test green. Composing inside each `liveValue` instead would make the decorators non-public and guardable, at the cost of the app no longer owning the choice.
* **`swift test -c release` does not compile `AuthenticationUI`.** DEBUG-only fixtures are referenced by the release test target. Pre-existing, verified on `main`, and hidden because all three CI jobs build debug.
* `HTTPClient`, `LoginMapper`, `AttendeeMapper` and `AuthGateway` were renamed but still record failures only. Adding their successes would put a debug line on every request and every parsed response.
* An offline user still sees a generic failure on the profile card, while the sign-in screen names the connection.
