### PR TITLE
refactor(SwiftLeeds): fetch sponsors through NetworkKit

### DIFF
--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		0B4B1A4B2A4858F600ED7EA9 /* SponsorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4B1A4A2A4858F600ED7EA9 /* SponsorsView.swift */; };
 		0B4B1A4D2A486EA800ED7EA9 /* SponsorsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4B1A4C2A486EA800ED7EA9 /* SponsorsViewModel.swift */; };
-		0B4B1A512A48FB6400ED7EA9 /* SponsorsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4B1A4C2A486EA800ED7EA9 /* SponsorsViewModel.swift */; };
 		0B4CB3C828EAF19100246E62 /* SwiftLeedsAppClipApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4CB3C728EAF19100246E62 /* SwiftLeedsAppClipApp.swift */; };
 		0B4CB3CA28EAF19100246E62 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4CB3C928EAF19100246E62 /* ContentView.swift */; };
 		0B4CB3CF28EAF19100246E62 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0B4CB3CE28EAF19100246E62 /* Preview Assets.xcassets */; };
@@ -43,7 +42,6 @@
 		0B59B5712E70EA6600820C3C /* About.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B59B5702E70EA6600820C3C /* About.swift */; };
 		0B59B5722E70EA6600820C3C /* About.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B59B5702E70EA6600820C3C /* About.swift */; };
 		0B59B5732E70EA6600820C3C /* About.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B59B5702E70EA6600820C3C /* About.swift */; };
-		0B910A352A48FEC100648B32 /* SponsorTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA57DE4E2875B09900911F03 /* SponsorTileView.swift */; };
 		0B910A372A49D07700648B32 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B910A362A49D07700648B32 /* Sponsor.swift */; };
 		0B910A382A49D09300648B32 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B910A362A49D07700648B32 /* Sponsor.swift */; };
 		13707030C1082B933C28151D /* SwiftLeedsAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4301D0D3F1C8979276E77084 /* SwiftLeedsAssets.xcassets */; };
@@ -62,7 +60,6 @@
 		740162DB2A7053A000C2D1B3 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740162D92A7053A000C2D1B3 /* AppState.swift */; };
 		7406572928E240720087F44F /* WidgetConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7406572828E240720087F44F /* WidgetConstants.swift */; };
 		741ED8FB2A75829C00494B25 /* ReadabilityModifier in Frameworks */ = {isa = PBXBuildFile; productRef = 741ED8FA2A75829C00494B25 /* ReadabilityModifier */; };
-		741ED8FC2A7582A600494B25 /* SponsorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4B1A4A2A4858F600ED7EA9 /* SponsorsView.swift */; };
 		74A09FDF28C6778C00E03F39 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74A09FDE28C6778C00E03F39 /* WidgetKit.framework */; };
 		74A09FE128C6778C00E03F39 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74A09FE028C6778C00E03F39 /* SwiftUI.framework */; };
 		74A09FE428C6778C00E03F39 /* SwiftLeedsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A09FE328C6778C00E03F39 /* SwiftLeedsWidget.swift */; };
@@ -906,13 +903,10 @@
 				0B4CB3EC28EAF5E900246E62 /* ActivityView.swift in Sources */,
 				0B4CB3F228EAF61600246E62 /* WebView.swift in Sources */,
 				0B59B5712E70EA6600820C3C /* About.swift in Sources */,
-				0B4B1A512A48FB6400ED7EA9 /* SponsorsViewModel.swift in Sources */,
 				0B4CB3EF28EAF60200246E62 /* FancyHeaderView.swift in Sources */,
 				0B4CB3F028EAF60800246E62 /* SpeakerView.swift in Sources */,
 				0B4CB3E428EAF5AF00246E62 /* Presentation.swift in Sources */,
-				741ED8FC2A7582A600494B25 /* SponsorsView.swift in Sources */,
 				0B4CB3E928EAF5D200246E62 /* Local.swift in Sources */,
-				0B910A352A48FEC100648B32 /* SponsorTileView.swift in Sources */,
 				E3569B062E5B903800BC9556 /* ShimmerView.swift in Sources */,
 				0B4CB3E528EAF5B700246E62 /* Speaker.swift in Sources */,
 				0B4CB3E828EAF5CD00246E62 /* AnnouncementCell.swift in Sources */,

