### PR TITLE
feat(AuthenticationFeature): replace raw status codes with HTTPStatus

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,8 +53,10 @@ nesting:
 # "id" is SwiftLint's own default allowance. An `excluded` list replaces the
 # default rather than adding to it, so dropping "id" here would start flagging
 # every `Identifiable` conformance. "x" and "y" name pixel coordinates.
+# "ok" is HTTP vocabulary: `HTTPStatus.ok` names the 200 status.
 identifier_name:
   excluded:
     - id
     - x
     - y
+    - ok

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Logging.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Logging.swift
@@ -16,7 +16,7 @@ extension HTTPClient {
                 let (data, response) = try await send(request)
                 let entry = LoggedHTTPRequestOutcome.success(
                     request: request,
-                    statusCode: response.statusCode
+                    status: response.status
                 )
                 log(entry.level, .network, entry.message)
                 return (data, response)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+SessionExpiry.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+SessionExpiry.swift
@@ -4,7 +4,7 @@ extension HTTPClient {
     package func interceptingSessionExpiry(onExpiry: @escaping @Sendable () async -> Void) -> HTTPClient {
         HTTPClient { request in
             let (data, response) = try await self.send(request)
-            if response.statusCode == 401, request.value(forHTTPHeaderField: "Authorization") != nil {
+            if response.status == .unauthorized, request.value(forHTTPHeaderField: "Authorization") != nil {
                 await onExpiry()
             }
             return (data, response)

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
@@ -2,11 +2,13 @@ import Foundation
 
 /// An HTTP response status, compared by its code.
 package struct HTTPStatus: Equatable, Hashable, Sendable {
-    fileprivate let code: Int
+    private let code: Int
 
     package init(_ code: Int) {
         self.code = code
     }
+
+    fileprivate var intValue: Int { code }
 }
 
 extension HTTPStatus {
@@ -16,7 +18,7 @@ extension HTTPStatus {
 
 extension Int {
     package init(_ status: HTTPStatus) {
-        self = status.code
+        self = status.intValue
     }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
@@ -15,9 +15,9 @@ package struct HTTPStatus: Equatable, Hashable, Sendable {
         case invalid
     }
 
-    fileprivate let code: Int
+    package let code: HTTPStatusCode
 
-    package init(_ code: Int) {
+    package init(code: HTTPStatusCode) {
         self.code = code
     }
 
@@ -43,69 +43,63 @@ package struct HTTPStatus: Equatable, Hashable, Sendable {
 // 7725, 8297 and 8470. The four codes RFC 9110 marks deprecated, reserved or
 // unused (305, 306, 402, 418) are deliberately absent.
 extension HTTPStatus {
-    package static let `continue` = HTTPStatus(100)
-    package static let switchingProtocols = HTTPStatus(101)
-    package static let earlyHints = HTTPStatus(103)
+    package static let `continue` = HTTPStatus(code: 100)
+    package static let switchingProtocols = HTTPStatus(code: 101)
+    package static let earlyHints = HTTPStatus(code: 103)
 
-    package static let ok = HTTPStatus(200)
-    package static let created = HTTPStatus(201)
-    package static let accepted = HTTPStatus(202)
-    package static let nonAuthoritativeInformation = HTTPStatus(203)
-    package static let noContent = HTTPStatus(204)
-    package static let resetContent = HTTPStatus(205)
-    package static let partialContent = HTTPStatus(206)
+    package static let ok = HTTPStatus(code: 200)
+    package static let created = HTTPStatus(code: 201)
+    package static let accepted = HTTPStatus(code: 202)
+    package static let nonAuthoritativeInformation = HTTPStatus(code: 203)
+    package static let noContent = HTTPStatus(code: 204)
+    package static let resetContent = HTTPStatus(code: 205)
+    package static let partialContent = HTTPStatus(code: 206)
 
-    package static let multipleChoices = HTTPStatus(300)
-    package static let movedPermanently = HTTPStatus(301)
-    package static let found = HTTPStatus(302)
-    package static let seeOther = HTTPStatus(303)
-    package static let notModified = HTTPStatus(304)
-    package static let temporaryRedirect = HTTPStatus(307)
-    package static let permanentRedirect = HTTPStatus(308)
+    package static let multipleChoices = HTTPStatus(code: 300)
+    package static let movedPermanently = HTTPStatus(code: 301)
+    package static let found = HTTPStatus(code: 302)
+    package static let seeOther = HTTPStatus(code: 303)
+    package static let notModified = HTTPStatus(code: 304)
+    package static let temporaryRedirect = HTTPStatus(code: 307)
+    package static let permanentRedirect = HTTPStatus(code: 308)
 
-    package static let badRequest = HTTPStatus(400)
-    package static let unauthorized = HTTPStatus(401)
-    package static let forbidden = HTTPStatus(403)
-    package static let notFound = HTTPStatus(404)
-    package static let methodNotAllowed = HTTPStatus(405)
-    package static let notAcceptable = HTTPStatus(406)
-    package static let proxyAuthenticationRequired = HTTPStatus(407)
-    package static let requestTimeout = HTTPStatus(408)
-    package static let conflict = HTTPStatus(409)
-    package static let gone = HTTPStatus(410)
-    package static let lengthRequired = HTTPStatus(411)
-    package static let preconditionFailed = HTTPStatus(412)
-    package static let contentTooLarge = HTTPStatus(413)
-    package static let uriTooLong = HTTPStatus(414)
-    package static let unsupportedMediaType = HTTPStatus(415)
-    package static let rangeNotSatisfiable = HTTPStatus(416)
-    package static let expectationFailed = HTTPStatus(417)
-    package static let misdirectedRequest = HTTPStatus(421)
-    package static let unprocessableContent = HTTPStatus(422)
-    package static let tooEarly = HTTPStatus(425)
-    package static let upgradeRequired = HTTPStatus(426)
-    package static let preconditionRequired = HTTPStatus(428)
-    package static let tooManyRequests = HTTPStatus(429)
-    package static let requestHeaderFieldsTooLarge = HTTPStatus(431)
-    package static let unavailableForLegalReasons = HTTPStatus(451)
+    package static let badRequest = HTTPStatus(code: 400)
+    package static let unauthorized = HTTPStatus(code: 401)
+    package static let forbidden = HTTPStatus(code: 403)
+    package static let notFound = HTTPStatus(code: 404)
+    package static let methodNotAllowed = HTTPStatus(code: 405)
+    package static let notAcceptable = HTTPStatus(code: 406)
+    package static let proxyAuthenticationRequired = HTTPStatus(code: 407)
+    package static let requestTimeout = HTTPStatus(code: 408)
+    package static let conflict = HTTPStatus(code: 409)
+    package static let gone = HTTPStatus(code: 410)
+    package static let lengthRequired = HTTPStatus(code: 411)
+    package static let preconditionFailed = HTTPStatus(code: 412)
+    package static let contentTooLarge = HTTPStatus(code: 413)
+    package static let uriTooLong = HTTPStatus(code: 414)
+    package static let unsupportedMediaType = HTTPStatus(code: 415)
+    package static let rangeNotSatisfiable = HTTPStatus(code: 416)
+    package static let expectationFailed = HTTPStatus(code: 417)
+    package static let misdirectedRequest = HTTPStatus(code: 421)
+    package static let unprocessableContent = HTTPStatus(code: 422)
+    package static let tooEarly = HTTPStatus(code: 425)
+    package static let upgradeRequired = HTTPStatus(code: 426)
+    package static let preconditionRequired = HTTPStatus(code: 428)
+    package static let tooManyRequests = HTTPStatus(code: 429)
+    package static let requestHeaderFieldsTooLarge = HTTPStatus(code: 431)
+    package static let unavailableForLegalReasons = HTTPStatus(code: 451)
 
-    package static let internalServerError = HTTPStatus(500)
-    package static let notImplemented = HTTPStatus(501)
-    package static let badGateway = HTTPStatus(502)
-    package static let serviceUnavailable = HTTPStatus(503)
-    package static let gatewayTimeout = HTTPStatus(504)
-    package static let httpVersionNotSupported = HTTPStatus(505)
-    package static let networkAuthenticationRequired = HTTPStatus(511)
-}
-
-extension Int {
-    package init(_ status: HTTPStatus) {
-        self = status.code
-    }
+    package static let internalServerError = HTTPStatus(code: 500)
+    package static let notImplemented = HTTPStatus(code: 501)
+    package static let badGateway = HTTPStatus(code: 502)
+    package static let serviceUnavailable = HTTPStatus(code: 503)
+    package static let gatewayTimeout = HTTPStatus(code: 504)
+    package static let httpVersionNotSupported = HTTPStatus(code: 505)
+    package static let networkAuthenticationRequired = HTTPStatus(code: 511)
 }
 
 extension HTTPURLResponse {
     package var status: HTTPStatus {
-        HTTPStatus(statusCode)
+        HTTPStatus(code: HTTPStatusCode(statusCode))
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
@@ -2,10 +2,40 @@ import Foundation
 
 /// An HTTP response status, compared by its code.
 package struct HTTPStatus: Equatable, Hashable, Sendable {
+    /// The class of a status, named by its first digit (RFC 9110 section 15).
+    ///
+    /// A code outside 100...599 is `invalid`: the wire grammar can carry it,
+    /// but no class is defined for it.
+    package enum Category: Equatable, Hashable, Sendable {
+        case informational
+        case successful
+        case redirection
+        case clientError
+        case serverError
+        case invalid
+    }
+
     fileprivate let code: Int
 
     package init(_ code: Int) {
         self.code = code
+    }
+
+    package var category: Category {
+        switch code {
+        case 100...199:
+            .informational
+        case 200...299:
+            .successful
+        case 300...399:
+            .redirection
+        case 400...499:
+            .clientError
+        case 500...599:
+            .serverError
+        default:
+            .invalid
+        }
     }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
@@ -39,9 +39,63 @@ package struct HTTPStatus: Equatable, Hashable, Sendable {
     }
 }
 
+// Every registered status the IANA registry names through RFCs 9110, 6585,
+// 7725, 8297 and 8470. The four codes RFC 9110 marks deprecated, reserved or
+// unused (305, 306, 402, 418) are deliberately absent.
 extension HTTPStatus {
+    package static let `continue` = HTTPStatus(100)
+    package static let switchingProtocols = HTTPStatus(101)
+    package static let earlyHints = HTTPStatus(103)
+
     package static let ok = HTTPStatus(200)
+    package static let created = HTTPStatus(201)
+    package static let accepted = HTTPStatus(202)
+    package static let nonAuthoritativeInformation = HTTPStatus(203)
+    package static let noContent = HTTPStatus(204)
+    package static let resetContent = HTTPStatus(205)
+    package static let partialContent = HTTPStatus(206)
+
+    package static let multipleChoices = HTTPStatus(300)
+    package static let movedPermanently = HTTPStatus(301)
+    package static let found = HTTPStatus(302)
+    package static let seeOther = HTTPStatus(303)
+    package static let notModified = HTTPStatus(304)
+    package static let temporaryRedirect = HTTPStatus(307)
+    package static let permanentRedirect = HTTPStatus(308)
+
+    package static let badRequest = HTTPStatus(400)
     package static let unauthorized = HTTPStatus(401)
+    package static let forbidden = HTTPStatus(403)
+    package static let notFound = HTTPStatus(404)
+    package static let methodNotAllowed = HTTPStatus(405)
+    package static let notAcceptable = HTTPStatus(406)
+    package static let proxyAuthenticationRequired = HTTPStatus(407)
+    package static let requestTimeout = HTTPStatus(408)
+    package static let conflict = HTTPStatus(409)
+    package static let gone = HTTPStatus(410)
+    package static let lengthRequired = HTTPStatus(411)
+    package static let preconditionFailed = HTTPStatus(412)
+    package static let contentTooLarge = HTTPStatus(413)
+    package static let uriTooLong = HTTPStatus(414)
+    package static let unsupportedMediaType = HTTPStatus(415)
+    package static let rangeNotSatisfiable = HTTPStatus(416)
+    package static let expectationFailed = HTTPStatus(417)
+    package static let misdirectedRequest = HTTPStatus(421)
+    package static let unprocessableContent = HTTPStatus(422)
+    package static let tooEarly = HTTPStatus(425)
+    package static let upgradeRequired = HTTPStatus(426)
+    package static let preconditionRequired = HTTPStatus(428)
+    package static let tooManyRequests = HTTPStatus(429)
+    package static let requestHeaderFieldsTooLarge = HTTPStatus(431)
+    package static let unavailableForLegalReasons = HTTPStatus(451)
+
+    package static let internalServerError = HTTPStatus(500)
+    package static let notImplemented = HTTPStatus(501)
+    package static let badGateway = HTTPStatus(502)
+    package static let serviceUnavailable = HTTPStatus(503)
+    package static let gatewayTimeout = HTTPStatus(504)
+    package static let httpVersionNotSupported = HTTPStatus(505)
+    package static let networkAuthenticationRequired = HTTPStatus(511)
 }
 
 extension Int {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
@@ -2,13 +2,11 @@ import Foundation
 
 /// An HTTP response status, compared by its code.
 package struct HTTPStatus: Equatable, Hashable, Sendable {
-    private let code: Int
+    fileprivate let code: Int
 
     package init(_ code: Int) {
         self.code = code
     }
-
-    fileprivate var intValue: Int { code }
 }
 
 extension HTTPStatus {
@@ -18,7 +16,7 @@ extension HTTPStatus {
 
 extension Int {
     package init(_ status: HTTPStatus) {
-        self = status.intValue
+        self = status.code
     }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
@@ -1,0 +1,19 @@
+/// An HTTP response status, compared by its code.
+package struct HTTPStatus: Equatable, Hashable, Sendable {
+    fileprivate let code: Int
+
+    package init(_ code: Int) {
+        self.code = code
+    }
+}
+
+extension HTTPStatus {
+    package static let ok = HTTPStatus(200)
+    package static let unauthorized = HTTPStatus(401)
+}
+
+extension Int {
+    package init(_ status: HTTPStatus) {
+        self = status.code
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// An HTTP response status, compared by its code.
 package struct HTTPStatus: Equatable, Hashable, Sendable {
     fileprivate let code: Int
@@ -15,5 +17,11 @@ extension HTTPStatus {
 extension Int {
     package init(_ status: HTTPStatus) {
         self = status.code
+    }
+}
+
+extension HTTPURLResponse {
+    package var status: HTTPStatus {
+        HTTPStatus(statusCode)
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatusCode.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatusCode.swift
@@ -1,0 +1,26 @@
+/// The code that identifies an HTTP response status.
+package struct HTTPStatusCode: Equatable, Hashable, Sendable {
+    fileprivate let value: Int
+
+    package init(_ value: Int) {
+        self.value = value
+    }
+}
+
+extension HTTPStatusCode: Comparable {
+    package static func < (lhs: HTTPStatusCode, rhs: HTTPStatusCode) -> Bool {
+        lhs.value < rhs.value
+    }
+}
+
+extension HTTPStatusCode: ExpressibleByIntegerLiteral {
+    package init(integerLiteral value: Int) {
+        self.init(value)
+    }
+}
+
+extension Int {
+    package init(_ code: HTTPStatusCode) {
+        self = code.value
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedHTTPRequestOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedHTTPRequestOutcome.swift
@@ -8,13 +8,13 @@ struct LoggedHTTPRequestOutcome {
     // A response runs on every request in the app, so it records at the level the platform drops
     // unless someone is watching. The status is data, not severity: whoever reads the response
     // decides whether a 500 is a failure.
-    static func success(request: URLRequest, statusCode: Int) -> LoggedHTTPRequestOutcome {
+    static func success(request: URLRequest, status: HTTPStatus) -> LoggedHTTPRequestOutcome {
         LoggedHTTPRequestOutcome(
             level: .debug,
             message: """
             A response arrived: \
             \(request.loggedSummary, name: "request", privacy: .open), \
-            \(statusCode, name: "statusCode", privacy: .open)
+            \(Int(status), name: "statusCode", privacy: .open)
             """
         )
     }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedHTTPRequestOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedHTTPRequestOutcome.swift
@@ -14,7 +14,7 @@ struct LoggedHTTPRequestOutcome {
             message: """
             A response arrived: \
             \(request.loggedSummary, name: "request", privacy: .open), \
-            \(Int(status), name: "statusCode", privacy: .open)
+            \(Int(status.code), name: "statusCode", privacy: .open)
             """
         )
     }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginResponseOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginResponseOutcome.swift
@@ -22,7 +22,7 @@ struct LoggedLoginResponseOutcome {
         case let .unexpectedStatus(status):
             LoggedLoginResponseOutcome(
                 level: .error,
-                message: "Sign-in got an unexpected status \(Int(status), name: "statusCode", privacy: .open)"
+                message: "Sign-in got an unexpected status \(Int(status.code), name: "statusCode", privacy: .open)"
             )
         case let .invalidToken(reason):
             LoggedLoginResponseOutcome(

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginResponseOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginResponseOutcome.swift
@@ -19,10 +19,10 @@ struct LoggedLoginResponseOutcome {
                 level: .notice,
                 message: "The sign-in credentials were rejected"
             )
-        case let .unexpectedStatus(code):
+        case let .unexpectedStatus(status):
             LoggedLoginResponseOutcome(
                 level: .error,
-                message: "Sign-in got an unexpected status \(code, name: "statusCode", privacy: .open)"
+                message: "Sign-in got an unexpected status \(Int(status), name: "statusCode", privacy: .open)"
             )
         case let .invalidToken(reason):
             LoggedLoginResponseOutcome(

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+ResponseError.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper+ResponseError.swift
@@ -2,7 +2,7 @@ extension LoginMapper {
     /// Why a login response could not be turned into a session.
     package enum ResponseError: Error {
         case invalidCredentials
-        case unexpectedStatus(Int)
+        case unexpectedStatus(HTTPStatus)
         case invalidToken(SessionToken.ParsingError)
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/LoginMapper.swift
@@ -11,17 +11,17 @@ package struct LoginMapper: Sendable {
 
 extension LoginMapper {
     package static let live = LoginMapper { data, response throws(ResponseError) in
-        switch response.statusCode {
-        case 200:
+        switch response.status {
+        case .ok:
             do throws(SessionToken.ParsingError) {
                 return try SessionToken(String(decoding: data, as: UTF8.self))
             } catch {
                 throw .invalidToken(error)
             }
-        case 401:
+        case .unauthorized:
             throw .invalidCredentials
         default:
-            throw .unexpectedStatus(response.statusCode)
+            throw .unexpectedStatus(response.status)
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+ResponseError.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper+ResponseError.swift
@@ -3,7 +3,7 @@ extension AttendeeMapper {
         case couldNotDecode(any Error)
         case invalidField(AttendeeDTO.FieldError)
         case unauthorized
-        case unexpectedStatus(Int)
+        case unexpectedStatus(HTTPStatus)
     }
 }
 

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeMapper.swift
@@ -11,8 +11,8 @@ package struct AttendeeMapper: Sendable {
 
 extension AttendeeMapper {
     package static let live = AttendeeMapper { data, response throws(ResponseError) in
-        switch response.statusCode {
-        case 200:
+        switch response.status {
+        case .ok:
             let dto: AttendeeDTO
             do {
                 dto = try JSONDecoder().decode(AttendeeDTO.self, from: data)
@@ -24,10 +24,10 @@ extension AttendeeMapper {
             } catch {
                 throw .invalidField(error)
             }
-        case 401:
+        case .unauthorized:
             throw .unauthorized
         default:
-            throw .unexpectedStatus(response.statusCode)
+            throw .unexpectedStatus(response.status)
         }
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedAttendeeResponseOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedAttendeeResponseOutcome.swift
@@ -36,7 +36,7 @@ struct LoggedAttendeeResponseOutcome {
                 level: .error,
                 message: """
                 The attendee request got an unexpected status \
-                \(Int(status), name: "statusCode", privacy: .open)
+                \(Int(status.code), name: "statusCode", privacy: .open)
                 """
             )
         }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedAttendeeResponseOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedAttendeeResponseOutcome.swift
@@ -31,10 +31,13 @@ struct LoggedAttendeeResponseOutcome {
                 level: .notice,
                 message: "The attendee request was not authorized"
             )
-        case let .unexpectedStatus(code):
+        case let .unexpectedStatus(status):
             LoggedAttendeeResponseOutcome(
                 level: .error,
-                message: "The attendee request got an unexpected status \(code, name: "statusCode", privacy: .open)"
+                message: """
+                The attendee request got an unexpected status \
+                \(Int(status), name: "statusCode", privacy: .open)
+                """
             )
         }
     }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusCodeTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusCodeTests.swift
@@ -1,0 +1,39 @@
+import AuthenticationFeature
+import Testing
+
+@Suite struct HTTPStatusCodeTests {
+    @Test func whenValuesMatch_shouldBeEqual() {
+        #expect(HTTPStatusCode(404) == HTTPStatusCode(404))
+    }
+
+    @Test func whenValuesDiffer_shouldNotBeEqual() {
+        #expect(HTTPStatusCode(200) != HTTPStatusCode(201))
+    }
+
+    @Test func whenWrittenAsIntegerLiteral_shouldEqualParsedValue() {
+        let code: HTTPStatusCode = 503
+
+        #expect(code == HTTPStatusCode(503))
+    }
+
+    @Test func whenValueIsExtracted_shouldReturnValueGiven() {
+        #expect(Int(HTTPStatusCode(418)) == 418)
+    }
+
+    @Test func whenCodesAreOrdered_shouldCompareByValue() {
+        #expect(HTTPStatusCode(200) < HTTPStatusCode(300))
+    }
+
+    @Test func whenCodeFallsInRange_shouldMatchRangePattern() {
+        let redirection: ClosedRange<HTTPStatusCode> = 300...399
+
+        #expect(redirection.contains(302))
+    }
+
+    @Test func whenCodeFallsOutsideRange_shouldNotMatchRangePattern() {
+        let redirection: ClosedRange<HTTPStatusCode> = 300...399
+
+        #expect(redirection.contains(299) == false)
+        #expect(redirection.contains(400) == false)
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
@@ -1,0 +1,24 @@
+import AuthenticationFeature
+import Testing
+
+@Suite struct HTTPStatusTests {
+    @Test func whenCodesMatch_shouldBeEqual() {
+        #expect(HTTPStatus(503) == HTTPStatus(503))
+    }
+
+    @Test func whenCodesDiffer_shouldNotBeEqual() {
+        #expect(HTTPStatus(200) != HTTPStatus(401))
+    }
+
+    @Test func whenCodeIsExtracted_shouldReturnCodeGiven() {
+        #expect(Int(HTTPStatus(418)) == 418)
+    }
+
+    @Test func whenStatusIsOK_shouldHaveCode200() {
+        #expect(Int(HTTPStatus.ok) == 200)
+    }
+
+    @Test func whenStatusIsUnauthorized_shouldHaveCode401() {
+        #expect(Int(HTTPStatus.unauthorized) == 401)
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
@@ -14,12 +14,61 @@ import Testing
         #expect(Int(HTTPStatus(418)) == 418)
     }
 
-    @Test func whenStatusIsOK_shouldHaveCode200() {
-        #expect(Int(HTTPStatus.ok) == 200)
-    }
+    private static let registeredStatuses: [(HTTPStatus, Int)] = [
+        (.continue, 100),
+        (.switchingProtocols, 101),
+        (.earlyHints, 103),
+        (.ok, 200),
+        (.created, 201),
+        (.accepted, 202),
+        (.nonAuthoritativeInformation, 203),
+        (.noContent, 204),
+        (.resetContent, 205),
+        (.partialContent, 206),
+        (.multipleChoices, 300),
+        (.movedPermanently, 301),
+        (.found, 302),
+        (.seeOther, 303),
+        (.notModified, 304),
+        (.temporaryRedirect, 307),
+        (.permanentRedirect, 308),
+        (.badRequest, 400),
+        (.unauthorized, 401),
+        (.forbidden, 403),
+        (.notFound, 404),
+        (.methodNotAllowed, 405),
+        (.notAcceptable, 406),
+        (.proxyAuthenticationRequired, 407),
+        (.requestTimeout, 408),
+        (.conflict, 409),
+        (.gone, 410),
+        (.lengthRequired, 411),
+        (.preconditionFailed, 412),
+        (.contentTooLarge, 413),
+        (.uriTooLong, 414),
+        (.unsupportedMediaType, 415),
+        (.rangeNotSatisfiable, 416),
+        (.expectationFailed, 417),
+        (.misdirectedRequest, 421),
+        (.unprocessableContent, 422),
+        (.tooEarly, 425),
+        (.upgradeRequired, 426),
+        (.preconditionRequired, 428),
+        (.tooManyRequests, 429),
+        (.requestHeaderFieldsTooLarge, 431),
+        (.unavailableForLegalReasons, 451),
+        (.internalServerError, 500),
+        (.notImplemented, 501),
+        (.badGateway, 502),
+        (.serviceUnavailable, 503),
+        (.gatewayTimeout, 504),
+        (.httpVersionNotSupported, 505),
+        (.networkAuthenticationRequired, 511),
+    ]
 
-    @Test func whenStatusIsUnauthorized_shouldHaveCode401() {
-        #expect(Int(HTTPStatus.unauthorized) == 401)
+    @Test(arguments: registeredStatuses)
+    func whenStatusIsNamed_shouldHaveRegisteredCode(status: HTTPStatus, code: Int) {
+        #expect(Int(status) == code)
     }
 
     @Test(arguments: [

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
@@ -3,15 +3,15 @@ import Testing
 
 @Suite struct HTTPStatusTests {
     @Test func whenCodesMatch_shouldBeEqual() {
-        #expect(HTTPStatus(503) == HTTPStatus(503))
+        #expect(HTTPStatus(code: 503) == HTTPStatus(code: 503))
     }
 
     @Test func whenCodesDiffer_shouldNotBeEqual() {
-        #expect(HTTPStatus(200) != HTTPStatus(401))
+        #expect(HTTPStatus(code: 200) != HTTPStatus(code: 401))
     }
 
     @Test func whenCodeIsExtracted_shouldReturnCodeGiven() {
-        #expect(Int(HTTPStatus(418)) == 418)
+        #expect(Int(HTTPStatus(code: 418).code) == 418)
     }
 
     private static let registeredStatuses: [(HTTPStatus, Int)] = [
@@ -68,7 +68,7 @@ import Testing
 
     @Test(arguments: registeredStatuses)
     func whenStatusIsNamed_shouldHaveRegisteredCode(status: HTTPStatus, code: Int) {
-        #expect(Int(status) == code)
+        #expect(Int(status.code) == code)
     }
 
     @Test(arguments: [
@@ -87,11 +87,11 @@ import Testing
         code: Int,
         category: HTTPStatus.Category
     ) {
-        #expect(HTTPStatus(code).category == category)
+        #expect(HTTPStatus(code: HTTPStatusCode(code)).category == category)
     }
 
     @Test(arguments: [99, 600, 0, -1, 1000])
     func whenCodeIsOutsideValidRange_shouldBeInvalid(code: Int) {
-        #expect(HTTPStatus(code).category == .invalid)
+        #expect(HTTPStatus(code: HTTPStatusCode(code)).category == .invalid)
     }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
@@ -21,4 +21,28 @@ import Testing
     @Test func whenStatusIsUnauthorized_shouldHaveCode401() {
         #expect(Int(HTTPStatus.unauthorized) == 401)
     }
+
+    @Test(arguments: [
+        (100, HTTPStatus.Category.informational),
+        (199, HTTPStatus.Category.informational),
+        (200, HTTPStatus.Category.successful),
+        (299, HTTPStatus.Category.successful),
+        (300, HTTPStatus.Category.redirection),
+        (399, HTTPStatus.Category.redirection),
+        (400, HTTPStatus.Category.clientError),
+        (499, HTTPStatus.Category.clientError),
+        (500, HTTPStatus.Category.serverError),
+        (599, HTTPStatus.Category.serverError),
+    ])
+    func whenCodeIsInDefinedClass_shouldDeriveCategoryFromFirstDigit(
+        code: Int,
+        category: HTTPStatus.Category
+    ) {
+        #expect(HTTPStatus(code).category == category)
+    }
+
+    @Test(arguments: [99, 600, 0, -1, 1000])
+    func whenCodeIsOutsideValidRange_shouldBeInvalid(code: Int) {
+        #expect(HTTPStatus(code).category == .invalid)
+    }
 }


### PR DESCRIPTION
## Problem

* Every response reader in the new networking stack switches on `HTTPURLResponse.statusCode: Int`, so 200 and 401 are magic numbers at four sites.
* The mappers' `unexpectedStatus` errors carry a bare `Int`.

## Solution

* `HTTPStatus`, a package struct: a named constant for every registered status code (RFCs 9110, 6585, 7725, 8297, 8470; the four codes RFC 9110 marks deprecated or unused are absent) and a nested `Category` enum deriving the class from the first digit per RFC 9110 section 15. Every integer the server sends stays representable; a code outside 100...599 is `Category.invalid`; rejection stays in the mappers' `default` arms, and exact-200 matching is kept deliberately.
* `HTTPStatusCode`, the identifying code as its own strong type, so the primitive `Int` lives in one place. `Comparable` plus integer literals give range patterns over the domain type (the `Category` derivation switches over `100...199` and friends directly), and `Int(_:)` extraction feeds log rendering via `Int(status.code)`.
* Adopted at all four read sites: both mappers, session-expiry detection, and transport logging.

```swift
switch response.status {
case .ok: ...
case .unauthorized: throw .invalidCredentials
default: throw .unexpectedStatus(response.status)
}
```

* SwiftLint's three-character identifier minimum would reject `ok`, so the config allows it beside the existing `id`, `x` and `y` entries.

## How to test

```bash
git fetch && git checkout feat/http-status
cd Packages/AuthenticationFeature && swift test
```
