### PR TITLE
fix(AuthenticationUI): make the failure copy warm, and tell VoiceOver the truth

### DIFF
--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountDetailView/AccountDetailView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountDetailView/AccountDetailView.swift
@@ -35,7 +35,7 @@ package struct AccountDetailView: View {
             }
 
             Section {
-                LabeledContent("Email") {
+                LabeledContent("Email address") {
                     Text(verbatim: profile.emailAddress)
                 }
                 LabeledContent("Ticket Reference") {

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountDetailView/AccountDetailView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/AccountDetailView/AccountDetailView.swift
@@ -38,7 +38,7 @@ package struct AccountDetailView: View {
                 LabeledContent("Email address") {
                     Text(verbatim: profile.emailAddress)
                 }
-                LabeledContent("Ticket Reference") {
+                LabeledContent("Ticket reference") {
                     Text(verbatim: profile.ticketReference)
                 }
             }

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Barcode/Barcode.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/DesignSystem/Barcode/Barcode.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// Barcode(.qr(slug))
 /// Barcode(.code128("ABCD-1"))
 /// Barcode(image: savedPass)
-/// Barcode(url: remoteCode) { Text("Couldn't load") }
+/// Barcode(url: remoteCode) { Text("We can't load the code") }
 /// ```
 ///
 /// The view keeps the code readable: it never smooths pixels when scaling up, and never
@@ -142,7 +142,7 @@ package extension Barcode where Placeholder == EmptyView, Failure == EmptyView {
 
 #Preview("Cannot encode") {
     Barcode(.code128("café-ticket-✓")) {
-        Label("Couldn't make a code", systemImage: "exclamationmark.triangle")
+        Label("We can't show the code", systemImage: "exclamationmark.triangle")
     }
     .frame(width: 220, height: 80)
     .padding()

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCardContent.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/ProfileCard/ProfileCardContent.swift
@@ -65,7 +65,7 @@ package struct ProfileCardContent: View {
 
     private var failed: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("We couldn't load your account.")
+            Text("We can't load your account just now.")
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView.swift
@@ -27,7 +27,7 @@ public struct SignInView: View {
                 TextField("Ticket reference", text: $viewModel.ticketReference)
                     .ticketReferenceFieldStyle()
             } header: {
-                Text("Ticket Reference")
+                Text("Ticket reference")
             } footer: {
                 Text("You'll find it in your confirmation email. It looks like ABCD-1.")
                     .font(.footnote)

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/SignInView/SignInView.swift
@@ -29,14 +29,16 @@ public struct SignInView: View {
             } header: {
                 Text("Ticket Reference")
             } footer: {
-                Text("It's in your confirmation email - for example, 'ABCD-1'")
+                Text("You'll find it in your confirmation email. It looks like ABCD-1.")
                     .font(.footnote)
             }
 
             if case .failed(.invalidCredentials) = viewModel.phase {
                 Section {
-                    Text("We couldn't find a ticket for that email and reference. Please check them and try again.")
-                        .foregroundStyle(.red)
+                    Text(
+                        "We can't find a ticket for that email address and ticket reference. Check them and try again."
+                    )
+                    .foregroundStyle(.red)
                 }
             }
 
@@ -57,15 +59,15 @@ public struct SignInView: View {
             }
         }
         .disabled(viewModel.isSubmitting)
-        .alert("Can't connect", isPresented: presenting(.cannotConnect)) {
+        .alert("We can't connect", isPresented: presenting(.cannotConnect)) {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Check your connection and try again.")
         }
-        .alert("Something went wrong", isPresented: presenting(.unexpected)) {
+        .alert("We can't sign you in", isPresented: presenting(.unexpected)) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Please try again.")
+            Text("Something went wrong at our end. Try again in a moment.")
         }
     }
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketCode.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketCode.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+/// An attendee's ticket code: drawn and ready to scan, or missing.
+package enum TicketCode {
+    case drawn(Image)
+    case unavailable
+
+    /// Creates the drawn code, or `unavailable` when `content` cannot be encoded.
+    @MainActor package init(drawing content: BarcodeContent) {
+        self = content.makeImage()
+            .map { .drawn(Image(decorative: $0, scale: 1)) }
+            ?? .unavailable
+    }
+}

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketCode.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketCode.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
 /// An attendee's ticket code: drawn and ready to scan, or missing.
-package enum TicketCode {
+enum TicketCode {
     case drawn(Image)
     case unavailable
 
     /// Creates the drawn code, or `unavailable` when `content` cannot be encoded.
-    @MainActor package init(drawing content: BarcodeContent) {
+    @MainActor init(drawing content: BarcodeContent) {
         self = content.makeImage()
             .map { .drawn(Image(decorative: $0, scale: 1)) }
             ?? .unavailable

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketView.swift
@@ -70,9 +70,15 @@ package struct TicketView: View {
     }
 
     private var unreadable: some View {
-        Label("We couldn't draw your code.", systemImage: "exclamationmark.triangle")
-            .foregroundStyle(.secondary)
-            .padding()
+        VStack(spacing: 8) {
+            Label("We can't show your QR code", systemImage: "exclamationmark.triangle")
+
+            Text("Show your ticket reference to a member of staff and they'll check you in.")
+                .font(.footnote)
+        }
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .padding()
     }
 }
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketView.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketView.swift
@@ -23,28 +23,12 @@ package struct TicketView: View {
 
     package var body: some View {
         NavigationStack {
-            VStack(spacing: 24) {
-                Spacer(minLength: 0)
-
-                Barcode(.qr(QRCode.Payload(String(slug)))) {
-                    unreadable
+            TicketViewContent(code: code, reference: reference, name: name)
+                .navigationTitle("Ticket")
+                .inlineNavigationTitle()
+                .toolbar {
+                    Button("Done") { dismiss() }
                 }
-                .frame(maxWidth: 320)
-                .accessibilityElement()
-                .accessibilityLabel("QR code")
-                .accessibilityHint("Hold this up to be scanned")
-
-                identity
-
-                Spacer(minLength: 0)
-            }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .navigationTitle("Ticket")
-            .inlineNavigationTitle()
-            .toolbar {
-                Button("Done") { dismiss() }
-            }
         }
         .presentationDragIndicator(.visible)
         .onAppear { viewModel.beginDisplaying() }
@@ -58,27 +42,8 @@ package struct TicketView: View {
         }
     }
 
-    private var identity: some View {
-        VStack(spacing: 4) {
-            Text(verbatim: reference)
-                .font(.title2.weight(.semibold).monospaced())
-                .textSelection(.enabled)
-
-            Text(name.formatted())
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private var unreadable: some View {
-        VStack(spacing: 8) {
-            Label("We can't show your QR code", systemImage: "exclamationmark.triangle")
-
-            Text("Show your ticket reference to a member of staff and they'll check you in.")
-                .font(.footnote)
-        }
-        .foregroundStyle(.secondary)
-        .multilineTextAlignment(.center)
-        .padding()
+    @MainActor private var code: TicketCode {
+        TicketCode(drawing: .qr(QRCode.Payload(String(slug))))
     }
 }
 
@@ -92,10 +57,12 @@ private extension View {
     }
 }
 
+#if DEBUG
 #Preview {
     TicketView(
-        slug: try! TicketSlug("ti_pxqFKr9pPWd6VeYKvMBKpjQ"),
-        reference: "YZHI-1",
-        name: PersonNameComponents(givenName: "Paul", familyName: "Willis")
+        slug: Profile.preview.ticketSlug,
+        reference: Profile.preview.ticketReference,
+        name: Profile.preview.name
     )
 }
+#endif

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketViewContent.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketViewContent.swift
@@ -3,18 +3,18 @@ import Foundation
 import SwiftUI
 
 /// The ticket screen's body: the code when it drew, and the way forward when it did not.
-package struct TicketViewContent: View {
+struct TicketViewContent: View {
     private let code: TicketCode
     private let reference: String
     private let name: PersonNameComponents
 
-    package init(code: TicketCode, reference: String, name: PersonNameComponents) {
+    init(code: TicketCode, reference: String, name: PersonNameComponents) {
         self.code = code
         self.reference = reference
         self.name = name
     }
 
-    package var body: some View {
+    var body: some View {
         VStack(spacing: 24) {
             Spacer(minLength: 0)
 

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketViewContent.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketViewContent.swift
@@ -1,0 +1,84 @@
+import AuthenticationFeature
+import Foundation
+import SwiftUI
+
+/// The ticket screen's body: the code when it drew, and the way forward when it did not.
+package struct TicketViewContent: View {
+    private let code: TicketCode
+    private let reference: String
+    private let name: PersonNameComponents
+
+    package init(code: TicketCode, reference: String, name: PersonNameComponents) {
+        self.code = code
+        self.reference = reference
+        self.name = name
+    }
+
+    package var body: some View {
+        VStack(spacing: 24) {
+            Spacer(minLength: 0)
+
+            ticketCode
+
+            identity
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+    }
+
+    @ViewBuilder private var ticketCode: some View {
+        switch code {
+        case .drawn(let image):
+            Barcode(image: image)
+                .frame(maxWidth: 320)
+                .accessibilityElement()
+                .accessibilityLabel("Ticket QR code")
+                .accessibilityHint("Hold this up to be scanned")
+        case .unavailable:
+            unavailable
+        }
+    }
+
+    private var identity: some View {
+        VStack(spacing: 4) {
+            Text(verbatim: reference)
+                .font(.title2.weight(.semibold).monospaced())
+                .textSelection(.enabled)
+
+            Text(name.formatted())
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var unavailable: some View {
+        VStack(spacing: 8) {
+            Label("We can't show your QR code", systemImage: "exclamationmark.triangle")
+
+            Text("Show your ticket reference to a member of staff and they'll check you in.")
+                .font(.footnote)
+        }
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .padding()
+    }
+}
+
+#if DEBUG
+#Preview("Ready to scan") {
+    TicketViewContent(
+        code: TicketCode(drawing: .qr(QRCode.Payload(String(Profile.preview.ticketSlug)))),
+        reference: Profile.preview.ticketReference,
+        name: Profile.preview.name
+    )
+}
+
+#Preview("Code will not draw") {
+    TicketViewContent(
+        code: .unavailable,
+        reference: Profile.preview.ticketReference,
+        name: Profile.preview.name
+    )
+}
+#endif

--- a/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketViewContent.swift
+++ b/Packages/AuthenticationUI/Sources/AuthenticationUI/TicketView/TicketViewContent.swift
@@ -46,6 +46,7 @@ package struct TicketViewContent: View {
             Text(verbatim: reference)
                 .font(.title2.weight(.semibold).monospaced())
                 .textSelection(.enabled)
+                .accessibilityLabel("Ticket reference \(reference)")
 
             Text(name.formatted())
                 .foregroundStyle(.secondary)


### PR DESCRIPTION
## Problem

* Failure messages were dead ends. "We couldn't draw your code." named a problem with no way forward, and "Something went wrong" was vaguest at the moment clarity mattered most.
* A VoiceOver user was told to hold up a QR code that had failed to draw, and never heard the failure at all. The label and hint sat outside the `Barcode`, so they applied whichever branch rendered.
* Terminology was split across screens: "Email" here, "Email address" there, and a hyphen standing in for an em dash in the ticket reference hint.

## Solution

* Every failure now says who could not do what, then gives the next step. "We can't show your QR code" plus "Show your ticket reference to a member of staff and they'll check you in."
* `TicketCode` holds either the drawn image or `unavailable`, and `TicketViewContent` switches on it. The code carries the "Ticket QR code" label and the hint; the failure carries its own text. The ticket reference gained a label, so VoiceOver stops reading it as an opaque token.
* Labels standardised on "Email address" and sentence case throughout. Title Case is now for buttons and navigation only.