### PR TITLE
fix(NetworkKit): name the non-HTTP response failure

### DIFF
--- a/Packages/NetworkKit/Sources/NetworkKit/HTTPClient+URLSession.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/HTTPClient+URLSession.swift
@@ -5,7 +5,7 @@ extension HTTPClient {
         HTTPClient { request in
             let (data, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse else {
-                throw URLError(.badServerResponse)
+                throw ResponseError.notHTTP
             }
             return (data, http)
         }

--- a/Packages/NetworkKit/Sources/NetworkKit/HTTPClient.swift
+++ b/Packages/NetworkKit/Sources/NetworkKit/HTTPClient.swift
@@ -2,6 +2,12 @@ import Dependencies
 import Foundation
 
 public struct HTTPClient: Sendable {
+    /// Why a response could not be used.
+    public enum ResponseError: Error, Equatable {
+        /// The transport answered, but not over HTTP.
+        case notHTTP
+    }
+
     public var send: @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     public init(send: @escaping @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)) {

--- a/Packages/NetworkKit/Tests/NetworkKitTests/HTTPClientURLSessionTests.swift
+++ b/Packages/NetworkKit/Tests/NetworkKitTests/HTTPClientURLSessionTests.swift
@@ -29,16 +29,20 @@ struct HTTPClientURLSessionTests {
         #expect(response.statusCode == 200)
     }
 
-    @Test func whenTransportFails_shouldThrow() async {
+    /// The adapter reports what the session reported. It does not wrap or reclassify it, so a
+    /// caller can still tell an offline device from a cancelled task.
+    @Test func whenTransportFails_shouldThrowSessionErrorUnchanged() async {
         URLProtocolStub.stub(data: nil, response: nil, error: URLError(.notConnectedToInternet))
         let sut = HTTPClient.urlSession(URLProtocolStub.session())
 
-        await #expect(throws: (any Error).self) {
+        let thrown = await #expect(throws: URLError.self) {
             _ = try await sut.send(URLRequest(url: url))
         }
+
+        #expect(thrown?.code == .notConnectedToInternet)
     }
 
-    @Test func whenResponseIsNotHTTP_shouldThrow() async {
+    @Test func whenResponseIsNotHTTP_shouldThrowNotHTTP() async {
         URLProtocolStub.stub(
             data: Data(),
             response: URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil),
@@ -46,7 +50,7 @@ struct HTTPClientURLSessionTests {
         )
         let sut = HTTPClient.urlSession(URLProtocolStub.session())
 
-        await #expect(throws: (any Error).self) {
+        await #expect(throws: HTTPClient.ResponseError.notHTTP) {
             _ = try await sut.send(URLRequest(url: url))
         }
     }


### PR DESCRIPTION
## Problem

When `URLSession` returns a response that is not HTTP, the adapter threw `URLError(.badServerResponse)`. That is Foundation's own transport error, so a caller cannot tell a dead network from an unusable response, and a retry decorator would retry a case that can never succeed.

Two tests asserted only `#expect(throws: (any Error).self)`, so they would pass if the adapter threw the wrong error for the wrong case.

## Solution

```swift
public enum ResponseError: Error, Equatable {
    case notHTTP
}
```

Both tests now assert something real: one that `.notHTTP` is thrown, the other that a `URLError` passes through with its code intact.

## How to test

```bash
(cd Packages/NetworkKit && swift test)
```

## Notes

* **The logged reason changes from `badServerResponse` to `notHTTP`.** The level does not. `LoggedHTTPRequestOutcome` keeps its `.badServerResponse` entry, because `URLSession` can still produce that code itself.
* Test count is unchanged at 78. Both changes sharpen existing tests rather than adding.
