### PR TITLE
refactor(SwiftLeeds): fetch locations through NetworkKit

### DIFF
--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		7B8C3ECF2EE4A9F70089C6CF /* SharedAssets in Frameworks */ = {isa = PBXBuildFile; productRef = 7B8C3ECE2EE4A9F70089C6CF /* SharedAssets */; };
 		7BE081522EE5BDA8004BCD1F /* SharedAssets in Frameworks */ = {isa = PBXBuildFile; productRef = 7BE081512EE5BDA8004BCD1F /* SharedAssets */; };
 		7BE081542EE5BF13004BCD1F /* SharedAssets in Frameworks */ = {isa = PBXBuildFile; productRef = 7BE081532EE5BF13004BCD1F /* SharedAssets */; };
+		911CBFE0C21C398999FE786C /* LocalMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6653F9331892E676D8F861C8 /* LocalMapper.swift */; };
 		7DD216398B20B302618BCB90 /* SwiftLeedsAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3275AD6541323F056786E508 /* SwiftLeedsAssets.xcassets */; };
 		802D63D966D0A9337F66041C /* KotlinLeedsAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 75075F01455C8AD72C71783C /* KotlinLeedsAssets.xcassets */; };
 		920187EBD71395160F1059C1 /* KotlinLeedsColors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0B3FFD994DBE3F62216150F8 /* KotlinLeedsColors.xcassets */; };
@@ -234,6 +235,7 @@
 		4301D0D3F1C8979276E77084 /* SwiftLeedsAssets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = SwiftLeedsAssets.xcassets; sourceTree = "<group>"; };
 		5F9FC40FEADC49E608696F7A /* SwiftLeeds.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLeeds.xcconfig; sourceTree = "<group>"; };
 		659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsorsMapper.swift; sourceTree = "<group>"; };
+		6653F9331892E676D8F861C8 /* LocalMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalMapper.swift; sourceTree = "<group>"; };
 		67624B7470D6BA62D4912236 /* ConferenceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConferenceConfig.swift; sourceTree = "<group>"; };
 		816A6083DA208AE9EED41E40 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		740162D92A7053A000C2D1B3 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -633,6 +635,7 @@
 			children = (
 				FA57DE572875B0E300911F03 /* Model */,
 				816A6083DA208AE9EED41E40 /* Endpoint.swift */,
+				6653F9331892E676D8F861C8 /* LocalMapper.swift */,
 				659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */,
 			);
 			path = Data;
@@ -956,6 +959,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B09ACE20A089F99B5404B667 /* Endpoint.swift in Sources */,
+				911CBFE0C21C398999FE786C /* LocalMapper.swift in Sources */,
 				0F532E9AAB8FD761A43947E1 /* SponsorsMapper.swift in Sources */,
 				A11CE57000000000000000F2 /* URLSession+SwiftLeeds.swift in Sources */,
 				AEDC22532898281300746247 /* MyConferenceViewModel.swift in Sources */,

--- a/SwiftLeeds/Data/Endpoint.swift
+++ b/SwiftLeeds/Data/Endpoint.swift
@@ -1,10 +1,14 @@
 import NetworkKit
 
 enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
