### PR TITLE
refactor(AuthenticationFeature): split the plain and authenticating HTTP clients

### DIFF
--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/AuthGateway+Live.swift
@@ -12,7 +12,7 @@ extension AuthGateway {
     /// Throws ``LoginRequestError`` or ``LoginMapper/ResponseError``.
     static var live: AuthGateway {
         AuthGateway { credential in
-            @Dependency(\.httpClient) var httpClient
+            @Dependency(\.authHTTPClient) var httpClient
             @Dependency(\.loginMapper) var loginMapper
 
             let content: Data

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Infrastructure/HTTPClient+Live.swift
@@ -1,5 +1,21 @@
+import Dependencies
 import Foundation
 import NetworkKit
+
+private enum AuthHTTPClientKey: TestDependencyKey {
+    static let testValue = HTTPClient(send: unimplemented("authHTTPClient.send"))
+}
+
+extension DependencyValues {
+    /// The client for requests that carry the signed-in session's bearer.
+    ///
+    /// Public endpoints use `\.httpClient`, which sends no bearer and does not
+    /// sign the user out on a 401.
+    public var authHTTPClient: HTTPClient {
+        get { self[AuthHTTPClientKey.self] }
+        set { self[AuthHTTPClientKey.self] = newValue }
+    }
+}
 
 extension HTTPClient {
     /// The composed client the app uses: transport, transport logging,

--- a/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
+++ b/Packages/AuthenticationFeature/Sources/AuthenticationFeature/Profile/Infrastructure/AttendeeRepository+Live.swift
@@ -5,7 +5,7 @@ import NetworkKit
 extension AttendeeRepository: DependencyKey {
     package static var liveValue: AttendeeRepository {
         AttendeeRepository { () async throws(AttendeeFetchError) -> Attendee in
-            @Dependency(\.httpClient) var httpClient
+            @Dependency(\.authHTTPClient) var httpClient
             @Dependency(\.attendeeMapper) var attendeeMapper
             let request = Endpoint.ticket.urlRequest()
             let data: Data

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryIntegrationTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AttendeeRepositoryIntegrationTests.swift
@@ -10,7 +10,7 @@ import Testing
         let expected = try expectedAttendee()
 
         let attendee = try await withDependencies {
-            $0.httpClient = .responding(with: attendeeJSON(), statusCode: 200)
+            $0.authHTTPClient = .responding(with: attendeeJSON(), statusCode: 200)
         } operation: {
             let sut = AttendeeRepository.liveValue
             return try await sut.fetch()
@@ -22,7 +22,7 @@ import Testing
     @Test func whenServerReturnsUnauthorized_shouldThrowUnauthorized() async throws {
         await #expect(throws: AttendeeFetchError.unauthorized) {
             try await withDependencies {
-                $0.httpClient = .responding(with: attendeeJSON(), statusCode: 401)
+                $0.authHTTPClient = .responding(with: attendeeJSON(), statusCode: 401)
             } operation: {
                 let sut = AttendeeRepository.liveValue
                 return try await sut.fetch()
@@ -33,7 +33,7 @@ import Testing
     @Test func whenServerReturnsOtherStatus_shouldThrowUnknown() async throws {
         await #expect(throws: AttendeeFetchError.unknown) {
             try await withDependencies {
-                $0.httpClient = .responding(with: attendeeJSON(), statusCode: 500)
+                $0.authHTTPClient = .responding(with: attendeeJSON(), statusCode: 500)
             } operation: {
                 let sut = AttendeeRepository.liveValue
                 return try await sut.fetch()
@@ -44,7 +44,7 @@ import Testing
     @Test func whenServerReturnsInvalidJSON_shouldThrowInvalidResponse() async throws {
         await #expect(throws: AttendeeFetchError.invalidResponse) {
             try await withDependencies {
-                $0.httpClient = .responding(with: Data("not json".utf8), statusCode: 200)
+                $0.authHTTPClient = .responding(with: Data("not json".utf8), statusCode: 200)
             } operation: {
                 let sut = AttendeeRepository.liveValue
                 return try await sut.fetch()
@@ -55,7 +55,7 @@ import Testing
     @Test func whenServerReturnsUnparsableTicketReference_shouldThrowInvalidResponse() async throws {
         await #expect(throws: AttendeeFetchError.invalidResponse) {
             try await withDependencies {
-                $0.httpClient = .responding(with: attendeeJSON(reference: "!!!"), statusCode: 200)
+                $0.authHTTPClient = .responding(with: attendeeJSON(reference: "!!!"), statusCode: 200)
             } operation: {
                 let sut = AttendeeRepository.liveValue
                 return try await sut.fetch()
@@ -66,7 +66,7 @@ import Testing
     @Test func whenServerReturnsUnparsableEmailAddress_shouldThrowInvalidResponse() async throws {
         await #expect(throws: AttendeeFetchError.invalidResponse) {
             try await withDependencies {
-                $0.httpClient = .responding(with: attendeeJSON(email: ""), statusCode: 200)
+                $0.authHTTPClient = .responding(with: attendeeJSON(email: ""), statusCode: 200)
             } operation: {
                 let sut = AttendeeRepository.liveValue
                 return try await sut.fetch()
@@ -78,7 +78,7 @@ import Testing
         let recorder = LogRecorder()
 
         try? await withDependencies {
-            $0.httpClient = .responding(with: attendeeJSON(reference: "!!!"), statusCode: 200)
+            $0.authHTTPClient = .responding(with: attendeeJSON(reference: "!!!"), statusCode: 200)
             $0.log = recorder.log
         } operation: {
             let sut = AttendeeRepository.liveValue
@@ -92,7 +92,7 @@ import Testing
         let spy = HTTPClientSpy(respondingWith: attendeeJSON(), statusCode: 200)
 
         _ = try await withDependencies {
-            $0.httpClient = spy.httpClient
+            $0.authHTTPClient = spy.httpClient
         } operation: {
             let sut = AttendeeRepository.liveValue
             return try await sut.fetch()
@@ -108,7 +108,7 @@ import Testing
     @Test func whenTransportFails_shouldThrowCouldNotReachServer() async throws {
         await #expect(throws: AttendeeFetchError.couldNotReachServer) {
             try await withDependencies {
-                $0.httpClient = .failing(with: StubError.transport)
+                $0.authHTTPClient = .failing(with: StubError.transport)
             } operation: {
                 let sut = AttendeeRepository.liveValue
                 return try await sut.fetch()

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayIntegrationTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/AuthGatewayIntegrationTests.swift
@@ -8,7 +8,7 @@ import Testing
 @Suite struct AuthGatewayIntegrationTests {
     @Test func whenServerReturnsJWT_shouldReturnSessionToken() async throws {
         let token = try await withDependencies {
-            $0.httpClient = .responding(with: Data("jwt-abc-123".utf8), statusCode: 200)
+            $0.authHTTPClient = .responding(with: Data("jwt-abc-123".utf8), statusCode: 200)
         } operation: {
             try await AuthGateway.liveValue.authenticate(Credential.fixture)
         }
@@ -19,7 +19,7 @@ import Testing
     @Test func whenServerReturnsUnauthorized_shouldThrowInvalidCredentials() async throws {
         await #expect(throws: SignInError.invalidCredentials) {
             try await withDependencies {
-                $0.httpClient = .responding(with: Data(), statusCode: 401)
+                $0.authHTTPClient = .responding(with: Data(), statusCode: 401)
             } operation: {
                 try await AuthGateway.liveValue.authenticate(Credential.fixture)
             }
@@ -30,7 +30,7 @@ import Testing
     @Test func whenServerReturnsEmptyBody_shouldThrowUnknown() async throws {
         await #expect(throws: SignInError.unknown) {
             try await withDependencies {
-                $0.httpClient = .responding(with: Data(), statusCode: 200)
+                $0.authHTTPClient = .responding(with: Data(), statusCode: 200)
             } operation: {
                 try await AuthGateway.liveValue.authenticate(Credential.fixture)
             }
@@ -40,7 +40,7 @@ import Testing
     @Test func whenRequestCannotReachServer_shouldThrowCouldNotReachServer() async throws {
         await #expect(throws: SignInError.couldNotReachServer) {
             try await withDependencies {
-                $0.httpClient = .failing(with: StubFailure.couldNotBuildResponse)
+                $0.authHTTPClient = .failing(with: StubFailure.couldNotBuildResponse)
             } operation: {
                 try await AuthGateway.liveValue.authenticate(Credential.fixture)
             }
@@ -50,7 +50,7 @@ import Testing
     @Test func whenServerReturnsOtherStatus_shouldThrowUnknown() async throws {
         await #expect(throws: SignInError.unknown) {
             try await withDependencies {
-                $0.httpClient = .responding(with: Data(), statusCode: 500)
+                $0.authHTTPClient = .responding(with: Data(), statusCode: 500)
             } operation: {
                 try await AuthGateway.liveValue.authenticate(Credential.fixture)
             }
@@ -61,7 +61,7 @@ import Testing
         let spy = HTTPClientSpy(respondingWith: Data("jwt".utf8), statusCode: 200)
 
         _ = try await withDependencies {
-            $0.httpClient = spy.httpClient
+            $0.authHTTPClient = spy.httpClient
         } operation: {
             try await AuthGateway.liveValue.authenticate(Credential.fixture)
         }
@@ -77,7 +77,7 @@ import Testing
         let spy = HTTPClientSpy(respondingWith: Data("jwt".utf8), statusCode: 200)
 
         _ = try await withDependencies {
-            $0.httpClient = spy.httpClient
+            $0.authHTTPClient = spy.httpClient
         } operation: {
             try await AuthGateway.liveValue.authenticate(Credential.fixture)
         }
@@ -91,7 +91,7 @@ import Testing
         let recorder = LogRecorder()
 
         try? await withDependencies {
-            $0.httpClient = .failing(with: StubFailure.couldNotBuildResponse).logging()
+            $0.authHTTPClient = .failing(with: StubFailure.couldNotBuildResponse).logging()
             $0.log = recorder.log
         } operation: {
             let sut = AuthGateway.liveValue
@@ -105,7 +105,7 @@ import Testing
         let recorder = LogRecorder()
 
         try? await withDependencies {
-            $0.httpClient = .responding(with: Data(), statusCode: 503)
+            $0.authHTTPClient = .responding(with: Data(), statusCode: 503)
             $0.log = recorder.log
         } operation: {
             let sut = AuthGateway.liveValue

--- a/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
+++ b/Packages/AuthenticationFeature/Tests/AuthenticationFeatureTests/FetchProfileLoggingTests.swift
@@ -53,7 +53,7 @@ import Testing
 
         try await withDependencies {
             $0.log = recorder.log
-            $0.httpClient = .responding(with: try attendeeJSON(reference: "!!!"), statusCode: 200)
+            $0.authHTTPClient = .responding(with: try attendeeJSON(reference: "!!!"), statusCode: 200)
             $0.attendeeRepository = .liveValue
         } operation: {
             let sut = FetchProfile.liveValue.logging()

--- a/SwiftLeeds/App/SwiftLeedsApp.swift
+++ b/SwiftLeeds/App/SwiftLeedsApp.swift
@@ -26,7 +26,8 @@ struct SwiftLeedsApp: App {
                 ?? .none
             $0.secureStorage = .keychain(service: KeychainService("uk.co.swiftleeds.authentication"))
             $0.apiConfiguration = APIConfiguration(baseURL: URL(string: "https://\(ConferenceConfig.apiHost)")!)
-            $0.httpClient = .live(onSessionExpiry: {
+            $0.httpClient = HTTPClient.urlSession(.api).logging()
+            $0.authHTTPClient = .live(onSessionExpiry: {
                 @Dependency(\.signOut) var signOut
                 try? await signOut()
             })


### PR DESCRIPTION
## Problem

One `\.httpClient` serves everything, and it is composed with the bearer and the sign-out interceptor. The content endpoints migrating next are public, so on that client they would:

* send the session token to endpoints that do not need it, putting it in scope for the response cache landing next
* sign the user out if a public endpoint ever returned 401

## Solution

Two clients. `\.httpClient` is plain, `\.authHTTPClient` carries the bearer.

```swift
// SwiftLeedsApp.init
$0.httpClient = HTTPClient.urlSession(.api).logging()
$0.authHTTPClient = .live(onSessionExpiry: { ... })
```

`AuthGateway` and `AttendeeRepository` move to `\.authHTTPClient`. No behaviour changes.

The key is declared in AuthenticationFeature, not NetworkKit, because that is the module that needs it and NetworkKit knows nothing about authentication.

## Notes

* Nothing reads `\.httpClient` yet. The content view models will.