### PR TITLE
feat(AuthenticationFeature): configure and guard the live transport

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Live.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 extension HTTPClient {
+    /// The composed client the app uses: transport, transport logging,
+    /// session-expiry interception and bearer attachment.
+    ///
+    /// - Parameters:
+    ///   - urlSession: The transport session. Defaults to the configured API
+    ///     session; a test passes a stubbed one.
+    ///   - onSessionExpiry: Called when a bearer-carrying request gets a 401.
     public static func live(
         urlSession: URLSession = .api,
         onSessionExpiry: @escaping @Sendable () async -> Void

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Live.swift
@@ -1,6 +1,11 @@
+import Foundation
+
 extension HTTPClient {
-    public static func live(onSessionExpiry: @escaping @Sendable () async -> Void) -> HTTPClient {
-        urlSession()
+    public static func live(
+        urlSession: URLSession = .api,
+        onSessionExpiry: @escaping @Sendable () async -> Void
+    ) -> HTTPClient {
+        HTTPClient.urlSession(urlSession)
             .logging()
             .interceptingSessionExpiry(onExpiry: onSessionExpiry)
             .authenticated()

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+URLSession.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+URLSession.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension HTTPClient {
-    package static func urlSession(_ session: URLSession = .shared) -> HTTPClient {
+    package static func urlSession(_ session: URLSession) -> HTTPClient {
         HTTPClient { request in
             let (data, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse else {

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/URLSession+API.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/URLSession+API.swift
@@ -3,7 +3,7 @@ import Foundation
 extension URLSession {
     /// The session for API calls: bounded waits, and no cached copies of
     /// bearer-fetched responses.
-    package static let api: URLSession = {
+    public static let api: URLSession = {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 30
         configuration.timeoutIntervalForResource = 30

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/URLSession+API.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/URLSession+API.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 extension URLSession {
-    /// The session for API calls: bounded waits, and no cached copies of
-    /// bearer-fetched responses.
+    /// The session for API calls: bounded waits, and no response caching.
     public static let api: URLSession = {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 30

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/URLSession+API.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/URLSession+API.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension URLSession {
+    /// The session for API calls: bounded waits, and no cached copies of
+    /// bearer-fetched responses.
+    package static let api: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 30
+        configuration.urlCache = nil
+        return URLSession(configuration: configuration)
+    }()
+}

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
@@ -81,6 +81,30 @@ struct HTTPClientURLSessionTests {
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer jwt-abc-123")
     }
 
+    @Test func whenBearerRequestGets401_shouldReportSessionExpiry() async throws {
+        URLProtocolStub.stub(
+            data: Data(),
+            response: try #require(
+                HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
+            ),
+            error: nil
+        )
+        let store = InMemorySessionStore(stored: Session(token: try SessionToken("jwt-abc-123")))
+
+        try await confirmation("session expiry reported") { expired in
+            _ = try await withDependencies {
+                $0.log = LogRecorder().log
+                $0.sessionStore = store.sessionStore
+            } operation: {
+                let sut = HTTPClient.live(
+                    urlSession: URLProtocolStub.session(),
+                    onSessionExpiry: { expired() }
+                )
+                return try await sut.send(URLRequest(url: url))
+            }
+        }
+    }
+
     @Test func whenServerResponds_shouldReturnDataAndHTTPResponse() async throws {
         let expected = Data("hello".utf8)
         URLProtocolStub.stub(

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
@@ -58,6 +58,29 @@ struct HTTPClientURLSessionTests {
         #expect(recorder.events.count == 1)
     }
 
+    @Test func whenSessionExists_shouldSendBearerThroughLiveChain() async throws {
+        URLProtocolStub.lastRequest = nil
+        URLProtocolStub.stub(
+            data: Data(),
+            response: try #require(
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            ),
+            error: nil
+        )
+        let store = InMemorySessionStore(stored: Session(token: try SessionToken("jwt-abc-123")))
+
+        _ = try await withDependencies {
+            $0.log = LogRecorder().log
+            $0.sessionStore = store.sessionStore
+        } operation: {
+            let sut = HTTPClient.live(urlSession: URLProtocolStub.session(), onSessionExpiry: {})
+            return try await sut.send(URLRequest(url: url))
+        }
+
+        let request = try #require(URLProtocolStub.lastRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer jwt-abc-123")
+    }
+
     @Test func whenServerResponds_shouldReturnDataAndHTTPResponse() async throws {
         let expected = Data("hello".utf8)
         URLProtocolStub.stub(

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
@@ -3,8 +3,8 @@ import Dependencies
 import Foundation
 import Testing
 
-/// Everything that touches `URLProtocolStub`'s shared state lives here, unit and wiring
-/// alike: `.serialized` only serializes within one suite.
+// Everything that touches URLProtocolStub's shared state lives here, unit and wiring
+// alike: .serialized only serializes within one suite.
 @Suite(.serialized)
 struct HTTPClientURLSessionTests {
     private let url: URL

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
@@ -36,6 +36,28 @@ struct HTTPClientURLSessionTests {
         #expect(response.statusCode == 200)
     }
 
+    @Test func whenLiveChainGetsResponse_shouldLogExactlyOnce() async throws {
+        URLProtocolStub.stub(
+            data: Data(),
+            response: try #require(
+                HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)
+            ),
+            error: nil
+        )
+        let recorder = LogRecorder()
+        let store = InMemorySessionStore()
+
+        _ = try await withDependencies {
+            $0.log = recorder.log
+            $0.sessionStore = store.sessionStore
+        } operation: {
+            let sut = HTTPClient.live(urlSession: URLProtocolStub.session(), onSessionExpiry: {})
+            return try await sut.send(URLRequest(url: url))
+        }
+
+        #expect(recorder.events.count == 1)
+    }
+
     @Test func whenServerResponds_shouldReturnDataAndHTTPResponse() async throws {
         let expected = Data("hello".utf8)
         URLProtocolStub.stub(

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientURLSessionTests.swift
@@ -1,13 +1,39 @@
 import AuthenticationFeature
+import Dependencies
 import Foundation
 import Testing
 
+/// Everything that touches `URLProtocolStub`'s shared state lives here, unit and wiring
+/// alike: `.serialized` only serializes within one suite.
 @Suite(.serialized)
 struct HTTPClientURLSessionTests {
     private let url: URL
 
     init() throws {
         url = try #require(URL(string: "https://example.com"))
+    }
+
+    @Test func whenLiveChainSendsRequest_shouldReturnServerResponse() async throws {
+        let expected = Data("pong".utf8)
+        URLProtocolStub.stub(
+            data: expected,
+            response: try #require(
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            ),
+            error: nil
+        )
+        let store = InMemorySessionStore()
+
+        let (data, response) = try await withDependencies {
+            $0.log = LogRecorder().log
+            $0.sessionStore = store.sessionStore
+        } operation: {
+            let sut = HTTPClient.live(urlSession: URLProtocolStub.session(), onSessionExpiry: {})
+            return try await sut.send(URLRequest(url: url))
+        }
+
+        #expect(data == expected)
+        #expect(response.statusCode == 200)
     }
 
     @Test func whenServerResponds_shouldReturnDataAndHTTPResponse() async throws {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLProtocolStub.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLProtocolStub.swift
@@ -9,6 +9,9 @@ final class URLProtocolStub: URLProtocol {
 
     nonisolated(unsafe) static var stub: Stub?
 
+    /// The request the stub most recently served.
+    nonisolated(unsafe) static var lastRequest: URLRequest?
+
     static func stub(data: Data?, response: URLResponse?, error: Error?) {
         stub = Stub(data: data, response: response, error: error)
     }
@@ -23,6 +26,7 @@ final class URLProtocolStub: URLProtocol {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
+        Self.lastRequest = request
         if let error = Self.stub?.error {
             client?.urlProtocol(self, didFailWithError: error)
         } else {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLProtocolStub.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLProtocolStub.swift
@@ -9,7 +9,7 @@ final class URLProtocolStub: URLProtocol {
 
     nonisolated(unsafe) static var stub: Stub?
 
-    /// The request the stub most recently served.
+    // The request the stub most recently served.
     nonisolated(unsafe) static var lastRequest: URLRequest?
 
     static func stub(data: Data?, response: URLResponse?, error: Error?) {

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLSessionAPITests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLSessionAPITests.swift
@@ -3,19 +3,19 @@ import Foundation
 import Testing
 
 @Suite struct URLSessionAPITests {
-    @Test func whenSessionIsConfigured_shouldBoundRequestWaitsToThirtySeconds() {
+    @Test func whenAPISessionIsConfigured_shouldBoundRequestWaitsToThirtySeconds() {
         #expect(URLSession.api.configuration.timeoutIntervalForRequest == 30)
     }
 
-    @Test func whenSessionIsConfigured_shouldBoundWholeTransfersToThirtySeconds() {
+    @Test func whenAPISessionIsConfigured_shouldBoundWholeTransfersToThirtySeconds() {
         #expect(URLSession.api.configuration.timeoutIntervalForResource == 30)
     }
 
-    @Test func whenSessionIsConfigured_shouldKeepNoURLCache() {
+    @Test func whenAPISessionIsConfigured_shouldKeepNoURLCache() {
         #expect(URLSession.api.configuration.urlCache == nil)
     }
 
-    @Test func whenSessionIsConfigured_shouldFailFastWithoutConnectivity() {
+    @Test func whenAPISessionIsConfigured_shouldFailFastWithoutConnectivity() {
         #expect(URLSession.api.configuration.waitsForConnectivity == false)
     }
 }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLSessionAPITests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLSessionAPITests.swift
@@ -1,0 +1,21 @@
+import AuthenticationFeature
+import Foundation
+import Testing
+
+@Suite struct URLSessionAPITests {
+    @Test func whenSessionIsConfigured_shouldBoundRequestWaitsToThirtySeconds() {
+        #expect(URLSession.api.configuration.timeoutIntervalForRequest == 30)
+    }
+
+    @Test func whenSessionIsConfigured_shouldBoundWholeTransfersToThirtySeconds() {
+        #expect(URLSession.api.configuration.timeoutIntervalForResource == 30)
+    }
+
+    @Test func whenSessionIsConfigured_shouldKeepNoURLCache() {
+        #expect(URLSession.api.configuration.urlCache == nil)
+    }
+
+    @Test func whenSessionIsConfigured_shouldFailFastWithoutConnectivity() {
+        #expect(URLSession.api.configuration.waitsForConnectivity == false)
+    }
+}


### PR DESCRIPTION
## Problem

* `HTTPClient.live` hardcoded `URLSession.shared`, so no test could drive the composed chain: deleting `.logging()` from `live` left every test green.
* The shared session brings a shared URL cache and unbounded resource waits, neither of which an API client wants.

## Solution

* `URLSession.api`: one configured session for API calls. Both timeouts bound to 30 seconds, URL cache off, connectivity waiting off (both operations are user-initiated; a fast failure beats a silent wait). Four tests pin the contract.
* `live` gains `urlSession: URLSession = .api`, so the app picks up the configured session with no call-site change, and a test can push a `URLProtocolStub`-backed session through the real chain:

```swift
public static func live(
    urlSession: URLSession = .api,
    onSessionExpiry: @escaping @Sendable () async -> Void
) -> HTTPClient
```

* Three wiring tests now guard the chain: removing `.logging()`, `.authenticated()`, or `.interceptingSessionExpiry` each turns exactly one test red. Every guard was proved by deliberately removing its decorator and watching it fail.

## Notes

* `urlSession(_:)` loses its `.shared` default: `live` was its only defaulted caller, and a bare call would silently bypass the configured session.
* The wiring tests live in the existing serialized suite because `.serialized` only serializes within one suite, and `URLProtocolStub`'s state is shared.

## How to test

* `git fetch && git checkout feat/configured-transport`
* `cd Packages/AuthenticationFeature && swift test` (179 tests, 33 suites)
