### PR TITLE
refactor(SwiftLeeds): fetch the schedule through NetworkKit

### DIFF
--- a/SwiftLeeds.xcodeproj/project.pbxproj
+++ b/SwiftLeeds.xcodeproj/project.pbxproj
@@ -44,7 +44,10 @@
 		0B59B5732E70EA6600820C3C /* About.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B59B5702E70EA6600820C3C /* About.swift */; };
 		0B910A372A49D07700648B32 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B910A362A49D07700648B32 /* Sponsor.swift */; };
 		0B910A382A49D09300648B32 /* Sponsor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B910A362A49D07700648B32 /* Sponsor.swift */; };
+		0A019758B5F7EFA2BFB39AC1 /* ScheduleMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5D5DE6F666FC86B4B9DC7B /* ScheduleMapper.swift */; };
 		0F532E9AAB8FD761A43947E1 /* SponsorsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */; };
+		1D35F8B0CDCE0771E02C3BDA /* ScheduleMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5D5DE6F666FC86B4B9DC7B /* ScheduleMapper.swift */; };
+		FB6B9D30B85EAAED16F69656 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816A6083DA208AE9EED41E40 /* Endpoint.swift */; };
 		106111EE0332466C39422B5E /* TeamMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AB02B37BB6C44A78DC7FF9 /* TeamMapper.swift */; };
 		13707030C1082B933C28151D /* SwiftLeedsAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4301D0D3F1C8979276E77084 /* SwiftLeedsAssets.xcassets */; };
 		1ED8FD9CBE313B23E73E8132 /* KotlinLeedsColors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0B3FFD994DBE3F62216150F8 /* KotlinLeedsColors.xcassets */; };
@@ -240,6 +243,7 @@
 		4301D0D3F1C8979276E77084 /* SwiftLeedsAssets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = SwiftLeedsAssets.xcassets; sourceTree = "<group>"; };
 		5F9FC40FEADC49E608696F7A /* SwiftLeeds.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLeeds.xcconfig; sourceTree = "<group>"; };
 		659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsorsMapper.swift; sourceTree = "<group>"; };
+		1A5D5DE6F666FC86B4B9DC7B /* ScheduleMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleMapper.swift; sourceTree = "<group>"; };
 		6653F9331892E676D8F861C8 /* LocalMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalMapper.swift; sourceTree = "<group>"; };
 		67624B7470D6BA62D4912236 /* ConferenceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConferenceConfig.swift; sourceTree = "<group>"; };
 		816A6083DA208AE9EED41E40 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
@@ -644,6 +648,7 @@
 				816A6083DA208AE9EED41E40 /* Endpoint.swift */,
 				6653F9331892E676D8F861C8 /* LocalMapper.swift */,
 				659D31BD07C04877B7AFF774 /* SponsorsMapper.swift */,
+				1A5D5DE6F666FC86B4B9DC7B /* ScheduleMapper.swift */,
 				41AB02B37BB6C44A78DC7FF9 /* TeamMapper.swift */,
 			);
 			path = Data;
@@ -939,6 +944,8 @@
 				0B4CB3F428EAF62100246E62 /* CommonTileView.swift in Sources */,
 				0B4CB3C828EAF19100246E62 /* SwiftLeedsAppClipApp.swift in Sources */,
 				F94828C06997CC0C7F25871C /* URLSession+SwiftLeeds.swift in Sources */,
+				FB6B9D30B85EAAED16F69656 /* Endpoint.swift in Sources */,
+				0A019758B5F7EFA2BFB39AC1 /* ScheduleMapper.swift in Sources */,
 				0B4CB3F328EAF61B00246E62 /* CommonTileButton.swift in Sources */,
 				79E3CB724EF853948BC7D906 /* ConferenceConfig.swift in Sources */,
 			);
