### PR TITLE
feat(SponsorsFeature): log mapping and fetch outcomes

### DIFF
--- a/Packages/SponsorsFeature/Package.swift
+++ b/Packages/SponsorsFeature/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .library(name: "SponsorsFeature", targets: ["SponsorsFeature"]),
     ],
     dependencies: [
+        .package(path: "../LogKit"),
         .package(path: "../NetworkKit"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
     ],
@@ -20,6 +21,7 @@ let package = Package(
             name: "SponsorsFeature",
             dependencies: [
                 .product(name: "Dependencies", package: "swift-dependencies"),
+                .product(name: "LogKit", package: "LogKit"),
                 .product(name: "NetworkKit", package: "NetworkKit"),
             ]
         ),
@@ -28,6 +30,7 @@ let package = Package(
             dependencies: [
                 "SponsorsFeature",
                 .product(name: "Dependencies", package: "swift-dependencies"),
+                .product(name: "LogKit", package: "LogKit"),
                 .product(name: "NetworkKit", package: "NetworkKit"),
             ]
         ),

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorMappingOutcome.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorMappingOutcome.swift
@@ -1,6 +1,5 @@
 import LogKit
 
-// How the outcome of mapping a sponsor list reads in a log.
 struct LoggedSponsorMappingOutcome {
     let level: LogLevel
     let message: LogMessage
@@ -12,7 +11,6 @@ struct LoggedSponsorMappingOutcome {
         )
     }
 
-    // Everything is open: a sponsor is advertised, and the value came from a public endpoint.
     static func failure(_ error: SponsorMapper.MappingError) -> LoggedSponsorMappingOutcome {
         LoggedSponsorMappingOutcome(
             level: .error,

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorMappingOutcome.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorMappingOutcome.swift
@@ -5,6 +5,14 @@ struct LoggedSponsorMappingOutcome {
     let level: LogLevel
     let message: LogMessage
 
+    // A count is all a success line needs, and the number of sponsors is public.
+    static func success(count: Int) -> LoggedSponsorMappingOutcome {
+        LoggedSponsorMappingOutcome(
+            level: .debug,
+            message: "The sponsor list was mapped: \(count, name: "count", privacy: .open)"
+        )
+    }
+
     // Everything is open: a sponsor is advertised, and the value came from a public endpoint.
     static func failure(_ error: SponsorMapper.MappingError) -> LoggedSponsorMappingOutcome {
         LoggedSponsorMappingOutcome(

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorMappingOutcome.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorMappingOutcome.swift
@@ -1,11 +1,10 @@
 import LogKit
 
-/// How the outcome of mapping a sponsor list reads in a log.
+// How the outcome of mapping a sponsor list reads in a log.
 struct LoggedSponsorMappingOutcome {
     let level: LogLevel
     let message: LogMessage
 
-    // A count is all a success line needs, and the number of sponsors is public.
     static func success(count: Int) -> LoggedSponsorMappingOutcome {
         LoggedSponsorMappingOutcome(
             level: .debug,
@@ -18,9 +17,8 @@ struct LoggedSponsorMappingOutcome {
         LoggedSponsorMappingOutcome(
             level: .error,
             message: """
-            A sponsor could not be mapped: \
-            \(error.sponsor, name: "sponsor", privacy: .open), \
-            \(error.field.rawValue, name: "field", privacy: .open), \
+            The sponsor \(error.sponsor, name: "sponsor", privacy: .open) had an invalid \
+            \(error.field.rawValue, name: "field", privacy: .open): \
             \(error.value, name: "value", privacy: .open)
             """
         )

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorMappingOutcome.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorMappingOutcome.swift
@@ -1,0 +1,20 @@
+import LogKit
+
+/// How the outcome of mapping a sponsor list reads in a log.
+struct LoggedSponsorMappingOutcome {
+    let level: LogLevel
+    let message: LogMessage
+
+    // Everything is open: a sponsor is advertised, and the value came from a public endpoint.
+    static func failure(_ error: SponsorMapper.MappingError) -> LoggedSponsorMappingOutcome {
+        LoggedSponsorMappingOutcome(
+            level: .error,
+            message: """
+            A sponsor could not be mapped: \
+            \(error.sponsor, name: "sponsor", privacy: .open), \
+            \(error.field.rawValue, name: "field", privacy: .open), \
+            \(error.value, name: "value", privacy: .open)
+            """
+        )
+    }
+}

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorsFetchOutcome.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorsFetchOutcome.swift
@@ -1,6 +1,5 @@
 import LogKit
 
-// How the outcome of a sponsors fetch reads in a log.
 struct LoggedSponsorsFetchOutcome {
     let level: LogLevel
     let message: LogMessage
@@ -13,7 +12,6 @@ struct LoggedSponsorsFetchOutcome {
     static func failure(_ error: SponsorFetchError) -> LoggedSponsorsFetchOutcome {
         switch error {
         case .couldNotReachServer:
-            // Expected: the device is offline. The user can retry.
             LoggedSponsorsFetchOutcome(
                 level: .notice,
                 message: "Loading the sponsors did not finish: the server could not be reached"

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorsFetchOutcome.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorsFetchOutcome.swift
@@ -1,0 +1,13 @@
+import LogKit
+
+/// How the outcome of a sponsors fetch reads in a log.
+struct LoggedSponsorsFetchOutcome {
+    let level: LogLevel
+    let message: LogMessage
+
+    // Carries no field. The mapper already recorded the count.
+    static let success = LoggedSponsorsFetchOutcome(
+        level: .info,
+        message: "The sponsors loaded"
+    )
+}

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorsFetchOutcome.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorsFetchOutcome.swift
@@ -10,4 +10,25 @@ struct LoggedSponsorsFetchOutcome {
         level: .info,
         message: "The sponsors loaded"
     )
+
+    static func failure(_ error: SponsorFetchError) -> LoggedSponsorsFetchOutcome {
+        switch error {
+        case .couldNotReachServer:
+            // Expected: the device is offline. The user can retry.
+            LoggedSponsorsFetchOutcome(
+                level: .notice,
+                message: "Loading the sponsors did not finish: the server could not be reached"
+            )
+        case .invalidResponse:
+            LoggedSponsorsFetchOutcome(
+                level: .error,
+                message: "Loading the sponsors did not finish: the server's answer was rejected"
+            )
+        case .unknown:
+            LoggedSponsorsFetchOutcome(
+                level: .error,
+                message: "Loading the sponsors did not finish: the reason is not known"
+            )
+        }
+    }
 }

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorsFetchOutcome.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/Logging/LoggedSponsorsFetchOutcome.swift
@@ -1,11 +1,10 @@
 import LogKit
 
-/// How the outcome of a sponsors fetch reads in a log.
+// How the outcome of a sponsors fetch reads in a log.
 struct LoggedSponsorsFetchOutcome {
     let level: LogLevel
     let message: LogMessage
 
-    // Carries no field. The mapper already recorded the count.
     static let success = LoggedSponsorsFetchOutcome(
         level: .info,
         message: "The sponsors loaded"

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
@@ -1,0 +1,23 @@
+import Dependencies
+import LogKit
+
+extension SponsorMapper {
+    /// Records whether the list mapped, then returns or rethrows.
+    ///
+    /// The public ``SponsorFetchError`` is deliberately bare, so this is the only place a
+    /// rejection's reason survives.
+    package func logging() -> SponsorMapper {
+        SponsorMapper { list throws(MappingError) in
+            // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+            // building liveValue would capture whichever log existed first.
+            @Dependency(\.log) var log
+            do throws(MappingError) {
+                return try map(list)
+            } catch {
+                let entry = LoggedSponsorMappingOutcome.failure(error)
+                log(entry.level, .sponsors, entry.message)
+                throw error
+            }
+        }
+    }
+}

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
@@ -4,8 +4,7 @@ import LogKit
 extension SponsorMapper {
     /// Records whether the list mapped, then returns or rethrows.
     ///
-    /// The only place a rejection's reason survives. The public ``SponsorFetchError`` does not
-    /// carry it.
+    /// The failure line carries the sponsor, the field and the refused value.
     package func logging() -> SponsorMapper {
         SponsorMapper { list throws(MappingError) in
             // Resolved per call, so a test overriding \.log is honored. Resolving it while

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
@@ -3,12 +3,8 @@ import LogKit
 
 extension SponsorMapper {
     /// Records whether the list mapped, then returns or rethrows.
-    ///
-    /// The failure line carries the sponsor, the field and the refused value.
     package func logging() -> SponsorMapper {
         SponsorMapper { list throws(MappingError) in
-            // Resolved per call, so a test overriding \.log is honored. Resolving it while
-            // building liveValue would capture whichever log existed first.
             @Dependency(\.log) var log
             do throws(MappingError) {
                 let sponsors = try map(list)

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
@@ -12,7 +12,10 @@ extension SponsorMapper {
             // building liveValue would capture whichever log existed first.
             @Dependency(\.log) var log
             do throws(MappingError) {
-                return try map(list)
+                let sponsors = try map(list)
+                let entry = LoggedSponsorMappingOutcome.success(count: list.data.count)
+                log(entry.level, .sponsors, entry.message)
+                return sponsors
             } catch {
                 let entry = LoggedSponsorMappingOutcome.failure(error)
                 log(entry.level, .sponsors, entry.message)

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper+Logging.swift
@@ -4,11 +4,11 @@ import LogKit
 extension SponsorMapper {
     /// Records whether the list mapped, then returns or rethrows.
     ///
-    /// The public ``SponsorFetchError`` is deliberately bare, so this is the only place a
-    /// rejection's reason survives.
+    /// The only place a rejection's reason survives. The public ``SponsorFetchError`` does not
+    /// carry it.
     package func logging() -> SponsorMapper {
         SponsorMapper { list throws(MappingError) in
-            // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+            // Resolved per call, so a test overriding \.log is honored. Resolving it while
             // building liveValue would capture whichever log existed first.
             @Dependency(\.log) var log
             do throws(MappingError) {

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorMapper.swift
@@ -59,7 +59,7 @@ extension SponsorMapper {
 }
 
 private enum SponsorMapperKey: DependencyKey {
-    static var liveValue: SponsorMapper { .live }
+    static var liveValue: SponsorMapper { .live.logging() }
     static var testValue: SponsorMapper { liveValue }
 }
 

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Live.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Live.swift
@@ -4,6 +4,10 @@ import NetworkKit
 
 extension SponsorsRepository: DependencyKey {
     package static var liveValue: SponsorsRepository {
+        live.logging()
+    }
+
+    static var live: SponsorsRepository {
         SponsorsRepository { () async throws(SponsorFetchError) -> Sponsors in
             @Dependency(\.httpClient) var httpClient
             @Dependency(\.sponsorMapper) var sponsorMapper

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
@@ -2,10 +2,10 @@ import Dependencies
 import LogKit
 
 extension SponsorsRepository {
-    /// Records the outcome the user got, then rethrows.
+    /// Records the outcome the user got, then returns or rethrows.
     ///
-    /// A failure's cause already reached the log at the seam that knew it: the transport or the
-    /// mapper. This line says what that meant for the person waiting for the sponsors.
+    /// The line names the outcome, not the cause. A transport or mapping cause reaches the log at
+    /// its own seam. A body that fails to decode has no seam and reaches the log as a rejection only.
     package func logging() -> SponsorsRepository {
         SponsorsRepository { () async throws(SponsorFetchError) -> Sponsors in
             // Resolved per call, so a test overriding \.log is honored. Resolving it while

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
@@ -11,10 +11,16 @@ extension SponsorsRepository {
             // Resolved per call, so a test overriding \.log is honoured. Resolving it while
             // building liveValue would capture whichever log existed first.
             @Dependency(\.log) var log
-            let sponsors = try await fetch()
-            let entry = LoggedSponsorsFetchOutcome.success
-            log(entry.level, .sponsors, entry.message)
-            return sponsors
+            do throws(SponsorFetchError) {
+                let sponsors = try await fetch()
+                let entry = LoggedSponsorsFetchOutcome.success
+                log(entry.level, .sponsors, entry.message)
+                return sponsors
+            } catch {
+                let entry = LoggedSponsorsFetchOutcome.failure(error)
+                log(entry.level, .sponsors, entry.message)
+                throw error
+            }
         }
     }
 }

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
@@ -8,7 +8,7 @@ extension SponsorsRepository {
     /// mapper. This line says what that meant for the person waiting for the sponsors.
     package func logging() -> SponsorsRepository {
         SponsorsRepository { () async throws(SponsorFetchError) -> Sponsors in
-            // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+            // Resolved per call, so a test overriding \.log is honored. Resolving it while
             // building liveValue would capture whichever log existed first.
             @Dependency(\.log) var log
             do throws(SponsorFetchError) {

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
@@ -1,0 +1,20 @@
+import Dependencies
+import LogKit
+
+extension SponsorsRepository {
+    /// Records the outcome the user got, then rethrows.
+    ///
+    /// A failure's cause already reached the log at the seam that knew it: the transport or the
+    /// mapper. This line says what that meant for the person waiting for the sponsors.
+    package func logging() -> SponsorsRepository {
+        SponsorsRepository { () async throws(SponsorFetchError) -> Sponsors in
+            // Resolved per call, so a test overriding \.log is honoured. Resolving it while
+            // building liveValue would capture whichever log existed first.
+            @Dependency(\.log) var log
+            let sponsors = try await fetch()
+            let entry = LoggedSponsorsFetchOutcome.success
+            log(entry.level, .sponsors, entry.message)
+            return sponsors
+        }
+    }
+}

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/Infrastructure/SponsorsRepository+Logging.swift
@@ -3,13 +3,8 @@ import LogKit
 
 extension SponsorsRepository {
     /// Records the outcome the user got, then returns or rethrows.
-    ///
-    /// The line names the outcome, not the cause. A transport or mapping cause reaches the log at
-    /// its own seam. A body that fails to decode has no seam and reaches the log as a rejection only.
     package func logging() -> SponsorsRepository {
         SponsorsRepository { () async throws(SponsorFetchError) -> Sponsors in
-            // Resolved per call, so a test overriding \.log is honored. Resolving it while
-            // building liveValue would capture whichever log existed first.
             @Dependency(\.log) var log
             do throws(SponsorFetchError) {
                 let sponsors = try await fetch()

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/LogCategories.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/LogCategories.swift
@@ -1,7 +1,5 @@
 import LogKit
 
-// This feature's log category. Naming it once means a typo cannot silently create a second
-// category and split a filter in two.
 extension LogCategory {
     static let sponsors: Self = "sponsors"
 }

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/LogCategories.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/LogCategories.swift
@@ -1,7 +1,7 @@
 import LogKit
 
-/// This feature's log category. Naming it once means a typo cannot silently create a second
-/// category and split a filter in two.
+// This feature's log category. Naming it once means a typo cannot silently create a second
+// category and split a filter in two.
 extension LogCategory {
     static let sponsors: Self = "sponsors"
 }

--- a/Packages/SponsorsFeature/Sources/SponsorsFeature/LogCategories.swift
+++ b/Packages/SponsorsFeature/Sources/SponsorsFeature/LogCategories.swift
@@ -1,0 +1,7 @@
+import LogKit
+
+/// This feature's log category. Naming it once means a typo cannot silently create a second
+/// category and split a filter in two.
+extension LogCategory {
+    static let sponsors: Self = "sponsors"
+}

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/LogRecorder.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/LogRecorder.swift
@@ -1,0 +1,22 @@
+import Foundation
+import LogKit
+
+/// Captures every event written to its `log`, so a test can assert what was recorded.
+final class LogRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [LogEvent] = []
+
+    var events: [LogEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    var log: Log {
+        Log { [self] event in
+            lock.lock()
+            defer { lock.unlock() }
+            storage.append(event)
+        }
+    }
+}

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
@@ -3,8 +3,7 @@ import LogKit
 import SponsorsFeature
 import Testing
 
-/// The public `SponsorFetchError` carries no reason, so these assert the reason survives to the
-/// log even though the caller never sees it.
+// The caller never sees why a list was refused. These assert the reason reaches the log.
 @Suite struct SponsorMapperLoggingTests {
     @Test func whenLevelIsUnknown_shouldLogAtErrorLevel() throws {
         let list = SponsorListDTO(data: [.fixture(name: "Bronze Co", sponsorLevel: "bronze")])
@@ -38,8 +37,8 @@ import Testing
         #expect(event.fields.first { String($0.name) == "value" }?.value == .string("bronze"))
     }
 
-    /// A list is mapped every time the sponsors screen loads, so it records at the level the
-    /// platform drops unless someone is watching.
+    // A list is mapped every time the sponsors screen loads, so it records at the level the
+    // platform drops unless someone is watching.
     @Test func whenListMaps_shouldLogAtDebugLevel() throws {
         let list = SponsorListDTO(data: [.fixture(id: "a"), .fixture(id: "b")])
 
@@ -70,8 +69,8 @@ import Testing
         }
     }
 
-    /// A destination groups by message, so two outcomes sharing one message could never be told
-    /// apart when filtering.
+    // A destination groups by message, so two outcomes sharing one message could never be told
+    // apart when filtering.
     @Test func whenOutcomesDiffer_shouldLogDifferentMessages() throws {
         let messages = try [
             #require(try mappedEvent(for: SponsorListDTO(data: [.fixture()]))),

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
@@ -3,7 +3,7 @@ import LogKit
 import SponsorsFeature
 import Testing
 
-/// The public `SponsorFetchError` is deliberately bare, so these assert the reason survives to the
+/// The public `SponsorFetchError` carries no reason, so these assert the reason survives to the
 /// log even though the caller never sees it.
 @Suite struct SponsorMapperLoggingTests {
     @Test func whenLevelIsUnknown_shouldLogAtErrorLevel() throws {

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
@@ -56,6 +56,31 @@ import Testing
         #expect(event.fields.first { String($0.name) == "count" }?.value == .integer(2))
     }
 
+    @Test func whenListIsRefused_shouldRethrowMappingError() {
+        let list = SponsorListDTO(data: [.fixture(name: "Bronze Co", sponsorLevel: "bronze")])
+
+        withDependencies {
+            $0.log = LogRecorder().log
+        } operation: {
+            let sut = SponsorMapper.live.logging()
+
+            #expect(throws: SponsorMapper.MappingError.self) {
+                try sut.map(list)
+            }
+        }
+    }
+
+    /// A destination groups by message, so two outcomes sharing one message could never be told
+    /// apart when filtering.
+    @Test func whenOutcomesDiffer_shouldLogDifferentMessages() throws {
+        let messages = try [
+            #require(try mappedEvent(for: SponsorListDTO(data: [.fixture()]))),
+            #require(refusedEvent(for: SponsorListDTO(data: [.fixture(sponsorLevel: "bronze")]))),
+        ].map(\.message)
+
+        #expect(Set(messages).count == messages.count)
+    }
+
     private func mappedEvent(for list: SponsorListDTO) throws -> LogEvent? {
         let recorder = LogRecorder()
 

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
@@ -1,0 +1,32 @@
+import Dependencies
+import LogKit
+import SponsorsFeature
+import Testing
+
+/// The public `SponsorFetchError` is deliberately bare, so these assert the reason survives to the
+/// log even though the caller never sees it.
+@Suite struct SponsorMapperLoggingTests {
+    @Test func whenLevelIsUnknown_shouldLogAtErrorLevel() throws {
+        let list = SponsorListDTO(data: [.fixture(name: "Bronze Co", sponsorLevel: "bronze")])
+
+        let event = try #require(refusedEvent(for: list))
+
+        #expect(event.level == .error)
+    }
+
+    private func refusedEvent(for list: SponsorListDTO) -> LogEvent? {
+        let recorder = LogRecorder()
+
+        withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            let sut = SponsorMapper.live.logging()
+            _ = try? sut.map(list)
+        }
+
+        // Pinned here rather than per test, so a decorator that logs an outcome twice fails
+        // everything rather than nothing.
+        #expect(recorder.events.count == 1)
+        return recorder.events.first
+    }
+}

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
@@ -14,6 +14,30 @@ import Testing
         #expect(event.level == .error)
     }
 
+    @Test func whenLevelIsUnknown_shouldLogSponsorName() throws {
+        let list = SponsorListDTO(data: [.fixture(name: "Bronze Co", sponsorLevel: "bronze")])
+
+        let event = try #require(refusedEvent(for: list))
+
+        #expect(event.fields.first { String($0.name) == "sponsor" }?.value == .string("Bronze Co"))
+    }
+
+    @Test func whenLevelIsUnknown_shouldLogFieldName() throws {
+        let list = SponsorListDTO(data: [.fixture(name: "Bronze Co", sponsorLevel: "bronze")])
+
+        let event = try #require(refusedEvent(for: list))
+
+        #expect(event.fields.first { String($0.name) == "field" }?.value == .string("sponsorLevel"))
+    }
+
+    @Test func whenLevelIsUnknown_shouldLogRefusedValue() throws {
+        let list = SponsorListDTO(data: [.fixture(name: "Bronze Co", sponsorLevel: "bronze")])
+
+        let event = try #require(refusedEvent(for: list))
+
+        #expect(event.fields.first { String($0.name) == "value" }?.value == .string("bronze"))
+    }
+
     private func refusedEvent(for list: SponsorListDTO) -> LogEvent? {
         let recorder = LogRecorder()
 

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
@@ -38,6 +38,40 @@ import Testing
         #expect(event.fields.first { String($0.name) == "value" }?.value == .string("bronze"))
     }
 
+    /// A list is mapped every time the sponsors screen loads, so it records at the level the
+    /// platform drops unless someone is watching.
+    @Test func whenListMaps_shouldLogAtDebugLevel() throws {
+        let list = SponsorListDTO(data: [.fixture(id: "a"), .fixture(id: "b")])
+
+        let event = try #require(try mappedEvent(for: list))
+
+        #expect(event.level == .debug)
+    }
+
+    @Test func whenListMaps_shouldLogSponsorCount() throws {
+        let list = SponsorListDTO(data: [.fixture(id: "a"), .fixture(id: "b")])
+
+        let event = try #require(try mappedEvent(for: list))
+
+        #expect(event.fields.first { String($0.name) == "count" }?.value == .integer(2))
+    }
+
+    private func mappedEvent(for list: SponsorListDTO) throws -> LogEvent? {
+        let recorder = LogRecorder()
+
+        try withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            let sut = SponsorMapper.live.logging()
+            _ = try sut.map(list)
+        }
+
+        // Pinned here rather than per test, so a decorator that logs an outcome twice fails
+        // everything rather than nothing.
+        #expect(recorder.events.count == 1)
+        return recorder.events.first
+    }
+
     private func refusedEvent(for list: SponsorListDTO) -> LogEvent? {
         let recorder = LogRecorder()
 

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
@@ -80,6 +80,19 @@ import Testing
         #expect(Set(messages).count == messages.count)
     }
 
+    @Test func whenLogIsOverriddenAfterBuilding_shouldWriteToTheOverride() throws {
+        let recorder = LogRecorder()
+        let sut = SponsorMapper.live.logging()
+
+        try withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            _ = try sut.map(SponsorListDTO(data: [.fixture()]))
+        }
+
+        #expect(recorder.events.count == 1)
+    }
+
     private func mappedEvent(for list: SponsorListDTO) throws -> LogEvent? {
         let recorder = LogRecorder()
 

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorMapperLoggingTests.swift
@@ -3,7 +3,6 @@ import LogKit
 import SponsorsFeature
 import Testing
 
-// The caller never sees why a list was refused. These assert the reason reaches the log.
 @Suite struct SponsorMapperLoggingTests {
     @Test func whenLevelIsUnknown_shouldLogAtErrorLevel() throws {
         let list = SponsorListDTO(data: [.fixture(name: "Bronze Co", sponsorLevel: "bronze")])
@@ -37,8 +36,6 @@ import Testing
         #expect(event.fields.first { String($0.name) == "value" }?.value == .string("bronze"))
     }
 
-    // A list is mapped every time the sponsors screen loads, so it records at the level the
-    // platform drops unless someone is watching.
     @Test func whenListMaps_shouldLogAtDebugLevel() throws {
         let list = SponsorListDTO(data: [.fixture(id: "a"), .fixture(id: "b")])
 
@@ -69,8 +66,6 @@ import Testing
         }
     }
 
-    // A destination groups by message, so two outcomes sharing one message could never be told
-    // apart when filtering.
     @Test func whenOutcomesDiffer_shouldLogDifferentMessages() throws {
         let messages = try [
             #require(try mappedEvent(for: SponsorListDTO(data: [.fixture()]))),
@@ -103,8 +98,6 @@ import Testing
             _ = try sut.map(list)
         }
 
-        // Pinned here rather than per test, so a decorator that logs an outcome twice fails
-        // everything rather than nothing.
         #expect(recorder.events.count == 1)
         return recorder.events.first
     }
@@ -119,8 +112,6 @@ import Testing
             _ = try? sut.map(list)
         }
 
-        // Pinned here rather than per test, so a decorator that logs an outcome twice fails
-        // everything rather than nothing.
         #expect(recorder.events.count == 1)
         return recorder.events.first
     }

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryIntegrationTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryIntegrationTests.swift
@@ -7,8 +7,8 @@ import Testing
 
 // Drives the composed `liveValue` with only the transport stubbed.
 @Suite struct SponsorsRepositoryIntegrationTests {
-    /// The mapper records the count, then the repository records the outcome. Two seams, two
-    /// lines, and no third line from anywhere else.
+    // The mapper records the count, then the repository records the outcome. Two seams, two
+    // lines, and no third line from anywhere else.
     @Test func whenServerAnswersWell_shouldLogMappingThenFetch() async throws {
         let recorder = LogRecorder()
         let data = SponsorsJSON.list(SponsorsJSON.sponsor())

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryIntegrationTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryIntegrationTests.swift
@@ -7,8 +7,6 @@ import Testing
 
 // Drives the composed `liveValue` with only the transport stubbed.
 @Suite struct SponsorsRepositoryIntegrationTests {
-    // The mapper records the count, then the repository records the outcome. Two seams, two
-    // lines, and no third line from anywhere else.
     @Test func whenServerAnswersWell_shouldLogMappingThenFetch() async throws {
         let recorder = LogRecorder()
         let data = SponsorsJSON.list(SponsorsJSON.sponsor())

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryIntegrationTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryIntegrationTests.swift
@@ -1,11 +1,28 @@
 import Dependencies
 import Foundation
+import LogKit
 import NetworkKit
 import SponsorsFeature
 import Testing
 
 // Drives the composed `liveValue` with only the transport stubbed.
 @Suite struct SponsorsRepositoryIntegrationTests {
+    /// The mapper records the count, then the repository records the outcome. Two seams, two
+    /// lines, and no third line from anywhere else.
+    @Test func whenServerAnswersWell_shouldLogMappingThenFetch() async throws {
+        let recorder = LogRecorder()
+        let data = SponsorsJSON.list(SponsorsJSON.sponsor())
+
+        _ = try await withDependencies {
+            $0.log = recorder.log
+            $0.httpClient = .responding(with: data, statusCode: 200)
+        } operation: {
+            try await SponsorsRepository.liveValue.fetch()
+        }
+
+        #expect(recorder.events.map(\.level) == [.debug, .info])
+    }
+
     @Test func whenServerAnswersWell_shouldReturnSponsors() async throws {
         let data = SponsorsJSON.list(SponsorsJSON.sponsor(id: "a", level: "gold"))
 

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
@@ -1,0 +1,31 @@
+import Dependencies
+import LogKit
+import SponsorsFeature
+import Testing
+
+/// The cause reaches the log at the mapper or the transport. These assert the outcome the user got.
+@Suite struct SponsorsRepositoryLoggingTests {
+    /// The sponsors load each time the screen appears, so the success sits below the levels the
+    /// platform writes to disk.
+    @Test func whenFetchSucceeds_shouldLogAtInfoLevel() async throws {
+        let event = try #require(try await successEvent())
+
+        #expect(event.level == .info)
+    }
+
+    private func successEvent() async throws -> LogEvent? {
+        let recorder = LogRecorder()
+
+        _ = try await withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            let sut = SponsorsRepository.returning(Sponsors([.fixture()])).logging()
+            return try await sut.fetch()
+        }
+
+        // Pinned here rather than per test, so a decorator that logs an outcome twice fails
+        // everything rather than nothing.
+        #expect(recorder.events.count == 1)
+        return recorder.events.first
+    }
+}

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
@@ -47,7 +47,7 @@ import Testing
     /// A destination groups by message, so two outcomes sharing one message could never be told
     /// apart when filtering.
     @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
-        let messages = try await [
+        let messages = try [
             #require(try await successEvent()),
             #require(await logEvent(whenRepositoryThrows: .couldNotReachServer)),
             #require(await logEvent(whenRepositoryThrows: .invalidResponse)),

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
@@ -3,17 +3,17 @@ import LogKit
 import SponsorsFeature
 import Testing
 
-/// The cause reaches the log at the mapper or the transport. These assert the outcome the user got.
+// The cause reaches the log at the mapper or the transport. These assert the outcome the user got.
 @Suite struct SponsorsRepositoryLoggingTests {
-    /// The sponsors load each time the screen appears, so the success sits below the levels the
-    /// platform writes to disk.
+    // The sponsors load each time the screen appears, so the success sits below the levels the
+    // platform writes to disk.
     @Test func whenFetchSucceeds_shouldLogAtInfoLevel() async throws {
         let event = try #require(try await successEvent())
 
         #expect(event.level == .info)
     }
 
-    /// An offline device is expected and the user can retry, so it is not a fault in the app.
+    // An offline device is expected and the user can retry, so it is not a fault in the app.
     @Test func whenServerCannotBeReached_shouldLogAtNoticeRatherThanError() async throws {
         let event = try #require(await logEvent(whenRepositoryThrows: .couldNotReachServer))
 
@@ -44,8 +44,8 @@ import Testing
         }
     }
 
-    /// A destination groups by message, so two outcomes sharing one message could never be told
-    /// apart when filtering.
+    // A destination groups by message, so two outcomes sharing one message could never be told
+    // apart when filtering.
     @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
         let messages = try [
             #require(try await successEvent()),

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
@@ -13,6 +13,41 @@ import Testing
         #expect(event.level == .info)
     }
 
+    /// An offline device is expected and the user can retry, so it is not a fault in the app.
+    @Test func whenServerCannotBeReached_shouldLogAtNoticeRatherThanError() async throws {
+        let event = try #require(await logEvent(whenRepositoryThrows: .couldNotReachServer))
+
+        #expect(event.level == .notice)
+    }
+
+    @Test func whenResponseIsRejected_shouldLogAtErrorLevel() async throws {
+        let event = try #require(await logEvent(whenRepositoryThrows: .invalidResponse))
+
+        #expect(event.level == .error)
+    }
+
+    @Test func whenReasonIsUnknown_shouldLogAtErrorLevel() async throws {
+        let event = try #require(await logEvent(whenRepositoryThrows: .unknown))
+
+        #expect(event.level == .error)
+    }
+
+    private func logEvent(whenRepositoryThrows error: SponsorFetchError) async -> LogEvent? {
+        let recorder = LogRecorder()
+
+        await withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            let sut = SponsorsRepository.failing(with: error).logging()
+            _ = try? await sut.fetch()
+        }
+
+        // Pinned here rather than per test, so a decorator that logs an outcome twice fails
+        // everything rather than nothing.
+        #expect(recorder.events.count == 1)
+        return recorder.events.first
+    }
+
     private func successEvent() async throws -> LogEvent? {
         let recorder = LogRecorder()
 

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
@@ -57,6 +57,19 @@ import Testing
         #expect(Set(messages).count == messages.count)
     }
 
+    @Test func whenLogIsOverriddenAfterBuilding_shouldWriteToTheOverride() async throws {
+        let recorder = LogRecorder()
+        let sut = SponsorsRepository.returning(Sponsors([.fixture()])).logging()
+
+        _ = try await withDependencies {
+            $0.log = recorder.log
+        } operation: {
+            try await sut.fetch()
+        }
+
+        #expect(recorder.events.count == 1)
+    }
+
     private func logEvent(whenRepositoryThrows error: SponsorFetchError) async -> LogEvent? {
         let recorder = LogRecorder()
 

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
@@ -3,17 +3,13 @@ import LogKit
 import SponsorsFeature
 import Testing
 
-// The cause reaches the log at the mapper or the transport. These assert the outcome the user got.
 @Suite struct SponsorsRepositoryLoggingTests {
-    // The sponsors load each time the screen appears, so the success sits below the levels the
-    // platform writes to disk.
     @Test func whenFetchSucceeds_shouldLogAtInfoLevel() async throws {
         let event = try #require(try await successEvent())
 
         #expect(event.level == .info)
     }
 
-    // An offline device is expected and the user can retry, so it is not a fault in the app.
     @Test func whenServerCannotBeReached_shouldLogAtNoticeRatherThanError() async throws {
         let event = try #require(await logEvent(whenRepositoryThrows: .couldNotReachServer))
 
@@ -44,8 +40,6 @@ import Testing
         }
     }
 
-    // A destination groups by message, so two outcomes sharing one message could never be told
-    // apart when filtering.
     @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
         let messages = try [
             #require(try await successEvent()),
@@ -80,8 +74,6 @@ import Testing
             _ = try? await sut.fetch()
         }
 
-        // Pinned here rather than per test, so a decorator that logs an outcome twice fails
-        // everything rather than nothing.
         #expect(recorder.events.count == 1)
         return recorder.events.first
     }
@@ -96,8 +88,6 @@ import Testing
             return try await sut.fetch()
         }
 
-        // Pinned here rather than per test, so a decorator that logs an outcome twice fails
-        // everything rather than nothing.
         #expect(recorder.events.count == 1)
         return recorder.events.first
     }

--- a/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
+++ b/Packages/SponsorsFeature/Tests/SponsorsFeatureTests/SponsorsRepositoryLoggingTests.swift
@@ -32,6 +32,31 @@ import Testing
         #expect(event.level == .error)
     }
 
+    @Test func whenFetchFails_shouldRethrowFailure() async {
+        await withDependencies {
+            $0.log = LogRecorder().log
+        } operation: {
+            let sut = SponsorsRepository.failing(with: .couldNotReachServer).logging()
+
+            await #expect(throws: SponsorFetchError.couldNotReachServer) {
+                try await sut.fetch()
+            }
+        }
+    }
+
+    /// A destination groups by message, so two outcomes sharing one message could never be told
+    /// apart when filtering.
+    @Test func whenOutcomesDiffer_shouldLogDifferentMessages() async throws {
+        let messages = try await [
+            #require(try await successEvent()),
+            #require(await logEvent(whenRepositoryThrows: .couldNotReachServer)),
+            #require(await logEvent(whenRepositoryThrows: .invalidResponse)),
+            #require(await logEvent(whenRepositoryThrows: .unknown)),
+        ].map(\.message)
+
+        #expect(Set(messages).count == messages.count)
+    }
+
     private func logEvent(whenRepositoryThrows error: SponsorFetchError) async -> LogEvent? {
         let recorder = LogRecorder()
 


### PR DESCRIPTION
## Problem

* The sponsors screen loads from the backend, and nothing records whether that worked.
* When the backend sends a sponsor level the app does not know, the whole list is refused. The public error says only "invalid response". Which sponsor, and which field, is lost.
* Every other feature in the app logs its outcomes. Sponsors did not.

## Solution

Two logging decorators. A decorator wraps an existing function value, adds one behavior (here, a log line), and returns or rethrows unchanged. Nothing inside the mapper or the repository changed.

| Seam | Success | Failure |
|---|---|---|
| `SponsorMapper` | `.debug`, with the sponsor count | `.error`, with the sponsor, the field and the refused value |
| `SponsorsRepository` | `.info` | `.notice` when offline, `.error` for a fault |

Two decorators, not one: the repository turns the mapper's rich error into a bare public one. Only the mapper decorator still sees the sponsor and the field.

Both are installed in the package's `liveValue`s, under the `sponsors` log category.

## How to test

```bash
git fetch && git checkout feat/sponsors-logging
swift test --package-path Packages/SponsorsFeature
```

* 47 tests pass, 17 new.
* One integration test fails if either decorator is removed from composition.
* One test per decorator fails if the log is resolved when the decorator is built rather than when it is called.

## Notes

* All logged values are `.open`. Sponsors are advertised, and the count is public.
* `FetchSponsors` is not decorated. It is public, so it composes at the app root once the app imports the package.
