### PR TITLE
feat(AuthenticationUI): log when a ticket QR code cannot be rendered

### DIFF
--- a/Packages/AuthenticationUI/Package.swift
+++ b/Packages/AuthenticationUI/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../AuthenticationFeature"),
+        .package(path: "../LogKit"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
     ],
     targets: [
@@ -21,6 +22,7 @@ let package = Package(
             dependencies: [
                 "AuthenticationFeature",
                 .product(name: "Dependencies", package: "swift-dependencies"),
+                .product(name: "LogKit", package: "LogKit"),
             ]
         ),
         .testTarget(
@@ -28,6 +30,7 @@ let package = Package(
             dependencies: [
                 "AuthenticationUI",
                 .product(name: "Dependencies", package: "swift-dependencies"),
+                .product(name: "LogKit", package: "LogKit"),
             ]
         ),
     ]

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Barcode/Barcode.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Barcode/Barcode.swift
@@ -1,4 +1,3 @@
-import CoreGraphics
 import SwiftUI
 
 /// A machine-readable code, drawn so that a scanner can read it.
@@ -19,10 +18,6 @@ import SwiftUI
 package struct Barcode<Placeholder: View, Failure: View>: View {
     @Environment(\.barcodeStyle) private var style
 
-    // Drawing runs CoreImage and a software rasteriser, and `body` reruns on any invalidation, so
-    // the result is kept rather than redrawn.
-    @State private var drawing: Drawing = .pending
-
     private let source: Source
     private let placeholder: () -> Placeholder
     private let failure: () -> Failure
@@ -31,12 +26,6 @@ package struct Barcode<Placeholder: View, Failure: View>: View {
         case generated(BarcodeContent)
         case supplied(Image)
         case remote(URL?)
-    }
-
-    private enum Drawing {
-        case pending
-        case drawn(CGImage)
-        case unavailable
     }
 
     private init(
@@ -52,7 +41,11 @@ package struct Barcode<Placeholder: View, Failure: View>: View {
     package var body: some View {
         switch source {
         case .generated(let content):
-            generated(content)
+            if let image = content.makeImage() {
+                styled(scannable(Image(decorative: image, scale: 1)))
+            } else {
+                styled(AnyView(failure()))
+            }
         case .supplied(let image):
             styled(scannable(image))
         case .remote(let url):
@@ -68,19 +61,6 @@ package struct Barcode<Placeholder: View, Failure: View>: View {
                     styled(AnyView(placeholder()))
                 }
             }
-        }
-    }
-
-    @ViewBuilder
-    private func generated(_ content: BarcodeContent) -> some View {
-        switch drawing {
-        case .pending:
-            styled(AnyView(placeholder()))
-                .task { drawing = content.makeImage().map(Drawing.drawn) ?? .unavailable }
-        case .drawn(let image):
-            styled(scannable(Image(decorative: image, scale: 1)))
-        case .unavailable:
-            styled(AnyView(failure()))
         }
     }
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Barcode/Barcode.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Barcode/Barcode.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import SwiftUI
 
 /// A machine-readable code, drawn so that a scanner can read it.
@@ -18,6 +19,10 @@ import SwiftUI
 package struct Barcode<Placeholder: View, Failure: View>: View {
     @Environment(\.barcodeStyle) private var style
 
+    // Drawing runs CoreImage and a software rasteriser, and `body` reruns on any invalidation, so
+    // the result is kept rather than redrawn.
+    @State private var drawing: Drawing = .pending
+
     private let source: Source
     private let placeholder: () -> Placeholder
     private let failure: () -> Failure
@@ -26,6 +31,12 @@ package struct Barcode<Placeholder: View, Failure: View>: View {
         case generated(BarcodeContent)
         case supplied(Image)
         case remote(URL?)
+    }
+
+    private enum Drawing {
+        case pending
+        case drawn(CGImage)
+        case unavailable
     }
 
     private init(
@@ -41,11 +52,7 @@ package struct Barcode<Placeholder: View, Failure: View>: View {
     package var body: some View {
         switch source {
         case .generated(let content):
-            if let image = content.makeImage() {
-                styled(scannable(Image(decorative: image, scale: 1)))
-            } else {
-                styled(AnyView(failure()))
-            }
+            generated(content)
         case .supplied(let image):
             styled(scannable(image))
         case .remote(let url):
@@ -61,6 +68,19 @@ package struct Barcode<Placeholder: View, Failure: View>: View {
                     styled(AnyView(placeholder()))
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private func generated(_ content: BarcodeContent) -> some View {
+        switch drawing {
+        case .pending:
+            styled(AnyView(placeholder()))
+                .task { drawing = content.makeImage().map(Drawing.drawn) ?? .unavailable }
+        case .drawn(let image):
+            styled(scannable(Image(decorative: image, scale: 1)))
+        case .unavailable:
+            styled(AnyView(failure()))
         }
     }
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Barcode/BarcodeContent.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Barcode/BarcodeContent.swift
@@ -11,6 +11,13 @@ package struct BarcodeContent {
         draw = { symbology.makeImage(encoding: payload) }
     }
 
+    /// Creates content that draws itself with `draw`.
+    ///
+    /// - Parameter draw: Returns the code image, or `nil` if it cannot be drawn.
+    package init(draw: @escaping @MainActor () -> CGImage?) {
+        self.draw = draw
+    }
+
     /// Draws the code, or returns `nil` if the payload cannot be encoded.
     @MainActor package func makeImage() -> CGImage? {
         draw()

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/LogCategories.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/LogCategories.swift
@@ -1,0 +1,7 @@
+import LogKit
+
+/// This package's log categories. Naming them once means a typo cannot silently create a second
+/// category and split a filter in two.
+extension LogCategory {
+    static let ticket: Self = "ticket"
+}

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/LogCategories.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/LogCategories.swift
@@ -1,7 +1,6 @@
 import LogKit
 
-/// This package's log categories. Naming them once means a typo cannot silently create a second
-/// category and split a filter in two.
+// Named once, so a typo cannot silently create a second category and split a filter in two.
 extension LogCategory {
     static let ticket: Self = "ticket"
 }

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/BarcodeContent+Logging.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/BarcodeContent+Logging.swift
@@ -1,21 +1,20 @@
-import CoreGraphics
 import Dependencies
 import LogKit
 
 extension BarcodeContent {
     /// Records that the code could not be drawn, then returns what it drew.
     ///
-    /// - Parameter payloadLength: How many characters the code carries. A payload too long for the
-    ///   symbology is the likeliest cause, so the length is what a reader can act on.
-    package func loggingFailures(payloadLength: Int) -> BarcodeContent {
+    /// - Parameter payloadBytes: How many bytes the code carries, which is what a symbology's
+    ///   capacity is measured in.
+    package func loggingFailures(payloadBytes: Int) -> BarcodeContent {
         BarcodeContent {
             guard let image = makeImage() else {
-                // Resolved per call, so a test overriding \.log is honoured.
+                // Resolved per call, so a test override is seen.
                 @Dependency(\.log) var log
                 log.error(
                     """
                     The ticket code could not be drawn: \
-                    \(payloadLength, name: "payloadLength", privacy: .open)
+                    \(payloadBytes, name: "payloadBytes", privacy: .open)
                     """,
                     in: .ticket
                 )

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/BarcodeContent+Logging.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/BarcodeContent+Logging.swift
@@ -1,0 +1,27 @@
+import CoreGraphics
+import Dependencies
+import LogKit
+
+extension BarcodeContent {
+    /// Records that the code could not be drawn, then returns what it drew.
+    ///
+    /// - Parameter payloadLength: How many characters the code carries. A payload too long for the
+    ///   symbology is the likeliest cause, so the length is what a reader can act on.
+    package func loggingFailures(payloadLength: Int) -> BarcodeContent {
+        BarcodeContent {
+            guard let image = makeImage() else {
+                // Resolved per call, so a test overriding \.log is honoured.
+                @Dependency(\.log) var log
+                log.error(
+                    """
+                    The ticket code could not be drawn: \
+                    \(payloadLength, name: "payloadLength", privacy: .open)
+                    """,
+                    in: .ticket
+                )
+                return nil
+            }
+            return image
+        }
+    }
+}

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketView.swift
@@ -60,7 +60,7 @@ package struct TicketView: View {
 
     private var code: BarcodeContent {
         let payload = String(slug)
-        return .qr(QRCode.Payload(payload)).loggingFailures(payloadLength: payload.count)
+        return .qr(QRCode.Payload(payload)).loggingFailures(payloadBytes: payload.utf8.count)
     }
 
     private var identity: some View {

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketView.swift
@@ -26,7 +26,7 @@ package struct TicketView: View {
             VStack(spacing: 24) {
                 Spacer(minLength: 0)
 
-                Barcode(.qr(QRCode.Payload(String(slug)))) {
+                Barcode(code) {
                     unreadable
                 }
                 .frame(maxWidth: 320)
@@ -56,6 +56,11 @@ package struct TicketView: View {
                 viewModel.endDisplaying()
             }
         }
+    }
+
+    private var code: BarcodeContent {
+        let payload = String(slug)
+        return .qr(QRCode.Payload(payload)).loggingFailures(payloadLength: payload.count)
     }
 
     private var identity: some View {

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/LogRecorder.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/LogRecorder.swift
@@ -1,0 +1,22 @@
+import Foundation
+import LogKit
+
+/// Captures every event written to its `log`, so a test can assert what was recorded.
+final class LogRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [LogEvent] = []
+
+    var events: [LogEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    var log: Log {
+        Log { [self] event in
+            lock.lock()
+            defer { lock.unlock() }
+            storage.append(event)
+        }
+    }
+}

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/TicketView/BarcodeContentLoggingTests.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/TicketView/BarcodeContentLoggingTests.swift
@@ -1,0 +1,74 @@
+import AuthenticationUI
+import Dependencies
+import LogKit
+import Testing
+
+/// A code that will not draw leaves the attendee holding a ticket that cannot be scanned, and the
+/// view shows a card rather than raising anything. This is the only record of it.
+@MainActor
+@Suite struct BarcodeContentLoggingTests {
+    private let undrawable = BarcodeContent.code128("café-ticket-✓")
+    private let drawable = BarcodeContent.code128("ABCD-1")
+
+    @Test func whenCodeCannotBeDrawn_shouldLogAtErrorLevel() throws {
+        let event = try #require(attempt(undrawable, payloadLength: 15))
+
+        #expect(event.level == .error)
+    }
+
+    @Test func whenCodeCannotBeDrawn_shouldLogPayloadLength() throws {
+        let event = try #require(attempt(undrawable, payloadLength: 15))
+
+        #expect(event.fields.first { String($0.name) == "payloadLength" }?.value == .integer(15))
+    }
+
+    @Test func whenCodeCannotBeDrawn_shouldStillReturnNothingToDraw() {
+        let recorder = LogRecorder()
+
+        withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            #expect(undrawable.loggingFailures(payloadLength: 15).makeImage() == nil)
+        }
+    }
+
+    @Test func whenCodeDraws_shouldLogNothing() {
+        let recorder = LogRecorder()
+
+        withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            _ = drawable.loggingFailures(payloadLength: 6).makeImage()
+        }
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func whenCodeDraws_shouldReturnTheSameImage() {
+        let recorder = LogRecorder()
+
+        withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            let undecorated = drawable.makeImage()
+            let decorated = drawable.loggingFailures(payloadLength: 6).makeImage()
+
+            #expect(decorated?.width == undecorated?.width)
+            #expect(decorated?.height == undecorated?.height)
+        }
+    }
+
+    private func attempt(_ content: BarcodeContent, payloadLength: Int) -> LogEvent? {
+        let recorder = LogRecorder()
+
+        withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            _ = content.loggingFailures(payloadLength: payloadLength).makeImage()
+        }
+
+        // Pinned here rather than per test, so a decorator that records twice fails everything.
+        #expect(recorder.events.count == 1)
+        return recorder.events.first
+    }
+}

--- a/Packages/AuthenticationUI/Tests/AuthenticationUITests/TicketView/BarcodeContentLoggingTests.swift
+++ b/Packages/AuthenticationUI/Tests/AuthenticationUITests/TicketView/BarcodeContentLoggingTests.swift
@@ -1,4 +1,5 @@
 import AuthenticationUI
+import CoreGraphics
 import Dependencies
 import LogKit
 import Testing
@@ -7,68 +8,88 @@ import Testing
 /// view shows a card rather than raising anything. This is the only record of it.
 @MainActor
 @Suite struct BarcodeContentLoggingTests {
-    private let undrawable = BarcodeContent.code128("café-ticket-✓")
-    private let drawable = BarcodeContent.code128("ABCD-1")
-
     @Test func whenCodeCannotBeDrawn_shouldLogAtErrorLevel() throws {
-        let event = try #require(attempt(undrawable, payloadLength: 15))
+        let event = try #require(attempt(.undrawable, payloadBytes: 26))
 
         #expect(event.level == .error)
     }
 
-    @Test func whenCodeCannotBeDrawn_shouldLogPayloadLength() throws {
-        let event = try #require(attempt(undrawable, payloadLength: 15))
+    @Test func whenCodeCannotBeDrawn_shouldLogPayloadBytes() throws {
+        let event = try #require(attempt(.undrawable, payloadBytes: 26))
 
-        #expect(event.fields.first { String($0.name) == "payloadLength" }?.value == .integer(15))
+        #expect(event.fields.first { String($0.name) == "payloadBytes" }?.value == .integer(26))
     }
 
     @Test func whenCodeCannotBeDrawn_shouldStillReturnNothingToDraw() {
-        let recorder = LogRecorder()
-
         withDependencies {
-            $0.log = recorder.log
+            $0.log = LogRecorder().log
         } operation: {
-            #expect(undrawable.loggingFailures(payloadLength: 15).makeImage() == nil)
+            let sut = BarcodeContent.undrawable.loggingFailures(payloadBytes: 26)
+
+            #expect(sut.makeImage() == nil)
         }
     }
 
-    @Test func whenCodeDraws_shouldLogNothing() {
+    @Test func whenCodeDraws_shouldLogNothing() throws {
         let recorder = LogRecorder()
+        let swatch = try #require(CGImage.swatch)
 
         withDependencies {
             $0.log = recorder.log
         } operation: {
-            _ = drawable.loggingFailures(payloadLength: 6).makeImage()
+            let sut = BarcodeContent.drawing(swatch).loggingFailures(payloadBytes: 26)
+            _ = sut.makeImage()
         }
 
         #expect(recorder.events.isEmpty)
     }
 
-    @Test func whenCodeDraws_shouldReturnTheSameImage() {
-        let recorder = LogRecorder()
+    // The decorator observes and passes through, so returning an image of its own making, even a
+    // correct redraw, would break that contract.
+    @Test func whenCodeDraws_shouldReturnThatExactImage() throws {
+        let swatch = try #require(CGImage.swatch)
 
         withDependencies {
-            $0.log = recorder.log
+            $0.log = LogRecorder().log
         } operation: {
-            let undecorated = drawable.makeImage()
-            let decorated = drawable.loggingFailures(payloadLength: 6).makeImage()
+            let sut = BarcodeContent.drawing(swatch).loggingFailures(payloadBytes: 26)
 
-            #expect(decorated?.width == undecorated?.width)
-            #expect(decorated?.height == undecorated?.height)
+            #expect(sut.makeImage() === swatch)
         }
     }
 
-    private func attempt(_ content: BarcodeContent, payloadLength: Int) -> LogEvent? {
+    private func attempt(_ content: BarcodeContent, payloadBytes: Int) -> LogEvent? {
         let recorder = LogRecorder()
 
         withDependencies {
             $0.log = recorder.log
         } operation: {
-            _ = content.loggingFailures(payloadLength: payloadLength).makeImage()
+            let sut = content.loggingFailures(payloadBytes: payloadBytes)
+            _ = sut.makeImage()
         }
 
         // Pinned here rather than per test, so a decorator that records twice fails everything.
         #expect(recorder.events.count == 1)
         return recorder.events.first
     }
+}
+
+private extension BarcodeContent {
+    /// Content that cannot draw, without depending on any symbology's rejection rules.
+    static var undrawable: BarcodeContent { BarcodeContent { nil } }
+
+    static func drawing(_ image: CGImage) -> BarcodeContent { BarcodeContent { image } }
+}
+
+private extension CGImage {
+    /// One opaque pixel. The tests care which image comes back, never what it shows.
+    static let swatch: CGImage? = CGContext(
+        data: nil,
+        width: 1,
+        height: 1,
+        bitsPerComponent: 8,
+        bytesPerRow: 1,
+        space: CGColorSpaceCreateDeviceGray(),
+        bitmapInfo: CGImageAlphaInfo.none.rawValue
+    )?.makeImage()
 }


### PR DESCRIPTION
## Problem

* When a ticket's QR code cannot be drawn, `Barcode` shows a warning card and records nothing.
* An attendee reaches the door, their code will not scan, and nobody finds out. The ticket reference is on screen so staff can still check them in, but no one learns the code failed.

## Solution

`BarcodeContent` was already a closure-struct, so it takes a decorator directly:

```swift
package func loggingFailures(payloadBytes: Int) -> BarcodeContent {
    BarcodeContent {
        guard let image = makeImage() else {
            @Dependency(\.log) var log
            log.error("The ticket code could not be drawn: \(payloadBytes, ...)", in: .ticket)
            return nil
        }
        return image
    }
}
```

`TicketView` composes it at its one call site. The decorator lives beside `TicketView`, not in `DesignSystem/Barcode/`, so the barcode component learns nothing about tickets or logging and stays fit to extract later.

`AuthenticationUI` gains LogKit and its own `LogCategories`, because `AuthenticationFeature`'s are internal to it. `Package.resolved` is unchanged.

## How to test

```bash
git fetch && git checkout feat/log-barcode-failures
swift test --package-path Packages/AuthenticationUI
```

Replace the decorator body with `makeImage()` and two tests fail; change `return image` to `return nil` and the pass-through test fails.

## Notes

* Nothing the attendee sees changes. Scope is record-only.
* Drawing happens on every `body` pass, so a broken code logs more than once. Fixing that needs a way to test a hosted SwiftUI view first, which the repo has none of.