@@ -971,6 +978,7 @@
 			files = (
 				B09ACE20A089F99B5404B667 /* Endpoint.swift in Sources */,
 				911CBFE0C21C398999FE786C /* LocalMapper.swift in Sources */,
+				1D35F8B0CDCE0771E02C3BDA /* ScheduleMapper.swift in Sources */,
 				0F532E9AAB8FD761A43947E1 /* SponsorsMapper.swift in Sources */,
 				106111EE0332466C39422B5E /* TeamMapper.swift in Sources */,
 				A11CE57000000000000000F2 /* URLSession+SwiftLeeds.swift in Sources */,

--- a/SwiftLeeds/Data/Endpoint.swift
+++ b/SwiftLeeds/Data/Endpoint.swift
@@ -1,7 +1,9 @@
+import Foundation
 import NetworkKit
 
 enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
     case local
+    case schedule(event: UUID?)
     case sponsors
     case team
 
@@ -10,6 +12,10 @@ enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
         case .local:
             .get("api/v1/local")
                 .appending(headerField: .accept, .application.json)
+        case let .schedule(event):
+            .get("api/v2/schedule")
+                .appending(headerField: .accept, .application.json)
+                .appending(queryItems: Self.queryItems(forEvent: event))
         case .sponsors:
             .get("api/v1/sponsors")
                 .appending(headerField: .accept, .application.json)
@@ -17,5 +23,10 @@ enum Endpoint: HTTPRequestConvertible, Equatable, Hashable, Sendable {
             .get("api/v2/team")
                 .appending(headerField: .accept, .application.json)
         }
+    }
+
+    private static func queryItems(forEvent event: UUID?) -> [URLQueryItem] {
+        guard let event else { return [] }
+        return [URLQueryItem(name: "event", value: event.uuidString)]
     }
 }

--- a/SwiftLeeds/Data/Model/Schedule.swift
+++ b/SwiftLeeds/Data/Model/Schedule.swift
@@ -59,8 +59,7 @@ extension Schedule.Slot: Codable {
         startTime = try values.decode(String.self, forKey: .startTime)
         duration = try values.decode(Int.self, forKey: .duration)
 
-        let date = try values.decodeIfPresent(String.self, forKey: .date) ?? ""
-        self.date = ISO8601DateFormatter().date(from: date)
+        self.date = try values.decodeIfPresent(Date.self, forKey: .date)
 
         if let activity = try values.decodeIfPresent(Activity.self, forKey: .activity) {
             self.activity = activity

--- a/SwiftLeeds/Data/ScheduleMapper.swift
+++ b/SwiftLeeds/Data/ScheduleMapper.swift
@@ -1,0 +1,72 @@
+import Dependencies
+import Foundation
+import NetworkKit
+
+struct ScheduleMapper: Sendable {
+    enum ResponseError: Error {
+        case couldNotDecode(any Error)
+        case unexpectedStatus(HTTPStatus)
+    }
+
+    var map: @Sendable (Data, HTTPURLResponse) throws(ResponseError) -> Schedule
+
+    init(map: @escaping @Sendable (Data, HTTPURLResponse) throws(ResponseError) -> Schedule) {
+        self.map = map
+    }
+}
+
+extension ScheduleMapper {
+    static let live = ScheduleMapper { data, response throws(ResponseError) in
+        switch response.status {
+        case .ok:
+            do {
+                return try decoder.decode(Schedule.self, from: data)
+            } catch {
+                throw .couldNotDecode(error)
+            }
+        default:
+            throw .unexpectedStatus(response.status)
+        }
+    }
+
+    // Slot dates arrive as ISO8601 and event dates as dd-MM-yyyy, in one payload.
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+
+            if let date = ISO8601DateFormatter().date(from: dateString) {
+                return date
+            }
+
+            if let date = dayFormatter.date(from: dateString) {
+                return date
+            }
+
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Expected an ISO8601 or dd-MM-yyyy date, got: \(dateString)"
+            )
+        }
+        return decoder
+    }()
+
+    private static let dayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "dd-MM-yyyy"
+        return formatter
+    }()
+}
+
+private enum ScheduleMapperKey: DependencyKey {
+    static var liveValue: ScheduleMapper { .live }
+    static var testValue: ScheduleMapper { liveValue }
+}
+
+extension DependencyValues {
+    var scheduleMapper: ScheduleMapper {
+        get { self[ScheduleMapperKey.self] }
+        set { self[ScheduleMapperKey.self] = newValue }
+    }
+}

