### PR TITLE
feat(AuthenticationFeature): make Endpoint own the whole request

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -15,15 +15,13 @@ extension AuthGateway {
             @Dependency(\.apiConfiguration) var apiConfiguration
             @Dependency(\.loginMapper) var loginMapper
 
-            var request = URLRequest(url: Endpoint.login.url(baseURL: apiConfiguration.baseURL))
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
+            let body: Data
             do {
-                request.httpBody = try JSONEncoder().encode(LoginRequestDTO(credential))
+                body = try JSONEncoder().encode(LoginRequestDTO(credential))
             } catch {
                 throw LoginRequestError.couldNotEncodeRequest(error)
             }
+            let request = Endpoint.login(body: body).urlRequest(baseURL: apiConfiguration.baseURL)
 
             let data: Data
             let response: HTTPURLResponse

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -12,7 +12,6 @@ extension AuthGateway {
     static var live: AuthGateway {
         AuthGateway { credential in
             @Dependency(\.httpClient) var httpClient
-            @Dependency(\.apiConfiguration) var apiConfiguration
             @Dependency(\.loginMapper) var loginMapper
 
             let body: Data
@@ -21,7 +20,7 @@ extension AuthGateway {
             } catch {
                 throw LoginRequestError.couldNotEncodeRequest(error)
             }
-            let request = Endpoint.login(body: body).urlRequest(baseURL: apiConfiguration.baseURL)
+            let request = Endpoint.login(body: body).urlRequest()
 
             let data: Data
             let response: HTTPURLResponse

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
@@ -14,14 +14,5 @@ package enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
         }
     }
 
-    func url(baseURL: URL) -> URL {
-        switch self {
-        case .login:
-            baseURL.appending(path: "api/v1/login/ticket")
-        case .profile:
-            baseURL.appending(path: "api/v1/login/ticket")
-        }
-    }
-
     private static let loginTicketPath: URLPath = "api/v1/login/ticket"
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
@@ -1,8 +1,18 @@
 import Foundation
 
-enum Endpoint {
-    case login
+/// A request to the SwiftLeeds backend, named in the backend's vocabulary.
+package enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
+    case login(body: Data)
     case profile
+
+    package var request: HTTPRequest {
+        switch self {
+        case let .login(body):
+            .post(Self.loginTicketPath, body: .json(body))
+        case .profile:
+            .get(Self.loginTicketPath)
+        }
+    }
 
     func url(baseURL: URL) -> URL {
         switch self {
@@ -12,4 +22,6 @@ enum Endpoint {
             baseURL.appending(path: "api/v1/login/ticket")
         }
     }
+
+    private static let loginTicketPath: URLPath = "api/v1/login/ticket"
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
@@ -3,13 +3,13 @@ import Foundation
 /// A request to the SwiftLeeds backend, named in the backend's vocabulary.
 package enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
     case login(body: Data)
-    case profile
+    case ticket
 
     package var request: HTTPRequest {
         switch self {
         case let .login(body):
             .post(Self.loginTicketPath, body: .json(body))
-        case .profile:
+        case .ticket:
             .get(Self.loginTicketPath)
         }
     }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPBody.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPBody.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// A request's content, paired with the media type that describes it.
+package struct HTTPBody: Equatable, Hashable, Sendable {
+    private let data: Data
+    private let mediaType: MediaType
+
+    package static func json(_ data: Data) -> HTTPBody {
+        HTTPBody(data: data, mediaType: .application.json)
+    }
+
+    /// Writes the content and its Content-Type header onto the request.
+    package func attach(to request: inout URLRequest) {
+        request.httpBody = data
+        request.setValue(String(mediaType), forHTTPHeaderField: "Content-Type")
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPMethod.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPMethod.swift
@@ -1,0 +1,15 @@
+/// An HTTP request method, carried on the wire as its uppercase raw value.
+///
+/// Methods are case-sensitive (RFC 9110 section 9.1).
+package enum HTTPMethod: String, Equatable, Hashable, Sendable {
+    // Every method RFC 9110 section 9 registers, plus PATCH (RFC 5789).
+    case get = "GET"
+    case head = "HEAD"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case connect = "CONNECT"
+    case options = "OPTIONS"
+    case trace = "TRACE"
+    case patch = "PATCH"
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPRequest.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPRequest.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// One HTTP request, described by its method, path and content.
+///
+/// The constructors follow RFC 9110's content semantics: a method with no
+/// defined content takes no body, so a GET cannot carry one.
+package struct HTTPRequest: Equatable, Hashable, Sendable {
+    private let method: HTTPMethod
+    private let path: URLPath
+    private let body: HTTPBody?
+
+    package static func get(_ path: URLPath) -> HTTPRequest {
+        HTTPRequest(method: .get, path: path, body: nil)
+    }
+
+    package static func post(_ path: URLPath, body: HTTPBody) -> HTTPRequest {
+        HTTPRequest(method: .post, path: path, body: body)
+    }
+
+    /// Builds the `URLRequest` this value describes.
+    ///
+    /// - Parameter baseURL: The server root the path is appended to.
+    package func urlRequest(baseURL: URL) -> URLRequest {
+        var request = URLRequest(url: baseURL.appending(path: String(path)))
+        request.httpMethod = method.rawValue
+        body?.attach(to: &request)
+        return request
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPRequest.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPRequest.swift
@@ -13,8 +13,36 @@ package struct HTTPRequest: Equatable, Hashable, Sendable {
         HTTPRequest(method: .get, path: path, body: nil)
     }
 
+    package static func head(_ path: URLPath) -> HTTPRequest {
+        HTTPRequest(method: .head, path: path, body: nil)
+    }
+
     package static func post(_ path: URLPath, body: HTTPBody) -> HTTPRequest {
         HTTPRequest(method: .post, path: path, body: body)
+    }
+
+    package static func put(_ path: URLPath, body: HTTPBody) -> HTTPRequest {
+        HTTPRequest(method: .put, path: path, body: body)
+    }
+
+    package static func delete(_ path: URLPath) -> HTTPRequest {
+        HTTPRequest(method: .delete, path: path, body: nil)
+    }
+
+    package static func connect(_ path: URLPath) -> HTTPRequest {
+        HTTPRequest(method: .connect, path: path, body: nil)
+    }
+
+    package static func options(_ path: URLPath) -> HTTPRequest {
+        HTTPRequest(method: .options, path: path, body: nil)
+    }
+
+    package static func trace(_ path: URLPath) -> HTTPRequest {
+        HTTPRequest(method: .trace, path: path, body: nil)
+    }
+
+    package static func patch(_ path: URLPath, body: HTTPBody) -> HTTPRequest {
+        HTTPRequest(method: .patch, path: path, body: body)
     }
 
     /// Builds the `URLRequest` this value describes.

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPRequestConvertible.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPRequestConvertible.swift
@@ -1,3 +1,4 @@
+import Dependencies
 import Foundation
 
 /// A value that describes itself as one HTTP request.
@@ -11,5 +12,11 @@ extension HTTPRequestConvertible {
     /// - Parameter baseURL: The server root the path is appended to.
     package func urlRequest(baseURL: URL) -> URLRequest {
         request.urlRequest(baseURL: baseURL)
+    }
+
+    /// Builds the `URLRequest` for ``request`` against the configured API's base URL.
+    package func urlRequest() -> URLRequest {
+        @Dependency(\.apiConfiguration) var apiConfiguration
+        return urlRequest(baseURL: apiConfiguration.baseURL)
     }
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPRequestConvertible.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPRequestConvertible.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// A value that describes itself as one HTTP request.
+package protocol HTTPRequestConvertible {
+    var request: HTTPRequest { get }
+}
+
+extension HTTPRequestConvertible {
+    /// Builds the `URLRequest` for ``request``.
+    ///
+    /// - Parameter baseURL: The server root the path is appended to.
+    package func urlRequest(baseURL: URL) -> URLRequest {
+        request.urlRequest(baseURL: baseURL)
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPStatus.swift
@@ -103,3 +103,23 @@ extension HTTPURLResponse {
         HTTPStatus(code: HTTPStatusCode(statusCode))
     }
 }
+
+extension String {
+    /// Creates the category's stable name for a log field.
+    package init(_ category: HTTPStatus.Category) {
+        self = switch category {
+        case .informational:
+            "informational"
+        case .successful:
+            "successful"
+        case .redirection:
+            "redirection"
+        case .clientError:
+            "clientError"
+        case .serverError:
+            "serverError"
+        case .invalid:
+            "invalid"
+        }
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginResponseOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Logging/LoggedLoginResponseOutcome.swift
@@ -22,7 +22,11 @@ struct LoggedLoginResponseOutcome {
         case let .unexpectedStatus(status):
             LoggedLoginResponseOutcome(
                 level: .error,
-                message: "Sign-in got an unexpected status \(Int(status.code), name: "statusCode", privacy: .open)"
+                message: """
+                Sign-in got an unexpected status \
+                \(Int(status.code), name: "statusCode", privacy: .open) \
+                (\(String(status.category), name: "statusCategory", privacy: .open))
+                """
             )
         case let .invalidToken(reason):
             LoggedLoginResponseOutcome(

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/MediaType.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/MediaType.swift
@@ -1,0 +1,29 @@
+/// A media type from the IANA registry, written as type/subtype.
+///
+/// Any value is representable through `init(_:)`; the named constants cover
+/// what the app sends.
+package struct MediaType: Equatable, Hashable, Sendable {
+    /// The registered subtypes of the application top-level type (RFC 6838).
+    package struct Application: Sendable {
+        package let json = MediaType("application/json")
+    }
+
+    fileprivate let value: String
+
+    package init(_ value: String) {
+        self.value = value
+    }
+}
+
+// Subtypes hang off their top-level type, so a media type reads as the
+// registry's own hierarchy: `.application.json`. A top-level type arrives
+// with its first used subtype; the subtype registry is open-ended.
+extension MediaType {
+    package static let application = Application()
+}
+
+extension String {
+    package init(_ mediaType: MediaType) {
+        self = mediaType.value
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/MediaType.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/MediaType.swift
@@ -3,7 +3,7 @@
 /// Any value is representable through `init(_:)`; the named constants cover
 /// what the app sends.
 package struct MediaType: Equatable, Hashable, Sendable {
-    /// The registered subtypes of the application top-level type (RFC 6838).
+    /// The subtypes of the application top-level type (RFC 6838) that the app uses.
     package struct Application: Sendable {
         package let json = MediaType("application/json")
     }
@@ -15,9 +15,8 @@ package struct MediaType: Equatable, Hashable, Sendable {
     }
 }
 
-// Subtypes hang off their top-level type, so a media type reads as the
-// registry's own hierarchy: `.application.json`. A top-level type arrives
-// with its first used subtype; the subtype registry is open-ended.
+// A top-level type arrives with its first used subtype; the subtype
+// registry is open-ended.
 extension MediaType {
     package static let application = Application()
 }

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/URLPath.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/URLPath.swift
@@ -1,0 +1,20 @@
+/// The path that locates a resource under a base URL.
+package struct URLPath: Equatable, Hashable, Sendable {
+    fileprivate let value: String
+
+    package init(_ value: String) {
+        self.value = value
+    }
+}
+
+extension URLPath: ExpressibleByStringLiteral {
+    package init(stringLiteral value: String) {
+        self.init(value)
+    }
+}
+
+extension String {
+    package init(_ path: URLPath) {
+        self = path.value
+    }
+}

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
@@ -5,9 +5,8 @@ extension AttendeeRepository: DependencyKey {
     package static var liveValue: AttendeeRepository {
         AttendeeRepository { () async throws(AttendeeFetchError) -> Attendee in
             @Dependency(\.httpClient) var httpClient
-            @Dependency(\.apiConfiguration) var apiConfiguration
             @Dependency(\.attendeeMapper) var attendeeMapper
-            let request = Endpoint.ticket.urlRequest(baseURL: apiConfiguration.baseURL)
+            let request = Endpoint.ticket.urlRequest()
             let data: Data
             let response: HTTPURLResponse
             do {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
@@ -7,7 +7,7 @@ extension AttendeeRepository: DependencyKey {
             @Dependency(\.httpClient) var httpClient
             @Dependency(\.apiConfiguration) var apiConfiguration
             @Dependency(\.attendeeMapper) var attendeeMapper
-            let request = URLRequest(url: Endpoint.profile.url(baseURL: apiConfiguration.baseURL))
+            let request = Endpoint.profile.urlRequest(baseURL: apiConfiguration.baseURL)
             let data: Data
             let response: HTTPURLResponse
             do {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
@@ -7,7 +7,7 @@ extension AttendeeRepository: DependencyKey {
             @Dependency(\.httpClient) var httpClient
             @Dependency(\.apiConfiguration) var apiConfiguration
             @Dependency(\.attendeeMapper) var attendeeMapper
-            let request = Endpoint.profile.urlRequest(baseURL: apiConfiguration.baseURL)
+            let request = Endpoint.ticket.urlRequest(baseURL: apiConfiguration.baseURL)
             let data: Data
             let response: HTTPURLResponse
             do {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedAttendeeResponseOutcome.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/Logging/LoggedAttendeeResponseOutcome.swift
@@ -36,7 +36,8 @@ struct LoggedAttendeeResponseOutcome {
                 level: .error,
                 message: """
                 The attendee request got an unexpected status \
-                \(Int(status.code), name: "statusCode", privacy: .open)
+                \(Int(status.code), name: "statusCode", privacy: .open) \
+                (\(String(status.category), name: "statusCategory", privacy: .open))
                 """
             )
         }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeMapperLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeMapperLoggingTests.swift
@@ -37,6 +37,13 @@ import Testing
         #expect(event.fields.first { String($0.name) == "statusCode" }?.value == .integer(503))
     }
 
+    @Test func whenServerReturnsUnexpectedStatus_shouldLogStatusCategory() throws {
+        let event = try #require(try logEvent(statusCode: 503))
+
+        let category = try #require(event.fields.first { String($0.name) == "statusCategory" })
+        #expect(category.value == .string("serverError"))
+    }
+
     @Test func whenEmailIsInvalid_shouldLogEmailField() throws {
         let event = try #require(try logEvent(forBody: attendeeJSON(email: "")))
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryIntegrationTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryIntegrationTests.swift
@@ -87,6 +87,21 @@ import Testing
         #expect(recorder.events.count == 1)
     }
 
+    @Test func whenFetchingAttendee_shouldGETLoginTicketResource() async throws {
+        let spy = HTTPClientSpy(respondingWith: attendeeJSON(), statusCode: 200)
+
+        _ = try await withDependencies {
+            $0.httpClient = spy.httpClient
+        } operation: {
+            let sut = AttendeeRepository.liveValue
+            return try await sut.fetch()
+        }
+
+        let request = try #require(await spy.requests.first)
+        #expect(request.httpMethod == "GET")
+        #expect(request.url?.path() == "/api/v1/login/ticket")
+    }
+
     /// An offline device is the commonest failure here, and it is not the same as a server the app
     /// cannot make sense of.
     @Test func whenTransportFails_shouldThrowCouldNotReachServer() async throws {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayIntegrationTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayIntegrationTests.swift
@@ -72,6 +72,20 @@ import Testing
         #expect(body?["ticket"] as? String == "ABCD-12")
         #expect(body?["event"] is NSNull)
     }
+    @Test func whenAuthenticating_shouldPOSTJSONToLoginTicketResource() async throws {
+        let spy = HTTPClientSpy(respondingWith: Data("jwt".utf8), statusCode: 200)
+
+        _ = try await withDependencies {
+            $0.httpClient = spy.httpClient
+        } operation: {
+            try await AuthGateway.liveValue.authenticate(Credential.fixture)
+        }
+
+        let request = try #require(await spy.requests.first)
+        #expect(request.url?.path() == "/api/v1/login/ticket")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
     @Test func whenTransportFails_shouldLogOnlyOnceAcrossChain() async throws {
         let recorder = LogRecorder()
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EndpointTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EndpointTests.swift
@@ -1,0 +1,61 @@
+import AuthenticationFeature
+import Foundation
+import Testing
+
+@Suite struct EndpointTests {
+    @Test func whenLoginRequestIsBuilt_shouldPOST() throws {
+        let request = try Endpoint.login(body: Data()).urlRequest(baseURL: baseURL)
+
+        #expect(request.httpMethod == "POST")
+    }
+
+    @Test func whenLoginRequestIsBuilt_shouldTargetLoginTicketPath() throws {
+        let request = try Endpoint.login(body: Data()).urlRequest(baseURL: baseURL)
+
+        let expected = try #require(URL(string: "https://example.com/api/v1/login/ticket"))
+        #expect(request.url == expected)
+    }
+
+    @Test func whenLoginRequestIsBuilt_shouldDeclareJSONContentType() throws {
+        let request = try Endpoint.login(body: Data()).urlRequest(baseURL: baseURL)
+
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    @Test func whenLoginRequestIsBuilt_shouldCarryBodyGiven() throws {
+        let body = Data(#"{"ticket": "ABCD-12"}"#.utf8)
+
+        let request = try Endpoint.login(body: body).urlRequest(baseURL: baseURL)
+
+        #expect(request.httpBody == body)
+    }
+
+    @Test func whenProfileRequestIsBuilt_shouldGET() throws {
+        let request = try Endpoint.profile.urlRequest(baseURL: baseURL)
+
+        #expect(request.httpMethod == "GET")
+    }
+
+    @Test func whenProfileRequestIsBuilt_shouldTargetLoginTicketPath() throws {
+        let request = try Endpoint.profile.urlRequest(baseURL: baseURL)
+
+        let expected = try #require(URL(string: "https://example.com/api/v1/login/ticket"))
+        #expect(request.url == expected)
+    }
+
+    @Test func whenProfileRequestIsBuilt_shouldCarryNoBody() throws {
+        let request = try Endpoint.profile.urlRequest(baseURL: baseURL)
+
+        #expect(request.httpBody == nil)
+    }
+
+    @Test func whenProfileRequestIsBuilt_shouldDeclareNoContentType() throws {
+        let request = try Endpoint.profile.urlRequest(baseURL: baseURL)
+
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == nil)
+    }
+
+    private var baseURL: URL {
+        get throws { try #require(URL(string: "https://example.com")) }
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EndpointTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EndpointTests.swift
@@ -30,27 +30,27 @@ import Testing
         #expect(request.httpBody == body)
     }
 
-    @Test func whenProfileRequestIsBuilt_shouldGET() throws {
-        let request = try Endpoint.profile.urlRequest(baseURL: baseURL)
+    @Test func whenTicketRequestIsBuilt_shouldGET() throws {
+        let request = try Endpoint.ticket.urlRequest(baseURL: baseURL)
 
         #expect(request.httpMethod == "GET")
     }
 
-    @Test func whenProfileRequestIsBuilt_shouldTargetLoginTicketPath() throws {
-        let request = try Endpoint.profile.urlRequest(baseURL: baseURL)
+    @Test func whenTicketRequestIsBuilt_shouldTargetLoginTicketPath() throws {
+        let request = try Endpoint.ticket.urlRequest(baseURL: baseURL)
 
         let expected = try #require(URL(string: "https://example.com/api/v1/login/ticket"))
         #expect(request.url == expected)
     }
 
-    @Test func whenProfileRequestIsBuilt_shouldCarryNoBody() throws {
-        let request = try Endpoint.profile.urlRequest(baseURL: baseURL)
+    @Test func whenTicketRequestIsBuilt_shouldCarryNoBody() throws {
+        let request = try Endpoint.ticket.urlRequest(baseURL: baseURL)
 
         #expect(request.httpBody == nil)
     }
 
-    @Test func whenProfileRequestIsBuilt_shouldDeclareNoContentType() throws {
-        let request = try Endpoint.profile.urlRequest(baseURL: baseURL)
+    @Test func whenTicketRequestIsBuilt_shouldDeclareNoContentType() throws {
+        let request = try Endpoint.ticket.urlRequest(baseURL: baseURL)
 
         #expect(request.value(forHTTPHeaderField: "Content-Type") == nil)
     }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPBodyTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPBodyTests.swift
@@ -1,0 +1,26 @@
+import AuthenticationFeature
+import Foundation
+import Testing
+
+@Suite struct HTTPBodyTests {
+    @Test func whenJSONBodyIsAttached_shouldCarryBytesGiven() throws {
+        let bytes = Data(#"{"ticket": "ABCD-12"}"#.utf8)
+        var request = try urlRequest()
+
+        HTTPBody.json(bytes).attach(to: &request)
+
+        #expect(request.httpBody == bytes)
+    }
+
+    @Test func whenJSONBodyIsAttached_shouldDeclareJSONContentType() throws {
+        var request = try urlRequest()
+
+        HTTPBody.json(Data()).attach(to: &request)
+
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    private func urlRequest() throws -> URLRequest {
+        URLRequest(url: try #require(URL(string: "https://example.com")))
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPMethodTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPMethodTests.swift
@@ -1,0 +1,21 @@
+import AuthenticationFeature
+import Testing
+
+@Suite struct HTTPMethodTests {
+    private static let registeredMethods: [(HTTPMethod, String)] = [
+        (.get, "GET"),
+        (.head, "HEAD"),
+        (.post, "POST"),
+        (.put, "PUT"),
+        (.delete, "DELETE"),
+        (.connect, "CONNECT"),
+        (.options, "OPTIONS"),
+        (.trace, "TRACE"),
+        (.patch, "PATCH"),
+    ]
+
+    @Test(arguments: registeredMethods)
+    func whenMethodIsNamed_shouldHaveRegisteredToken(method: HTTPMethod, token: String) {
+        #expect(method.rawValue == token)
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPRequestConvertibleTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPRequestConvertibleTests.swift
@@ -1,0 +1,17 @@
+import AuthenticationFeature
+import Foundation
+import Testing
+
+@Suite struct HTTPRequestConvertibleTests {
+    private struct ConvertibleStub: HTTPRequestConvertible {
+        let request: HTTPRequest = .get("api/v1/resource")
+    }
+
+    @Test func whenConformerBuildsURLRequest_shouldBuildFromItsOwnRequest() throws {
+        let baseURL = try #require(URL(string: "https://example.com"))
+
+        let built = ConvertibleStub().urlRequest(baseURL: baseURL)
+
+        #expect(built == HTTPRequest.get("api/v1/resource").urlRequest(baseURL: baseURL))
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPRequestConvertibleTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPRequestConvertibleTests.swift
@@ -1,4 +1,5 @@
 import AuthenticationFeature
+import Dependencies
 import Foundation
 import Testing
 
@@ -13,5 +14,18 @@ import Testing
         let built = ConvertibleStub().urlRequest(baseURL: baseURL)
 
         #expect(built == HTTPRequest.get("api/v1/resource").urlRequest(baseURL: baseURL))
+    }
+
+    @Test func whenNoBaseURLIsGiven_shouldBuildAgainstConfiguredAPI() throws {
+        let configured = try #require(URL(string: "https://configured.example.com"))
+
+        let built = withDependencies {
+            $0.apiConfiguration = APIConfiguration(baseURL: configured)
+        } operation: {
+            ConvertibleStub().urlRequest()
+        }
+
+        let expected = try #require(URL(string: "https://configured.example.com/api/v1/resource"))
+        #expect(built.url == expected)
     }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPRequestTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPRequestTests.swift
@@ -51,6 +51,45 @@ import Testing
         #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
     }
 
+    private static let path: URLPath = "api/v1/resource"
+
+    private static let bodilessRequests: [(HTTPRequest, String)] = [
+        (.get(path), "GET"),
+        (.head(path), "HEAD"),
+        (.delete(path), "DELETE"),
+        (.connect(path), "CONNECT"),
+        (.options(path), "OPTIONS"),
+        (.trace(path), "TRACE"),
+    ]
+
+    private static let bodyCarryingRequests: [(HTTPRequest, String)] = [
+        (.post(path, body: .json(Data())), "POST"),
+        (.put(path, body: .json(Data())), "PUT"),
+        (.patch(path, body: .json(Data())), "PATCH"),
+    ]
+
+    @Test(arguments: bodilessRequests)
+    func whenMethodHasNoDefinedContent_shouldBuildWithoutBody(
+        request: HTTPRequest,
+        token: String
+    ) throws {
+        let built = try request.urlRequest(baseURL: baseURL)
+
+        #expect(built.httpMethod == token)
+        #expect(built.httpBody == nil)
+    }
+
+    @Test(arguments: bodyCarryingRequests)
+    func whenMethodDefinesContent_shouldBuildWithBody(
+        request: HTTPRequest,
+        token: String
+    ) throws {
+        let built = try request.urlRequest(baseURL: baseURL)
+
+        #expect(built.httpMethod == token)
+        #expect(built.httpBody != nil)
+    }
+
     private var baseURL: URL {
         get throws { try #require(URL(string: "https://example.com")) }
     }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPRequestTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPRequestTests.swift
@@ -1,0 +1,57 @@
+import AuthenticationFeature
+import Foundation
+import Testing
+
+@Suite struct HTTPRequestTests {
+    @Test func whenGETIsBuilt_shouldUseGETMethod() throws {
+        let request = try HTTPRequest.get("api/v1/login/ticket").urlRequest(baseURL: baseURL)
+
+        #expect(request.httpMethod == "GET")
+    }
+
+    @Test func whenGETIsBuilt_shouldAppendPathToBaseURL() throws {
+        let request = try HTTPRequest.get("api/v1/login/ticket").urlRequest(baseURL: baseURL)
+
+        let expected = try #require(URL(string: "https://example.com/api/v1/login/ticket"))
+        #expect(request.url == expected)
+    }
+
+    @Test func whenGETIsBuilt_shouldCarryNoBody() throws {
+        let request = try HTTPRequest.get("api/v1/login/ticket").urlRequest(baseURL: baseURL)
+
+        #expect(request.httpBody == nil)
+    }
+
+    @Test func whenGETIsBuilt_shouldDeclareNoContentType() throws {
+        let request = try HTTPRequest.get("api/v1/login/ticket").urlRequest(baseURL: baseURL)
+
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == nil)
+    }
+
+    @Test func whenPOSTIsBuilt_shouldUsePOSTMethod() throws {
+        let request = try HTTPRequest.post("api/v1/login/ticket", body: .json(Data()))
+            .urlRequest(baseURL: baseURL)
+
+        #expect(request.httpMethod == "POST")
+    }
+
+    @Test func whenPOSTIsBuilt_shouldCarryBodyGiven() throws {
+        let bytes = Data(#"{"ticket": "ABCD-12"}"#.utf8)
+
+        let request = try HTTPRequest.post("api/v1/login/ticket", body: .json(bytes))
+            .urlRequest(baseURL: baseURL)
+
+        #expect(request.httpBody == bytes)
+    }
+
+    @Test func whenPOSTIsBuilt_shouldDeclareJSONContentType() throws {
+        let request = try HTTPRequest.post("api/v1/login/ticket", body: .json(Data()))
+            .urlRequest(baseURL: baseURL)
+
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    private var baseURL: URL {
+        get throws { try #require(URL(string: "https://example.com")) }
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPStatusTests.swift
@@ -94,4 +94,19 @@ import Testing
     func whenCodeIsOutsideValidRange_shouldBeInvalid(code: Int) {
         #expect(HTTPStatus(code: HTTPStatusCode(code)).category == .invalid)
     }
+
+    @Test(arguments: [
+        (HTTPStatus.Category.informational, "informational"),
+        (HTTPStatus.Category.successful, "successful"),
+        (HTTPStatus.Category.redirection, "redirection"),
+        (HTTPStatus.Category.clientError, "clientError"),
+        (HTTPStatus.Category.serverError, "serverError"),
+        (HTTPStatus.Category.invalid, "invalid"),
+    ])
+    func whenCategoryNameIsExtracted_shouldReturnStableName(
+        category: HTTPStatus.Category,
+        name: String
+    ) {
+        #expect(String(category) == name)
+    }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/LoginMapperLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/LoginMapperLoggingTests.swift
@@ -28,6 +28,13 @@ import Testing
         #expect(event.fields.first { String($0.name) == "statusCode" }?.value == .integer(503))
     }
 
+    @Test func whenServerReturnsUnexpectedStatus_shouldLogStatusCategory() throws {
+        let event = try #require(try logEvent(statusCode: 503))
+
+        let category = try #require(event.fields.first { String($0.name) == "statusCategory" })
+        #expect(category.value == .string("serverError"))
+    }
+
     @Test func whenTokenIsBlank_shouldLogRejectionReason() throws {
         let event = try #require(try logEvent(forBody: Data("   ".utf8)))
 

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/MediaTypeTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/MediaTypeTests.swift
@@ -1,0 +1,22 @@
+import AuthenticationFeature
+import Testing
+
+@Suite struct MediaTypeTests {
+    @Test func whenValuesMatch_shouldBeEqual() {
+        #expect(MediaType("application/json") == MediaType("application/json"))
+    }
+
+    @Test func whenValuesDiffer_shouldNotBeEqual() {
+        #expect(MediaType("application/json") != MediaType("text/plain"))
+    }
+
+    @Test func whenWrittenAsRegistryHierarchy_shouldEqualWrappedValue() {
+        let mediaType: MediaType = .application.json
+
+        #expect(mediaType == MediaType("application/json"))
+    }
+
+    @Test func whenValueIsExtracted_shouldReturnValueGiven() {
+        #expect(String(MediaType("application/vnd.api+json")) == "application/vnd.api+json")
+    }
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLPathTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLPathTests.swift
@@ -1,0 +1,22 @@
+import AuthenticationFeature
+import Testing
+
+@Suite struct URLPathTests {
+    @Test func whenValuesMatch_shouldBeEqual() {
+        #expect(URLPath("api/v1/login/ticket") == URLPath("api/v1/login/ticket"))
+    }
+
+    @Test func whenValuesDiffer_shouldNotBeEqual() {
+        #expect(URLPath("api/v1/login/ticket") != URLPath("api/v1/schedule"))
+    }
+
+    @Test func whenWrittenAsStringLiteral_shouldEqualWrappedValue() {
+        let path: URLPath = "api/v1/login/ticket"
+
+        #expect(path == URLPath("api/v1/login/ticket"))
+    }
+
+    @Test func whenValueIsExtracted_shouldReturnValueGiven() {
+        #expect(String(URLPath("api/v1/login/ticket")) == "api/v1/login/ticket")
+    }
+}


### PR DESCRIPTION
## Problem

* `Endpoint` returned only a URL. Both call sites hand-built their `URLRequest`, and the profile fetch relied on the implicit GET.
* The request's parts (method, path, media type) were loose primitives with no single builder, so every future feature would re-earn the same guarantees.
* The two rejection log lines carry the status code but not its class, which is the field a remote log destination facets on.

## Solution

* `HTTPRequest` describes one request and is the app's one `URLRequest` builder. Its nine per-method constructors decide which methods carry a body, so a GET cannot gain one anywhere.
* `HTTPBody` couples the content bytes to their `MediaType` (`.application.json`) and writes body and Content-Type together, so the header cannot drift from the data. `URLPath` types the path.
* `Endpoint` becomes a `package` catalog conforming to `HTTPRequestConvertible`, which derives the builder. Each case states its whole wire contract in one line, and `profile` is renamed `ticket`, the backend's handler name for this route:

```swift
package enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
    case login(body: Data)
    case ticket

    package var request: HTTPRequest {
        switch self {
        case let .login(body):
            .post(Self.loginTicketPath, body: .json(body))
        case .ticket:
            .get(Self.loginTicketPath)
        }
    }

    private static let loginTicketPath: URLPath = "api/v1/login/ticket"
}
```

* Rider: the two rejection log lines gain `statusCategory` beside `statusCode` (`statusCode=503 statusCategory=serverError`), mapped by an explicit, test-pinned switch, never reflection.

## Notes

* `urlRequest()` with no argument builds against the configured API's base URL (`\.apiConfiguration`, resolved at call time); both live closures use it. The explicit `urlRequest(baseURL:)` stays the pure form that unit tests use.
* Wire behavior is unchanged and pinned: integration tests assert the login POST's path, Content-Type and body, and the ticket fetch's GET and path, through the transport spy.
* A header modifier, query items, and a per-request base URL override are designed to slot in as additive modifiers on `HTTPRequest`; each lands with its first consumer.

## How to test

* `git fetch && git checkout feat/endpoint-owns-request`
* `cd Packages/AuthenticationFeature && swift test` (170 tests, 32 suites)
