### PR TITLE
feat(NetworkKit): append query items to a request

### DIFF
--- a/Packages/NetworkKit/Sources/NetworkKit/HTTPRequest.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/HTTPRequest.swift
@@ -8,6 +8,19 @@ public struct HTTPRequest: Equatable, Hashable, Sendable {
     private let method: HTTPMethod
     private let path: URLPath
     private let content: HTTPContent?
+    private let queryItems: [URLQueryItem]
+
+    private init(
+        method: HTTPMethod,
+        path: URLPath,
+        content: HTTPContent?,
+        queryItems: [URLQueryItem] = []
+    ) {
+        self.method = method
+        self.path = path
+        self.content = content
+        self.queryItems = queryItems
+    }
 
     public static func get(_ path: URLPath) -> HTTPRequest {
         HTTPRequest(method: .get, path: path, content: nil)
@@ -45,13 +58,32 @@ public struct HTTPRequest: Equatable, Hashable, Sendable {
         HTTPRequest(method: .patch, path: path, content: content)
     }
 
+    /// Returns a copy carrying the given query items after any it already holds.
+    ///
+    /// - Parameter queryItems: The items to append. An empty array changes nothing.
+    public func appending(queryItems: [URLQueryItem]) -> HTTPRequest {
+        HTTPRequest(
+            method: method,
+            path: path,
+            content: content,
+            queryItems: self.queryItems + queryItems
+        )
+    }
+
     /// Builds the `URLRequest` this value describes.
     ///
     /// - Parameter baseURL: The server root the path is appended to.
     public func urlRequest(baseURL: URL) -> URLRequest {
-        var request = URLRequest(url: baseURL.appending(path: String(path)))
+        var request = URLRequest(url: url(baseURL: baseURL))
         request.httpMethod = method.rawValue
         content?.attach(to: &request)
         return request
+    }
+
+    private func url(baseURL: URL) -> URL {
+        let resource = baseURL.appending(path: String(path))
+        // Foundation appends a bare "?" for an empty array, so the guard is load-bearing.
+        guard !queryItems.isEmpty else { return resource }
+        return resource.appending(queryItems: queryItems)
     }
 }

--- a/Packages/NetworkKit/Tests/NetworkKitTests/HTTPRequestTests.swift
+++ b/Packages/NetworkKit/Tests/NetworkKitTests/HTTPRequestTests.swift
@@ -51,6 +51,75 @@ import Testing
         #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
     }
 
+    @Test func whenNoQueryItemsAreAppended_shouldBuildURLWithoutQuery() throws {
+        let request = try HTTPRequest.get(Self.path)
+            .appending(queryItems: [])
+            .urlRequest(baseURL: baseURL)
+
+        let expected = try #require(URL(string: "https://example.com/api/v1/resource"))
+        #expect(request.url == expected)
+    }
+
+    @Test func whenOneQueryItemIsAppended_shouldBuildURLWithThatQuery() throws {
+        let request = try HTTPRequest.get(Self.path)
+            .appending(queryItems: [URLQueryItem(name: "event", value: "abc")])
+            .urlRequest(baseURL: baseURL)
+
+        let expected = try #require(URL(string: "https://example.com/api/v1/resource?event=abc"))
+        #expect(request.url == expected)
+    }
+
+    @Test func whenSeveralQueryItemsAreAppended_shouldKeepTheirOrder() throws {
+        let request = try HTTPRequest.get(Self.path)
+            .appending(queryItems: [
+                URLQueryItem(name: "a", value: "1"),
+                URLQueryItem(name: "b", value: "2"),
+            ])
+            .urlRequest(baseURL: baseURL)
+
+        let expected = try #require(URL(string: "https://example.com/api/v1/resource?a=1&b=2"))
+        #expect(request.url == expected)
+    }
+
+    @Test func whenQueryItemValueNeedsEncoding_shouldPercentEncodeIt() throws {
+        let request = try HTTPRequest.get(Self.path)
+            .appending(queryItems: [URLQueryItem(name: "q", value: "a b&c=d")])
+            .urlRequest(baseURL: baseURL)
+
+        let expected = try #require(URL(string: "https://example.com/api/v1/resource?q=a%20b%26c%3Dd"))
+        #expect(request.url == expected)
+    }
+
+    @Test func whenQueryItemHasNoValue_shouldBuildURLWithBareName() throws {
+        let request = try HTTPRequest.get(Self.path)
+            .appending(queryItems: [URLQueryItem(name: "flag", value: nil)])
+            .urlRequest(baseURL: baseURL)
+
+        let expected = try #require(URL(string: "https://example.com/api/v1/resource?flag"))
+        #expect(request.url == expected)
+    }
+
+    @Test func whenQueryItemsAreAppendedTwice_shouldCarryBothSets() throws {
+        let request = try HTTPRequest.get(Self.path)
+            .appending(queryItems: [URLQueryItem(name: "a", value: "1")])
+            .appending(queryItems: [URLQueryItem(name: "b", value: "2")])
+            .urlRequest(baseURL: baseURL)
+
+        let expected = try #require(URL(string: "https://example.com/api/v1/resource?a=1&b=2"))
+        #expect(request.url == expected)
+    }
+
+    @Test func whenQueryItemsAreAppendedToPOST_shouldKeepMethodAndContent() throws {
+        let bytes = Data(#"{"ticket": "ABCD-12"}"#.utf8)
+
+        let request = try HTTPRequest.post(Self.path, content: .json(bytes))
+            .appending(queryItems: [URLQueryItem(name: "a", value: "1")])
+            .urlRequest(baseURL: baseURL)
+
+        #expect(request.httpMethod == "POST")
+        #expect(request.httpBody == bytes)
+    }
+
     private static let path: URLPath = "api/v1/resource"
 
     private static let requestsWithoutContent: [(HTTPRequest, String)] = [


### PR DESCRIPTION
## Problem

* `HTTPRequest` cannot express a query string. It carries a method, a path and content, and nothing else.
* The schedule endpoint needs `?event=<uuid>`, so no content view model can move to NetworkKit until this exists.

## Solution

* `HTTPRequest.appending(queryItems:)` takes Foundation's `[URLQueryItem]` and returns a copy. The name echoes `URL.appending(queryItems:)`.

```swift
.get("api/v2/schedule")
    .appending(queryItems: [URLQueryItem(name: "event", value: id.uuidString)])
// https://host/api/v2/schedule?event=<uuid>
```

## Notes

* **An empty array makes Foundation append a bare `?`**, so the builder guards it. Deleting that guard turns three tests red, two of which predate this change.