### PR TITLE
fix(SwiftLeeds): link the LogKit product again

### DIFF
--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -98,7 +98,7 @@
 		A11CE57000000000000000D7 /* NetworkKit in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C7 /* NetworkKit */; };
 		A11CE57000000000000000D3 /* SecureStorageKit in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C3 /* SecureStorageKit */; };
 		A11CE57000000000000000D4 /* SecureStorageKitKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C4 /* SecureStorageKitKeychain */; };
-		A11CE57000000000000000D5 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C5 /* Dependencies */; };
+		A11CE57000000000000000D8 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = A11CE57000000000000000C8 /* Dependencies */; };
 		7B31C8F32ED0AB0E00FEEDF7 /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 7B31C8F22ED0AB0E00FEEDF7 /* Settings */; };
 		7B31C8F52ED0AB1600FEEDF7 /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 7B31C8F42ED0AB1600FEEDF7 /* Settings */; };
 		7B6278A22EEDDE1B00DE1473 /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6278A12EEDDE1B00DE1473 /* SectionHeader.swift */; };
@@ -345,7 +345,7 @@
 				A11CE57000000000000000D7 /* NetworkKit in Frameworks */,
 				A11CE57000000000000000D3 /* SecureStorageKit in Frameworks */,
 				A11CE57000000000000000D4 /* SecureStorageKitKeychain in Frameworks */,
-				A11CE57000000000000000D5 /* Dependencies in Frameworks */,
+				A11CE57000000000000000D8 /* Dependencies in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -732,7 +732,7 @@
 				A11CE57000000000000000C7 /* NetworkKit */,
 				A11CE57000000000000000C3 /* SecureStorageKit */,
 				A11CE57000000000000000C4 /* SecureStorageKitKeychain */,
-				A11CE57000000000000000C5 /* Dependencies */,
+				A11CE57000000000000000C8 /* Dependencies */,
 			);
 			productName = SwiftLeeds;
 			productReference = AECB295327417F9D00CDC983 /* SwiftLeeds.app */;
@@ -2041,7 +2041,7 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = SecureStorageKitKeychain;
 		};
-		A11CE57000000000000000C5 /* Dependencies */ = {
+		A11CE57000000000000000C8 /* Dependencies */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = A11CE57000000000000000E1 /* XCRemoteSwiftPackageReference "swift-dependencies" */;
 			productName = Dependencies;


### PR DESCRIPTION
## Problem

* Two objects in the Xcode project share the id `A11CE57000000000000000C5`, and two more share `A11CE57000000000000000D5`.
* A project file is a property list, so a duplicate key is undefined. The parser keeps the last definition and drops the first.
* The app target therefore linked the `Dependencies` product twice and never linked `LogKit`, even though three app files import it.

## Solution

* Give the `Dependencies` product dependency and its build file fresh ids, `...C8` and `...D8`.
* `C1` to `C7` stay a contiguous series for the local package products, with `Dn` as each one's build file.

## How to test

```bash
git fetch && git checkout fix/pbxproj-duplicate-object-ids
```

Count the objects the parser actually keeps:

```bash
plutil -convert json -o /tmp/p.json SwiftLeeds.xcodeproj/project.pbxproj
python3 -c "
import json, re
n = len(json.load(open('/tmp/p.json'))['objects'])
lines = sum(1 for l in open('SwiftLeeds.xcodeproj/project.pbxproj') if re.match(r'\t\t[A-F0-9]{24}[ =]', l))
print('lines', lines, 'keys', n, 'lost', lines - n)
"
```

On `main` this prints `lost 2`. On this branch it prints `lost 0`.

Then build:

```bash
xcodebuild build -project SwiftLeeds.xcodeproj -scheme SwiftLeeds \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -derivedDataPath /tmp/dd CODE_SIGNING_ALLOWED=NO
```
