### PR TITLE
refactor(AuthenticationFeature): stop hiding value objects from the debugger

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/EmailAddress.swift
@@ -26,9 +26,3 @@ extension String {
         self = email.stringValue
     }
 }
-
-// Redacted so the address can't leak via logs, interpolation, or reflection.
-extension EmailAddress: CustomStringConvertible, CustomDebugStringConvertible {
-    public var description: String { "•••" }
-    public var debugDescription: String { description }
-}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SessionToken.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/SessionToken.swift
@@ -23,9 +23,3 @@ extension String {
         self = token.stringValue
     }
 }
-
-// Redacted so the JWT can't leak via logs, interpolation, or reflection.
-extension SessionToken: CustomStringConvertible, CustomDebugStringConvertible {
-    package var description: String { "•••" }
-    package var debugDescription: String { description }
-}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Domain/TicketReference.swift
@@ -31,9 +31,3 @@ extension String {
         self = ticketReference.stringValue
     }
 }
-
-// Redacted so the reference can't leak via logs, interpolation, or reflection.
-extension TicketReference: CustomStringConvertible, CustomDebugStringConvertible {
-    public var description: String { "•••" }
-    public var debugDescription: String { description }
-}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/CredentialTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/CredentialTests.swift
@@ -2,8 +2,8 @@ import AuthenticationFeature
 import Testing
 
 @Suite struct CredentialTests {
-    // The member tests cover each type alone. This covers an aggregate gaining its own redaction.
-    @Test func whenDescribed_shouldShowEmailAndTicket() throws {
+    // Fails if Credential gains a description of its own that hides its members.
+    @Test func whenDescribed_shouldShowEmailAndTicketReference() throws {
         let credential = Credential(
             email: try EmailAddress("person@example.com"),
             ticketReference: try TicketReference("ABCD-1")

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/CredentialTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/CredentialTests.swift
@@ -2,7 +2,8 @@ import AuthenticationFeature
 import Testing
 
 @Suite struct CredentialTests {
-    @Test func whenDescribed_shouldRedactEmailAndTicket() throws {
+    // The member tests cover each type alone. This covers an aggregate gaining its own redaction.
+    @Test func whenDescribed_shouldShowEmailAndTicket() throws {
         let credential = Credential(
             email: try EmailAddress("person@example.com"),
             ticketReference: try TicketReference("ABCD-1")
@@ -10,7 +11,7 @@ import Testing
 
         let described = String(describing: credential)
 
-        #expect(!described.contains("person@example.com"))
-        #expect(!described.contains("ABCD-1"))
+        #expect(described.contains("person@example.com"))
+        #expect(described.contains("ABCD-1"))
     }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EmailAddressTests.swift
@@ -17,8 +17,8 @@ import Testing
         #expect(String(email) == "person@example.com")
     }
 
-    @Test func whenDescribed_shouldRedactValue() throws {
+    @Test func whenDescribed_shouldShowValue() throws {
         let email = try EmailAddress("person@example.com")
-        #expect(!String(describing: email).contains("person@example.com"))
+        #expect(String(describing: email).contains("person@example.com"))
     }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionTokenTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/SessionTokenTests.swift
@@ -2,10 +2,10 @@ import AuthenticationFeature
 import Testing
 
 @Suite struct SessionTokenTests {
-    @Test func whenDescribed_shouldRedactValue() throws {
+    @Test func whenDescribed_shouldShowValue() throws {
         let token = try SessionToken("jwt-abc-123")
 
-        #expect(!String(describing: token).contains("jwt-abc-123"))
+        #expect(String(describing: token).contains("jwt-abc-123"))
     }
 
     @Test func whenCreatedWithSurroundingWhitespace_shouldTrim() throws {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/TicketReferenceTests.swift
@@ -37,8 +37,8 @@ import Testing
         }
     }
 
-    @Test func whenDescribed_shouldRedactValue() throws {
+    @Test func whenDescribed_shouldShowValue() throws {
         let reference = try TicketReference("ABCD-1")
-        #expect(!String(describing: reference).contains("ABCD-1"))
+        #expect(String(describing: reference).contains("ABCD-1"))
     }
 }


### PR DESCRIPTION
## Problem

* `EmailAddress`, `SessionToken` and `TicketReference` each returned the literal `•••` from `description`.
* That broke the `CustomStringConvertible` contract, made `po value` in LLDB show `•••`, and turned a failing comparison into `••• == •••`.
* It was shallow. `String(x)` reads the stored property directly and always returned the real value, so the redaction never covered the path that mattered.

## Solution

All three types lose the whole `CustomStringConvertible, CustomDebugStringConvertible` extension, rather than keeping the conformance and returning storage.

```swift
// Deleted from each of the three files. Nothing replaces it.
extension EmailAddress: CustomStringConvertible, CustomDebugStringConvertible {
    public var description: String { "•••" }
    public var debugDescription: String { description }
}
```