--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		AEDC0DAE286759630078A153 /* Tabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDC0DAD286759630078A153 /* Tabs.swift */; };
 		AEDC22532898281300746247 /* MyConferenceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDC22522898281300746247 /* MyConferenceViewModel.swift */; };
 		AEDC22552898288F00746247 /* Schedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDC22542898288F00746247 /* Schedule.swift */; };
+		B09ACE20A089F99B5404B667 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816A6083DA208AE9EED41E40 /* Endpoint.swift */; };
 		B2A3D0194187CEC82CCD3F5D /* ConferenceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67624B7470D6BA62D4912236 /* ConferenceConfig.swift */; };
 		B7E34B6C6CE38F48068FB98A /* SwiftLeedsAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EEFB1E37D5A542A1798C92D5 /* SwiftLeedsAssets.xcassets */; };
 		C88307224ADAA4C64A455D74 /* KotlinLeedsAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 40AEBC0F9109732F54C608A9 /* KotlinLeedsAssets.xcassets */; };
@@ -232,6 +233,7 @@
 		4301D0D3F1C8979276E77084 /* SwiftLeedsAssets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = SwiftLeedsAssets.xcassets; sourceTree = "<group>"; };
 		5F9FC40FEADC49E608696F7A /* SwiftLeeds.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLeeds.xcconfig; sourceTree = "<group>"; };
 		67624B7470D6BA62D4912236 /* ConferenceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConferenceConfig.swift; sourceTree = "<group>"; };
+		816A6083DA208AE9EED41E40 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		740162D92A7053A000C2D1B3 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		7406572828E240720087F44F /* WidgetConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetConstants.swift; sourceTree = "<group>"; };
 		74A09FDD28C6778C00E03F39 /* SwiftLeedsWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SwiftLeedsWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -628,6 +630,7 @@
 			isa = PBXGroup;
 			children = (
 				FA57DE572875B0E300911F03 /* Model */,
+				816A6083DA208AE9EED41E40 /* Endpoint.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -949,6 +952,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B09ACE20A089F99B5404B667 /* Endpoint.swift in Sources */,
 				A11CE57000000000000000F2 /* URLSession+SwiftLeeds.swift in Sources */,
 				AEDC22532898281300746247 /* MyConferenceViewModel.swift in Sources */,
 				AED26F7828676A9900E06064 /* AboutView.swift in Sources */,

--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		0B59B5732E70EA6600820C3C /* About.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B59B5702E70EA6600820C3C /* About.swift */; };
 		0B910A372A49D07700648B32 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B910A362A49D07700648B32 /* Sponsor.swift */; };
 		0B910A382A49D09300648B32 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B910A362A49D07700648B32 /* Sponsor.swift */; };
+		0F532E9AAB8FD761A43947E1 /* SponsorsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */; };
 		13707030C1082B933C28151D /* SwiftLeedsAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4301D0D3F1C8979276E77084 /* SwiftLeedsAssets.xcassets */; };
 		1ED8FD9CBE313B23E73E8132 /* KotlinLeedsColors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0B3FFD994DBE3F62216150F8 /* KotlinLeedsColors.xcassets */; };
 		2A3831122884A96600030002 /* FancyHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3831112884A96600030002 /* FancyHeaderView.swift */; };
@@ -232,6 +233,7 @@
 		40AEBC0F9109732F54C608A9 /* KotlinLeedsAssets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = KotlinLeedsAssets.xcassets; sourceTree = "<group>"; };
 		4301D0D3F1C8979276E77084 /* SwiftLeedsAssets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = SwiftLeedsAssets.xcassets; sourceTree = "<group>"; };
 		5F9FC40FEADC49E608696F7A /* SwiftLeeds.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLeeds.xcconfig; sourceTree = "<group>"; };
+		659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsorsMapper.swift; sourceTree = "<group>"; };
 		67624B7470D6BA62D4912236 /* ConferenceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConferenceConfig.swift; sourceTree = "<group>"; };
 		816A6083DA208AE9EED41E40 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		740162D92A7053A000C2D1B3 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -631,6 +633,7 @@
 			children = (
 				FA57DE572875B0E300911F03 /* Model */,
 				816A6083DA208AE9EED41E40 /* Endpoint.swift */,
+				659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -953,6 +956,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B09ACE20A089F99B5404B667 /* Endpoint.swift in Sources */,
+				0F532E9AAB8FD761A43947E1 /* SponsorsMapper.swift in Sources */,
 				A11CE57000000000000000F2 /* URLSession+SwiftLeeds.swift in Sources */,
 				AEDC22532898281300746247 /* MyConferenceViewModel.swift in Sources */,
 				AED26F7828676A9900E06064 /* AboutView.swift in Sources */,

