### PR TITLE
refactor(SwiftLeeds): fetch the team through NetworkKit

### DIFF
--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		0B910A372A49D07700648B32 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B910A362A49D07700648B32 /* Sponsor.swift */; };
 		0B910A382A49D09300648B32 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B910A362A49D07700648B32 /* Sponsor.swift */; };
 		0F532E9AAB8FD761A43947E1 /* SponsorsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */; };
+		106111EE0332466C39422B5E /* TeamMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AB02B37BB6C44A78DC7FF9 /* TeamMapper.swift */; };
 		13707030C1082B933C28151D /* SwiftLeedsAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4301D0D3F1C8979276E77084 /* SwiftLeedsAssets.xcassets */; };
 		1ED8FD9CBE313B23E73E8132 /* KotlinLeedsColors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0B3FFD994DBE3F62216150F8 /* KotlinLeedsColors.xcassets */; };
 		2A3831122884A96600030002 /* FancyHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3831112884A96600030002 /* FancyHeaderView.swift */; };
@@ -232,6 +233,7 @@
 		394653AA288BB7C800212E1C /* SpeakerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerView.swift; sourceTree = "<group>"; };
 		39ED0033288F113500AB337A /* LocalCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalCell.swift; sourceTree = "<group>"; };
 		40AEBC0F9109732F54C608A9 /* KotlinLeedsAssets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = KotlinLeedsAssets.xcassets; sourceTree = "<group>"; };
+		41AB02B37BB6C44A78DC7FF9 /* TeamMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMapper.swift; sourceTree = "<group>"; };
 		4301D0D3F1C8979276E77084 /* SwiftLeedsAssets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = SwiftLeedsAssets.xcassets; sourceTree = "<group>"; };
 		5F9FC40FEADC49E608696F7A /* SwiftLeeds.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLeeds.xcconfig; sourceTree = "<group>"; };
 		659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsorsMapper.swift; sourceTree = "<group>"; };
@@ -637,6 +639,7 @@
 				816A6083DA208AE9EED41E40 /* Endpoint.swift */,
 				6653F9331892E676D8F861C8 /* LocalMapper.swift */,
 				659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */,
+				41AB02B37BB6C44A78DC7FF9 /* TeamMapper.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -961,6 +964,7 @@
 				B09ACE20A089F99B5404B667 /* Endpoint.swift in Sources */,
 				911CBFE0C21C398999FE786C /* LocalMapper.swift in Sources */,
 				0F532E9AAB8FD761A43947E1 /* SponsorsMapper.swift in Sources */,
+				106111EE0332466C39422B5E /* TeamMapper.swift in Sources */,
 				A11CE57000000000000000F2 /* URLSession+SwiftLeeds.swift in Sources */,
 				AEDC22532898281300746247 /* MyConferenceViewModel.swift in Sources */,
 				AED26F7828676A9900E06064 /* AboutView.swift in Sources */,

--- a/SwiftLeeds/Data/Endpoint.swift
+++ b/SwiftLeeds/Data/Endpoint.swift
@@ -3,6 +3,7 @@ import NetworkKit
 enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
     case local
     case sponsors
+    case team
 
     var request: HTTPRequest {
         switch self {
@@ -11,6 +12,9 @@ enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
                 .appending(headerField: .accept, .application.json)
         case .sponsors:
             .get("api/v1/sponsors")
+                .appending(headerField: .accept, .application.json)
+        case .team:
+            .get("api/v2/team")
                 .appending(headerField: .accept, .application.json)
         }
     }

