### PR TITLE
fix(SwiftLeedsWidget): stop the widget trapping on its display name

### DIFF
--- a/SwiftLeedsWidget/SwiftLeedsWidget.swift
+++ b/SwiftLeedsWidget/SwiftLeedsWidget.swift
@@ -9,7 +9,7 @@ struct SwiftLeedsWidget: Widget {
         StaticConfiguration(kind: kind, provider: Provider()) { entry in
             SwiftLeedsWidgetEntryView(entry: entry)
         }
-        .configurationDisplayName("\(ConferenceConfig.conferenceName) What's up next?")
+        .configurationDisplayName(Text(verbatim: "\(ConferenceConfig.conferenceName) What's up next?"))
         .description("This widget to know what is the next talk on our stage.")
         .supportedFamilies([.systemSmall, .systemMedium])
     }


### PR DESCRIPTION
## Problem

* The widget extension traps on launch: `Fatal error: Formatted text for configurationDisplayName is not supported`.
* An interpolated string literal resolves to `LocalizedStringKey`, because the `StringProtocol` overload is `@_disfavoredOverload`. WidgetKit refuses a display name carrying format arguments.
* It compiles cleanly, so no build has ever caught it. Trapping since `0da286f`, March 2026.

## Solution

* Pass `Text(verbatim:)`, which says what was meant: this is a literal, not a localisation key.

## Notes

* Measured on the simulator: the extension trapped repeatedly before, and logged zero fatal errors over five minutes after, with 66 lines of normal activity.
* This was the second of two bugs keeping the widget empty. #157 fixed the other, a property-list decode that threw on every slot.

## Screenshots

<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/b500a57c-92ff-4097-8aeb-4195d86ecaa1" />


## How to test

```bash
git fetch && git checkout fix/widget-display-name
```

Run the `SwiftLeedsWidgetExtension` scheme, which crashed before. Then run `SwiftLeeds`, open the Schedule tab once so the store is written, and check the widget on the home screen.
