### PR TITLE
chore(SwiftLeedsPackage): build DesignKit and SharedAssets for macOS

### DIFF
--- a/SwiftLeedsPackage/Package.resolved
+++ b/SwiftLeedsPackage/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "e72f8f7e5964e57cc3bd7cf4731a74f3869e73bfce1ee20f37f3216c7ed82a39",
+  "originHash" : "7d728fb22cc8bfe3bed726751f577064cb1c42d0884749144a052b6f44ed0c84",
   "pins" : [
     {
       "identity" : "swiftgenplugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftGen/SwiftGenPlugin",
+      "location" : "https://github.com/shadone/SwiftGenPlugin",
       "state" : {
-        "revision" : "879b85a470cacd70c19e22eb7e11a3aed66f4068",
-        "version" : "6.6.2"
+        "branch" : "6.6.2+deriveddatafix",
+        "revision" : "9eb26960d2ebecbe74feecc695e6125eb39e797e"
       }
     }
   ],

--- a/SwiftLeedsPackage/Package.swift
+++ b/SwiftLeedsPackage/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     name: "SwiftLeedsPackage",
     platforms: [
         .iOS(.v16),
+        .macOS(.v13),
     ],
     products: [
         .library(
@@ -54,6 +55,11 @@ let package = Package(
         ),
         .target(
             name: "SharedAssets",
+            // SwiftGen's generated code reads Bundle.module, which SwiftPM
+            // synthesises only for a target that declares resources.
+            resources: [
+                .process("Resources"),
+            ],
             plugins: [
               .plugin(name: "SwiftGenPlugin", package: "SwiftGenPlugin"),
             ]


### PR DESCRIPTION
## Problem

* `SwiftLeedsPackage` declares an iOS platform and no macOS one, so SwiftPM builds it at the default macOS floor. `DesignKit` and `SharedAssets` do not compile there: `'View' is only available in macOS 10.15 or newer`.
* That blocks the architecture migration. A package under `Packages/` that depends on either product could not run `swift test`, which is the job that runs every package suite on the macOS runner.
* Separately, the committed `Package.resolved` named `SwiftGen/SwiftGenPlugin` at tag 6.6.2, while the manifest declares `shadone/SwiftGenPlugin` on a branch. Any resolve rewrote the file.

## Solution

* `SwiftLeedsPackage` now declares `.macOS(.v13)`, matching the other local packages.
* `SharedAssets` declares its resources explicitly. SwiftGen's generated code reads `Bundle.module`, and SwiftPM synthesises that accessor only for a target that declares resources. Xcode inferred it, the command line did not.
* `Package.resolved` now records the revision the workspace already pins.

Neither target imports UIKit, so nothing needed fencing.

## How to test

```bash
git fetch && git checkout chore/swiftleedspackage-macos
swift build --package-path SwiftLeedsPackage --target DesignKit
swift build --package-path SwiftLeedsPackage --target SharedAssets
```

Both succeed. On `main` the first fails with the availability error above, and adding only the platform leaves the second failing with `type 'Bundle' has no member 'module'`.

Then the full recipe:

```bash
for p in LogKit NetworkKit SecureStorageKit AuthenticationFeature AuthenticationUI; do
  swift test --package-path "Packages/$p"
done
xcodebuild build -project SwiftLeeds.xcodeproj -scheme SwiftLeeds \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO
xcodebuild build -project SwiftLeeds.xcodeproj -scheme KotlinLeeds \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO
```

394 tests pass across the five packages. Both brands build, with only the four pre-existing App Clip asset catalog warnings.

## Notes

* The declared resource rule matches what Xcode already inferred. The built `SwiftLeeds.app` ships `SwiftLeedsPackage_SharedAssets.bundle` containing a compiled `Assets.car`, so the catalogs still resolve at runtime.
* `swift build` for the whole package still fails on `ColorTheme`, which imports UIKit. That predates this change and is untouched by it. Fixing it is more than a `#if canImport` fence, because `ThemeOption.userInterfaceStyle` is public API returning a UIKit type and `Settings` depends on the module.
* No behaviour change in either app.
