### PR TITLE
refactor(AuthenticationFeature): name the login payload content

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -15,13 +15,13 @@ extension AuthGateway {
             @Dependency(\.httpClient) var httpClient
             @Dependency(\.loginMapper) var loginMapper
 
-            let body: Data
+            let content: Data
             do {
-                body = try JSONEncoder().encode(LoginRequestDTO(credential))
+                content = try JSONEncoder().encode(LoginRequestDTO(credential))
             } catch {
                 throw LoginRequestError.couldNotEncodeRequest(error)
             }
-            let request = Endpoint.login(body: body).urlRequest()
+            let request = Endpoint.login(content: content).urlRequest()
 
             let data: Data
             let response: HTTPURLResponse

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/Endpoint.swift
@@ -3,13 +3,13 @@ import NetworkKit
 
 /// A request to the SwiftLeeds backend, named in the backend's vocabulary.
 package enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
-    case login(body: Data)
+    case login(content: Data)
     case ticket
 
     package var request: HTTPRequest {
         switch self {
-        case let .login(body):
-            .post(Self.loginTicketPath, content: .json(body))
+        case let .login(content):
+            .post(Self.loginTicketPath, content: .json(content))
         case .ticket:
             .get(Self.loginTicketPath)
         }

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EndpointTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/EndpointTests.swift
@@ -5,30 +5,30 @@ import Testing
 
 @Suite struct EndpointTests {
     @Test func whenLoginRequestIsBuilt_shouldPOST() throws {
-        let request = try Endpoint.login(body: Data()).urlRequest(baseURL: baseURL)
+        let request = try Endpoint.login(content: Data()).urlRequest(baseURL: baseURL)
 
         #expect(request.httpMethod == "POST")
     }
 
     @Test func whenLoginRequestIsBuilt_shouldTargetLoginTicketPath() throws {
-        let request = try Endpoint.login(body: Data()).urlRequest(baseURL: baseURL)
+        let request = try Endpoint.login(content: Data()).urlRequest(baseURL: baseURL)
 
         let expected = try #require(URL(string: "https://example.com/api/v1/login/ticket"))
         #expect(request.url == expected)
     }
 
     @Test func whenLoginRequestIsBuilt_shouldDeclareJSONContentType() throws {
-        let request = try Endpoint.login(body: Data()).urlRequest(baseURL: baseURL)
+        let request = try Endpoint.login(content: Data()).urlRequest(baseURL: baseURL)
 
         #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
     }
 
-    @Test func whenLoginRequestIsBuilt_shouldCarryBodyGiven() throws {
-        let body = Data(#"{"ticket": "ABCD-12"}"#.utf8)
+    @Test func whenLoginRequestIsBuilt_shouldCarryContentGiven() throws {
+        let content = Data(#"{"ticket": "ABCD-12"}"#.utf8)
 
-        let request = try Endpoint.login(body: body).urlRequest(baseURL: baseURL)
+        let request = try Endpoint.login(content: content).urlRequest(baseURL: baseURL)
 
-        #expect(request.httpBody == body)
+        #expect(request.httpBody == content)
     }
 
     @Test func whenTicketRequestIsBuilt_shouldGET() throws {
@@ -44,7 +44,7 @@ import Testing
         #expect(request.url == expected)
     }
 
-    @Test func whenTicketRequestIsBuilt_shouldCarryNoBody() throws {
+    @Test func whenTicketRequestIsBuilt_shouldCarryNoContent() throws {
         let request = try Endpoint.ticket.urlRequest(baseURL: baseURL)
 
         #expect(request.httpBody == nil)


### PR DESCRIPTION
* `Endpoint.login(body:)` renamed to `Endpoint.login(content:)`.

```swift
// before
case login(body: Data)
Endpoint.login(body: body).urlRequest()

// after
case login(content: Data)
Endpoint.login(content: content).urlRequest()
```

## Notes

* Test counts unchanged: AuthenticationFeature 124, AuthenticationUI 50.
* `login` keeps the backend's word, per the two-vocabulary rule. Only the payload label changed, and `content` is the HTTP spec's word for it.
* Other names containing "body" are left alone. They refer to a response body or to Foundation's `httpBody`, neither of which this rename covers.