--- a/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
+import Dependencies
 import Foundation
-import Networking
+import NetworkKit
 import SwiftUI
 
 class MyConferenceViewModel: ObservableObject {
@@ -10,31 +11,37 @@ class MyConferenceViewModel: ObservableObject {
     @Published private(set) var days: [Schedule.Day] = []
     @Published private(set) var currentEvent: Schedule.Event?
 
+    private static let scheduleKey = "Schedule"
+
     func loadSchedule() async throws {
         do {
-            let schedule = try await URLSession.awaitConnectivity.decode(
-                Requests.schedule,
-                dateDecodingStrategy: Requests.scheduleDateDecodingStrategy
-            )
-
+            let schedule = try await fetchSchedule(for: nil)
             await updateSchedule(schedule)
-
-            do {
-                let data = try PropertyListEncoder().encode(schedule)
-                UserDefaults(suiteName: ConferenceConfig.appGroupIdentifier)?.setValue(data, forKey: "Schedule")
-            } catch {
-                throw(error)
-            }
+            store(schedule)
         } catch {
-            if let cachedResponse = try? await URLSession.shared.cached(
-                Requests.schedule,
-                dateDecodingStrategy: Requests.scheduleDateDecodingStrategy
-            ) {
-                await updateSchedule(cachedResponse)
-            } else {
-                throw(error)
-            }
+            guard let stored = storedSchedule() else { throw error }
+            await updateSchedule(stored)
         }
+    }
+
+    private func fetchSchedule(for event: UUID?) async throws -> Schedule {
+        @Dependency(\.httpClient) var httpClient
+        @Dependency(\.scheduleMapper) var scheduleMapper
+
+        let (data, response) = try await httpClient.send(Endpoint.schedule(event: event).urlRequest())
+        return try scheduleMapper.map(data, response)
+    }
+
+    private func store(_ schedule: Schedule) {
+        guard let data = try? PropertyListEncoder().encode(schedule) else { return }
+
+        UserDefaults.standard.set(data, forKey: Self.scheduleKey)
+        UserDefaults(suiteName: ConferenceConfig.appGroupIdentifier)?.set(data, forKey: Self.scheduleKey)
+    }
+
+    private func storedSchedule() -> Schedule? {
+        UserDefaults.standard.data(forKey: Self.scheduleKey)
+            .flatMap { try? PropertyListDecoder().decode(Schedule.self, from: $0) }
     }
 
     @MainActor
@@ -63,12 +70,7 @@ class MyConferenceViewModel: ObservableObject {
     private func reloadSchedule() async throws {
         guard let currentEvent else { return }
 
-        let schedule = try await URLSession.awaitConnectivity.decode(
-            Requests.schedule(for: currentEvent.id),
-            dateDecodingStrategy: Requests.scheduleDateDecodingStrategy,
-            filename: "schedule-\(currentEvent.id.uuidString)"
-        )
-
+        let schedule = try await fetchSchedule(for: currentEvent.id)
         await updateSchedule(schedule)
     }
 
@@ -102,50 +104,4 @@ class MyConferenceViewModel: ObservableObject {
             try? await reloadSchedule()
         }
     }
-}
-
-private extension Requests {
-    static let schedule = Request<Schedule>(
-        host: host,
-        path: "\(apiVersion2)/schedule",
-        eTagKey: "etag-schedule"
-    )
-
-    static func schedule(for eventID: UUID) -> Request<Schedule> {
-        Request<Schedule>(
-            host: host,
-            path: "\(apiVersion2)/schedule",
-            method: .get([.init(
-                name: "event",
-                value: eventID.uuidString)
-            ]),
-            eTagKey: "etag-schedule-\(eventID.uuidString)"
-        )
-    }
-
-    // Custom strategy for v2 schedule endpoint (handles both ISO8601 and dd-MM-yyyy)
-    static var scheduleDateDecodingStrategy: JSONDecoder.DateDecodingStrategy = {
-        return .custom { decoder in
-            let container = try decoder.singleValueContainer()
-            let dateString = try container.decode(String.self)
-
-            // Try ISO8601 first (for slot dates)
-            if let date = ISO8601DateFormatter().date(from: dateString) {
-                return date
-            }
-
-            // Fallback to dd-MM-yyyy format (for event dates)
-            let formatter = DateFormatter()
-            formatter.dateFormat = "dd-MM-yyyy"
-            if let date = formatter.date(from: dateString) {
-                return date
-            }
-
-            // If neither works, throw an error
-            throw DecodingError.dataCorruptedError(
-                in: container,
-                debugDescription: "Date string does not match expected format. Expected ISO8601 or dd-MM-yyyy, got: \(dateString)"
-            )
-        }
-    }()
 }

--- a/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
@@ -91,12 +91,6 @@ class MyConferenceViewModel: ObservableObject {
         return days <= 0 && days >= -1
     }
 
-    static let stringDateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
-        return dateFormatter
-    }()
-
     func updateCurrentEvent(_ event: Schedule.Event) {
         currentEvent = event
 

--- a/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
+++ b/SwiftLeeds/Views/My Conference/MyConferenceViewModel.swift
@@ -15,7 +15,7 @@ class MyConferenceViewModel: ObservableObject {
 
     func loadSchedule() async throws {
         do {
-            let schedule = try await fetchSchedule(for: nil)
+            let schedule = try await fetchSchedule()
             await updateSchedule(schedule)
             store(schedule)
         } catch {
@@ -24,7 +24,7 @@ class MyConferenceViewModel: ObservableObject {
         }
     }
 
-    private func fetchSchedule(for event: UUID?) async throws -> Schedule {
+    private func fetchSchedule(for event: UUID? = nil) async throws -> Schedule {
         @Dependency(\.httpClient) var httpClient
         @Dependency(\.scheduleMapper) var scheduleMapper
 


### PR DESCRIPTION
## Problem

* The schedule loads through the legacy `Networking` module, the last of four screens to do so.
* Its offline copy lives in a temp file the legacy module owns, so it cannot move without a replacement.
* `Schedule.Slot` read `date` as a string but its synthesised encoder wrote a date, so every property-list round trip threw. That is why the widget has been empty.
* `MyConferenceViewModel` declared a date formatter nothing used.

## Solution

* `Endpoint` gains `case schedule(event: UUID?)`. One case, because the backend serves the current year and any past year from the same path.
* New `ScheduleMapper`, whose decoder carries the mixed date formats this payload uses: ISO8601 for slots, `dd-MM-yyyy` for events.
* `MyConferenceViewModel` sends both requests through `@Dependency(\.httpClient)`.
* The offline copy moves to `UserDefaults`, per target. The App Clip has no app group entitlement, so a shared store would have left it with no offline schedule at all.
* `Schedule.Slot` decodes `date` as a date. The mapper's decoder already parses both wire formats, and a property list carries dates natively, so one line covers both readers.

## Notes

* The app group write that feeds the widget is unchanged, same key, same encoder. Only the decode changed, which is what was broken.
* Checked against the live API before changing the decode: all six years, 165 slots, every slot date parses.
* Two deliberate behaviour changes. Offline the screen now fills at once, where the old session waited up to 30 seconds for a connection first. And a failed encode no longer throws away a schedule that was fetched and already on screen.
* This endpoint sends no `Cache-Control`, no `Last-Modified` and no `ETag`, so `URLCache` cannot hold it and the hand-written store is doing real work.

## Screenshots

| App | App Clip | Past year | Offline |
|---|---|---|---|
|<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/cb490eb1-fbde-4891-8906-d6addc98fc7f" />|<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/f58b08c6-3505-4599-8abb-515d743570b4" />|<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/d4140cc7-998d-4865-9e46-668449db0d1c" />|<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/ac434a2d-1779-4a9c-b2e4-e3a53516885a" />|

## How to test

```bash
git fetch && git checkout feat/schedule-viewmodel-networkkit
```

Run `SwiftLeeds`, check the Schedule tab, then use the year picker at the top right to switch to a past year: that is the only path that exercises the second request. Run `SwiftLeedsAppClip` and check the schedule appears. Turn the network off and launch each again. Check the widget still fills.

