### PR TITLE
test(NetworkKit): forget the URLProtocol stub between tests

### DIFF
--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientLiveIntegrationTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/HTTPClientLiveIntegrationTests.swift
@@ -11,7 +11,9 @@ import Testing
 struct HTTPClientLiveIntegrationTests {
     private let url: URL
 
+    // Swift Testing builds a fresh suite per test, so this runs before each one.
     init() throws {
+        URLProtocolStub.removeStub()
         url = try #require(URL(string: "https://example.com"))
     }
 
@@ -61,7 +63,6 @@ struct HTTPClientLiveIntegrationTests {
     }
 
     @Test func whenSessionExists_shouldSendBearerThroughLiveChain() async throws {
-        URLProtocolStub.lastRequest = nil
         URLProtocolStub.stub(
             data: Data(),
             response: try #require(

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLProtocolStub.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/URLProtocolStub.swift
@@ -16,6 +16,12 @@ final class URLProtocolStub: URLProtocol {
         stub = Stub(data: data, response: response, error: error)
     }
 
+    /// Forgets the current stub and the last request, so neither can reach a later test.
+    static func removeStub() {
+        stub = nil
+        lastRequest = nil
+    }
+
     static func session() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [URLProtocolStub.self]

--- a/Packages/NetworkKit/Tests/NetworkKitTests/HTTPClientURLSessionTests.swift
+++ b/Packages/NetworkKit/Tests/NetworkKitTests/HTTPClientURLSessionTests.swift
@@ -8,7 +8,9 @@ import Testing
 struct HTTPClientURLSessionTests {
     private let url: URL
 
+    // Swift Testing builds a fresh suite per test, so this runs before each one.
     init() throws {
+        URLProtocolStub.removeStub()
         url = try #require(URL(string: "https://example.com"))
     }
 

--- a/Packages/NetworkKit/Tests/NetworkKitTests/URLProtocolStub.swift
+++ b/Packages/NetworkKit/Tests/NetworkKitTests/URLProtocolStub.swift
@@ -13,6 +13,11 @@ final class URLProtocolStub: URLProtocol {
         stub = Stub(data: data, response: response, error: error)
     }
 
+    /// Forgets the current stub, so it cannot serve a test that did not set one.
+    static func removeStub() {
+        stub = nil
+    }
+
     static func session() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [URLProtocolStub.self]


### PR DESCRIPTION
## Problem

`URLProtocolStub` keeps its stub in a static with no teardown, in two copies. One test's stub is still there for the next.

## Solution

`removeStub()` on both copies, called from each suite's `init()`. Swift Testing builds a fresh suite per test, so it runs before every one.