--- a/SwiftLeeds/Data/TeamMapper.swift
+++ b/SwiftLeeds/Data/TeamMapper.swift
@@ -1,0 +1,43 @@
+import Dependencies
+import Foundation
+import NetworkKit
+
+struct TeamMapper: Sendable {
+    enum ResponseError: Error {
+        case couldNotDecode(any Error)
+        case unexpectedStatus(HTTPStatus)
+    }
+
+    var map: @Sendable (Data, HTTPURLResponse) throws(ResponseError) -> Team
+
+    init(map: @escaping @Sendable (Data, HTTPURLResponse) throws(ResponseError) -> Team) {
+        self.map = map
+    }
+}
+
+extension TeamMapper {
+    static let live = TeamMapper { data, response throws(ResponseError) in
+        switch response.status {
+        case .ok:
+            do {
+                return try JSONDecoder().decode(Team.self, from: data)
+            } catch {
+                throw .couldNotDecode(error)
+            }
+        default:
+            throw .unexpectedStatus(response.status)
+        }
+    }
+}
+
+private enum TeamMapperKey: DependencyKey {
+    static var liveValue: TeamMapper { .live }
+    static var testValue: TeamMapper { liveValue }
+}
+
+extension DependencyValues {
+    var teamMapper: TeamMapper {
+        get { self[TeamMapperKey.self] }
+        set { self[TeamMapperKey.self] = newValue }
+    }
+}

--- a/SwiftLeeds/Views/About/AboutViewModel.swift
+++ b/SwiftLeeds/Views/About/AboutViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
+import Dependencies
 import Foundation
-import Networking
+import NetworkKit
 
 @MainActor
 class AboutViewModel: ObservableObject {
@@ -73,22 +74,15 @@ class AboutViewModel: ObservableObject {
     }
 
     private func loadTeamData() async {
+        @Dependency(\.httpClient) var httpClient
+        @Dependency(\.teamMapper) var teamMapper
+
         do {
-            let teamApiResponse = try await URLSession.shared.decode(
-                Requests.team,
-                dateDecodingStrategy: Requests.defaultDateDecodingStratergy
-            )
-            await updateTeamMembers(teamApiResponse.teamMembers)
+            let (data, response) = try await httpClient.send(Endpoint.team.urlRequest())
+            let team = try teamMapper.map(data, response)
+            await updateTeamMembers(team.teamMembers)
         } catch {
-            // Try to load from cache if API fails
-            if let cachedResponse = try? await URLSession.shared.cached(
-                Requests.team,
-                dateDecodingStrategy: Requests.defaultDateDecodingStratergy
-            ) {
-                await updateTeamMembers(cachedResponse.teamMembers)
-            } else {
-                errorMessage = "Failed to load team data: \(error.localizedDescription)"
-            }
+            errorMessage = "Failed to load team data: \(error.localizedDescription)"
         }
     }
 
@@ -96,12 +90,4 @@ class AboutViewModel: ObservableObject {
     private func updateTeamMembers(_ members: [TeamMember]) async {
         self.teamMembers = members
     }
-}
-
-private extension Requests {
-    static let team = Request<Team>(
-        host: host,
-        path: "\(apiVersion2)/team",
-        eTagKey: "etag-team"
-    )
 }


### PR DESCRIPTION
## Problem

* The team list loads through the legacy `Networking` module.
* It passes a date decoding strategy this payload never uses.

## Solution

* `Endpoint` gains `case team`, at `api/v2/team`. The first v2 path in the catalog.
* New `TeamMapper` decodes the response, with a typed error.
* `AboutViewModel` sends the request through `@Dependency(\.httpClient)`.

## Notes

* Only the team fetch moves. `loadLocalAboutContent()` still reads `about.json` from the bundle, so this view model is half NetworkKit and half `Bundle.main` until that content moves too.
* This endpoint sends no `Cache-Control` and no `Last-Modified`, so `URLCache` cannot stand in for the etag cache that goes with the old request. Offline the team grid is empty, with no message, because `AboutView` reads neither `isLoading` nor `errorMessage`.

## Screenshots

| Team | Offline |
|---|---|
|<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/2cdb92c1-4d36-4786-afb8-e66e201ade17" />|<img width="300" height="650" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-10 at 17 56 07" src="https://github.com/user-attachments/assets/d04e544f-74e7-4c31-8404-3735a8ad919b" />|

## How to test

```bash
git fetch && git checkout feat/about-viewmodel-networkkit
```

Run on a simulator. Open About and scroll to the team. Check all 10 members appear with photos, roles and links, and that the blurb and the buttons above still render. Turn the network off and open it again.
