### PR TITLE
refactor(NetworkKit): rename HTTPBody to HTTPContent

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
@@ -9,7 +9,7 @@ package enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
     package var request: HTTPRequest {
         switch self {
         case let .login(body):
-            .post(Self.loginTicketPath, body: .json(body))
+            .post(Self.loginTicketPath, content: .json(body))
         case .ticket:
             .get(Self.loginTicketPath)
         }

--- a/Packages/NetworkKit/Sources/NetworkKit/HTTPContent.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/HTTPContent.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// A request's content, paired with the media type that describes it.
-public struct HTTPBody: Equatable, Hashable, Sendable {
+public struct HTTPContent: Equatable, Hashable, Sendable {
     private let data: Data
     private let mediaType: MediaType
 
-    public static func json(_ data: Data) -> HTTPBody {
-        HTTPBody(data: data, mediaType: .application.json)
+    public static func json(_ data: Data) -> HTTPContent {
+        HTTPContent(data: data, mediaType: .application.json)
     }
 
     /// Writes the content and its Content-Type header onto the request.

--- a/Packages/NetworkKit/Sources/NetworkKit/HTTPRequest.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/HTTPRequest.swift
@@ -2,47 +2,47 @@ import Foundation
 
 /// One HTTP request, described by its method, path and content.
 ///
-/// The constructors follow RFC 9110's content semantics: a method with no
-/// defined content takes no body, so a GET cannot carry one.
+/// The constructors follow RFC 9110's content semantics: only `post`, `put`
+/// and `patch` take content, so a GET cannot carry any.
 public struct HTTPRequest: Equatable, Hashable, Sendable {
     private let method: HTTPMethod
     private let path: URLPath
-    private let body: HTTPBody?
+    private let content: HTTPContent?
 
     public static func get(_ path: URLPath) -> HTTPRequest {
-        HTTPRequest(method: .get, path: path, body: nil)
+        HTTPRequest(method: .get, path: path, content: nil)
     }
 
     public static func head(_ path: URLPath) -> HTTPRequest {
-        HTTPRequest(method: .head, path: path, body: nil)
+        HTTPRequest(method: .head, path: path, content: nil)
     }
 
-    public static func post(_ path: URLPath, body: HTTPBody) -> HTTPRequest {
-        HTTPRequest(method: .post, path: path, body: body)
+    public static func post(_ path: URLPath, content: HTTPContent) -> HTTPRequest {
+        HTTPRequest(method: .post, path: path, content: content)
     }
 
-    public static func put(_ path: URLPath, body: HTTPBody) -> HTTPRequest {
-        HTTPRequest(method: .put, path: path, body: body)
+    public static func put(_ path: URLPath, content: HTTPContent) -> HTTPRequest {
+        HTTPRequest(method: .put, path: path, content: content)
     }
 
     public static func delete(_ path: URLPath) -> HTTPRequest {
-        HTTPRequest(method: .delete, path: path, body: nil)
+        HTTPRequest(method: .delete, path: path, content: nil)
     }
 
     public static func connect(_ path: URLPath) -> HTTPRequest {
-        HTTPRequest(method: .connect, path: path, body: nil)
+        HTTPRequest(method: .connect, path: path, content: nil)
     }
 
     public static func options(_ path: URLPath) -> HTTPRequest {
-        HTTPRequest(method: .options, path: path, body: nil)
+        HTTPRequest(method: .options, path: path, content: nil)
     }
 
     public static func trace(_ path: URLPath) -> HTTPRequest {
-        HTTPRequest(method: .trace, path: path, body: nil)
+        HTTPRequest(method: .trace, path: path, content: nil)
     }
 
-    public static func patch(_ path: URLPath, body: HTTPBody) -> HTTPRequest {
-        HTTPRequest(method: .patch, path: path, body: body)
+    public static func patch(_ path: URLPath, content: HTTPContent) -> HTTPRequest {
+        HTTPRequest(method: .patch, path: path, content: content)
     }
 
     /// Builds the `URLRequest` this value describes.
@@ -51,7 +51,7 @@ public struct HTTPRequest: Equatable, Hashable, Sendable {
     public func urlRequest(baseURL: URL) -> URLRequest {
         var request = URLRequest(url: baseURL.appending(path: String(path)))
         request.httpMethod = method.rawValue
-        body?.attach(to: &request)
+        content?.attach(to: &request)
         return request
     }
 }

--- a/Packages/NetworkKit/Tests/NetworkKitTests/HTTPContentTests.swift
+++ b/Packages/NetworkKit/Tests/NetworkKitTests/HTTPContentTests.swift
@@ -2,20 +2,20 @@ import Foundation
 import NetworkKit
 import Testing
 
-@Suite struct HTTPBodyTests {
-    @Test func whenJSONBodyIsAttached_shouldCarryBytesGiven() throws {
+@Suite struct HTTPContentTests {
+    @Test func whenJSONContentIsAttached_shouldCarryBytesGiven() throws {
         let bytes = Data(#"{"ticket": "ABCD-12"}"#.utf8)
         var request = try urlRequest()
 
-        HTTPBody.json(bytes).attach(to: &request)
+        HTTPContent.json(bytes).attach(to: &request)
 
         #expect(request.httpBody == bytes)
     }
 
-    @Test func whenJSONBodyIsAttached_shouldDeclareJSONContentType() throws {
+    @Test func whenJSONContentIsAttached_shouldDeclareJSONContentType() throws {
         var request = try urlRequest()
 
-        HTTPBody.json(Data()).attach(to: &request)
+        HTTPContent.json(Data()).attach(to: &request)
 
         #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
     }

--- a/Packages/NetworkKit/Tests/NetworkKitTests/HTTPRequestTests.swift
+++ b/Packages/NetworkKit/Tests/NetworkKitTests/HTTPRequestTests.swift
@@ -29,23 +29,23 @@ import Testing
     }
 
     @Test func whenPOSTIsBuilt_shouldUsePOSTMethod() throws {
-        let request = try HTTPRequest.post("api/v1/login/ticket", body: .json(Data()))
+        let request = try HTTPRequest.post("api/v1/login/ticket", content: .json(Data()))
             .urlRequest(baseURL: baseURL)
 
         #expect(request.httpMethod == "POST")
     }
 
-    @Test func whenPOSTIsBuilt_shouldCarryBodyGiven() throws {
+    @Test func whenPOSTIsBuilt_shouldCarryContentGiven() throws {
         let bytes = Data(#"{"ticket": "ABCD-12"}"#.utf8)
 
-        let request = try HTTPRequest.post("api/v1/login/ticket", body: .json(bytes))
+        let request = try HTTPRequest.post("api/v1/login/ticket", content: .json(bytes))
             .urlRequest(baseURL: baseURL)
 
         #expect(request.httpBody == bytes)
     }
 
     @Test func whenPOSTIsBuilt_shouldDeclareJSONContentType() throws {
-        let request = try HTTPRequest.post("api/v1/login/ticket", body: .json(Data()))
+        let request = try HTTPRequest.post("api/v1/login/ticket", content: .json(Data()))
             .urlRequest(baseURL: baseURL)
 
         #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
@@ -53,7 +53,7 @@ import Testing
 
     private static let path: URLPath = "api/v1/resource"
 
-    private static let bodilessRequests: [(HTTPRequest, String)] = [
+    private static let requestsWithoutContent: [(HTTPRequest, String)] = [
         (.get(path), "GET"),
         (.head(path), "HEAD"),
         (.delete(path), "DELETE"),
@@ -62,14 +62,14 @@ import Testing
         (.trace(path), "TRACE"),
     ]
 
-    private static let bodyCarryingRequests: [(HTTPRequest, String)] = [
-        (.post(path, body: .json(Data())), "POST"),
-        (.put(path, body: .json(Data())), "PUT"),
-        (.patch(path, body: .json(Data())), "PATCH"),
+    private static let requestsWithContent: [(HTTPRequest, String)] = [
+        (.post(path, content: .json(Data())), "POST"),
+        (.put(path, content: .json(Data())), "PUT"),
+        (.patch(path, content: .json(Data())), "PATCH"),
     ]
 
-    @Test(arguments: bodilessRequests)
-    func whenMethodHasNoDefinedContent_shouldBuildWithoutBody(
+    @Test(arguments: requestsWithoutContent)
+    func whenMethodHasNoDefinedContent_shouldBuildWithoutContent(
         request: HTTPRequest,
         token: String
     ) throws {
@@ -79,8 +79,8 @@ import Testing
         #expect(built.httpBody == nil)
     }
 
-    @Test(arguments: bodyCarryingRequests)
-    func whenMethodDefinesContent_shouldBuildWithBody(
+    @Test(arguments: requestsWithContent)
+    func whenMethodDefinesContent_shouldBuildWithContent(
         request: HTTPRequest,
         token: String
     ) throws {


### PR DESCRIPTION
* `HTTPBody` becomes `HTTPContent`. The argument label on `post`, `put` and `patch` follows.

```swift
// before
.post(Self.loginTicketPath, body: .json(body))

// after
.post(Self.loginTicketPath, content: .json(body))
```

* No behaviour changes. The type is still `public`, still pairs bytes with a `MediaType`, and still writes `Content-Type` with the bytes.

## Notes

* `Endpoint.login(body:)` keeps its label. That name is the feature's own vocabulary for the login payload, not NetworkKit's.