--- a/SwiftLeeds/Data/Endpoint.swift
+++ b/SwiftLeeds/Data/Endpoint.swift
@@ -1,0 +1,13 @@
+import NetworkKit
+
+enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
+    case sponsors
+
+    var request: HTTPRequest {
+        switch self {
+        case .sponsors:
+            .get("api/v1/sponsors")
+                .appending(headerField: .accept, .application.json)
+        }
+    }
+}

--- a/SwiftLeeds/Data/SponsorsMapper.swift
+++ b/SwiftLeeds/Data/SponsorsMapper.swift
@@ -1,0 +1,43 @@
+import Dependencies
+import Foundation
+import NetworkKit
+
+struct SponsorsMapper: Sendable {
+    enum ResponseError: Error {
+        case couldNotDecode(any Error)
+        case unexpectedStatus(HTTPStatus)
+    }
+
+    var map: @Sendable (Data, HTTPURLResponse) throws(ResponseError) -> Sponsors
+
+    init(map: @escaping @Sendable (Data, HTTPURLResponse) throws(ResponseError) -> Sponsors) {
+        self.map = map
+    }
+}
+
+extension SponsorsMapper {
+    static let live = SponsorsMapper { data, response throws(ResponseError) in
+        switch response.status {
+        case .ok:
+            do {
+                return try JSONDecoder().decode(Sponsors.self, from: data)
+            } catch {
+                throw .couldNotDecode(error)
+            }
+        default:
+            throw .unexpectedStatus(response.status)
+        }
+    }
+}
+
+private enum SponsorsMapperKey: DependencyKey {
+    static var liveValue: SponsorsMapper { .live }
+    static var testValue: SponsorsMapper { liveValue }
+}
+
+extension DependencyValues {
+    var sponsorsMapper: SponsorsMapper {
+        get { self[SponsorsMapperKey.self] }
+        set { self[SponsorsMapperKey.self] = newValue }
+    }
+}

--- a/SwiftLeeds/Views/Sponsors/SponsorsViewModel.swift
+++ b/SwiftLeeds/Views/Sponsors/SponsorsViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
+import Dependencies
 import Foundation
-import Networking
+import NetworkKit
 import SwiftUI
 
 final class SponsorsViewModel: ObservableObject {
@@ -13,16 +14,12 @@ final class SponsorsViewModel: ObservableObject {
     }
 
     func loadSponsors() async throws {
-        do {
-            let sponsors = try await URLSession.shared.decode(Requests.sponsors, dateDecodingStrategy: Requests.defaultDateDecodingStratergy)
-            await updateSponsors(sponsors)
-        } catch {
-            if let cachedResponse = try? await URLSession.shared.cached(Requests.sponsors, dateDecodingStrategy: Requests.defaultDateDecodingStratergy) {
-                await updateSponsors(cachedResponse)
-            } else {
-                throw(error)
-            }
-        }
+        @Dependency(\.httpClient) var httpClient
+        @Dependency(\.sponsorsMapper) var sponsorsMapper
+
+        let (data, response) = try await httpClient.send(Endpoint.sponsors.urlRequest())
+        let sponsors = try sponsorsMapper.map(data, response)
+        await updateSponsors(sponsors)
     }
 
     @MainActor
@@ -53,12 +50,4 @@ final class SponsorsViewModel: ObservableObject {
 
         self.sections = sections
     }
-}
-
-private extension Requests {
-    static let sponsors = Request<Sponsors>(
-        host: host,
-        path: "\(apiVersion1)/sponsors",
-        eTagKey: "etag-sponsors"
-    )
 }


### PR DESCRIPTION
## Problem

* Sponsors load through the legacy `Networking` module.
* It passes a date decoding strategy this payload never uses.
* The App Clip compiles the sponsors screen but never shows it.

## Solution

* New `Endpoint` enum names each backend request. Sponsors is its only case.
* New `SponsorsMapper` decodes the response, with a typed error.
* `SponsorsViewModel` sends the request through `@Dependency(\.httpClient)`.
* The App Clip stops compiling the three sponsors files.

## Notes

* The request now sends only `Accept: application/json`.
* Offline, the tab still fills from `URLCache`. Tested with the network off.

## How to test

```bash
git fetch && git checkout feat/sponsors-viewmodel-networkkit
```

Run on a simulator. Open Sponsors. Check platinum, gold and silver each list sponsors. Turn the network off and open the tab again.