+    case local
     case sponsors
 
     var request: HTTPRequest {
         switch self {
+        case .local:
+            .get("api/v1/local")
+                .appending(headerField: .accept, .application.json)
         case .sponsors:
             .get("api/v1/sponsors")
                 .appending(headerField: .accept, .application.json)

--- a/SwiftLeeds/Data/LocalMapper.swift
+++ b/SwiftLeeds/Data/LocalMapper.swift
@@ -1,0 +1,43 @@
+import Dependencies
+import Foundation
+import NetworkKit
+
+struct LocalMapper: Sendable {
+    enum ResponseError: Error {
+        case couldNotDecode(any Error)
+        case unexpectedStatus(HTTPStatus)
+    }
+
+    var map: @Sendable (Data, HTTPURLResponse) throws(ResponseError) -> Local
+
+    init(map: @escaping @Sendable (Data, HTTPURLResponse) throws(ResponseError) -> Local) {
+        self.map = map
+    }
+}
+
+extension LocalMapper {
+    static let live = LocalMapper { data, response throws(ResponseError) in
+        switch response.status {
+        case .ok:
+            do {
+                return try JSONDecoder().decode(Local.self, from: data)
+            } catch {
+                throw .couldNotDecode(error)
+            }
+        default:
+            throw .unexpectedStatus(response.status)
+        }
+    }
+}
+
+private enum LocalMapperKey: DependencyKey {
+    static var liveValue: LocalMapper { .live }
+    static var testValue: LocalMapper { liveValue }
+}
+
+extension DependencyValues {
+    var localMapper: LocalMapper {
+        get { self[LocalMapperKey.self] }
+        set { self[LocalMapperKey.self] = newValue }
+    }
+}

--- a/SwiftLeeds/Views/Local/LocalViewModel.swift
+++ b/SwiftLeeds/Views/Local/LocalViewModel.swift
@@ -1,6 +1,7 @@
+import Dependencies
 import Foundation
 import MapKit
-import Networking
+import NetworkKit
 import SwiftUI
 
 class LocalViewModel: ObservableObject {
@@ -20,15 +21,15 @@ class LocalViewModel: ObservableObject {
     }
 
     func loadData() async {
+        @Dependency(\.httpClient) var httpClient
+        @Dependency(\.localMapper) var localMapper
+
         do {
-            let localResults = try await URLSession.shared.decode(Requests.local, dateDecodingStrategy: Requests.defaultDateDecodingStratergy)
+            let (data, response) = try await httpClient.send(Endpoint.local.urlRequest())
+            let localResults = try localMapper.map(data, response)
             await updateLocal(localResults)
         } catch {
-            if let cachedResponse = try? await URLSession.shared.cached(Requests.local, dateDecodingStrategy: Requests.defaultDateDecodingStratergy) {
-                await updateLocal(cachedResponse)
-            } else {
-                self.error = error
-            }
+            self.error = error
         }
     }
 
@@ -37,12 +38,4 @@ class LocalViewModel: ObservableObject {
         self.categories = localResults.data
         self.selectedCategory = self.categories.first
     }
-}
-
-private extension Requests {
-    static let local = Request<Local>(
-        host: host,
-        path: "\(apiVersion1)/local",
-        eTagKey: "etag-local"
-    )
 }

--- a/SwiftLeeds/Views/Local/LocalViewModel.swift
+++ b/SwiftLeeds/Views/Local/LocalViewModel.swift
@@ -35,6 +35,7 @@ class LocalViewModel: ObservableObject {
 
     @MainActor
     private func updateLocal(_ localResults: Local) async {
+        self.error = nil
         self.categories = localResults.data
         self.selectedCategory = self.categories.first
     }


### PR DESCRIPTION
## Problem

* The Local screen loads through the legacy `Networking` module.
* It passes a date decoding strategy this payload never uses.

## Solution

* `Endpoint` gains `case local`, at `api/v1/local`.
* New `LocalMapper` decodes the response, with a typed error.
* `LocalViewModel` sends the request through `@Dependency(\.httpClient)`.
* A successful load now clears the error, so the error overlay stops covering the map after a Reload.

## Notes

* The request now sends only `Accept: application/json`.
* This endpoint sends no `Cache-Control` and no `Last-Modified`, so `URLCache` cannot stand in for the etag cache that goes with the old request. Tested with the network off: the screen shows "Something has gone wrong" and a Reload button, where before it showed the last fetched locations.

## Screenshots

| Local | Offline |
|---|---|
| <img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/e734c603-6eef-446d-a5ac-179f317371e9" /> | <img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/4ca85f0a-6862-4912-9f0c-eb677bda6ddd" /> |

## How to test

```bash
git fetch && git checkout feat/local-viewmodel-networkkit
```

Run on a simulator. Open Local. Check the map shows pins and the sheet lists the categories. Turn the network off and open it again. Turn it back on and tap Reload: the map should fill and the overlay should go.

